### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: daily
-  target-branch: master
-  labels:
-      - "submodule"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Dependabot is a GitHub run dependency checker.

This will set it up to run daily (at 5 am), checking if there are newer
commits of the git submodules as well as the GitHub Actions used in the
CI GitHub Actions workflow.

For more information, see [the GitHub Dependabot documentation](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-github-dependabot-version-updates).