### PR TITLE
Renamed generic-properties to generic-concepts.

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -2,6 +2,7 @@
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
         <uri name="http://emmo.info/emmo-inferred/1.0.0-beta" uri="https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta/emmo-inferred-chemistry.ttl"/>
+        <uri name="http://emmo.info/emmo/1.0.0-beta/generic-concepts"  uri="generic-concepts.ttl"/>
 	<uri name="http://emmo.info/BattINFO/0.0.1"                    uri="BattINFO.ttl"/>
 	<uri name="http://emmo.info/BattINFO/0.0.1/battery"            uri="battery.ttl"/>
         <uri name="http://emmo.info/BattINFO/0.0.1/electrode"          uri="electrode.ttl"/>
@@ -10,6 +11,5 @@
 	<uri name="http://emmo.info/BattINFO/0.0.1/properties"         uri="properties.ttl"/>
 	<uri name="http://emmo.info/BattINFO/0.0.1/observations"       uri="observations.ttl"/>
 	<uri name="http://emmo.info/BattINFO/0.0.1/models"             uri="models.ttl"/>
-        <uri name="http://emmo.info/BattINFO/0.0.1/generic-properties" uri="generic-properties.ttl"/>
     </group>
 </catalog>

--- a/electrochemistry.ttl
+++ b/electrochemistry.ttl
@@ -12,7 +12,7 @@
 
 <http://emmo.info/BattINFO/electrochemistry> rdf:type owl:Ontology ;
                                               owl:versionIRI <http://emmo.info/BattINFO/0.0.1/electrochemistry> ;
-                                              owl:imports <http://emmo.info/BattINFO/0.0.1/generic-properties> ;
+                                              owl:imports <http://emmo.info/emmo/1.0.0-beta/generic-concepts> ;
                                               dcterms:abstract """Concepts related to electrochemistry.
 
 Released under the Creative Commons license Attribution 4.0 International (CC BY 4.0)."""@en ;

--- a/generic-concepts.ttl
+++ b/generic-concepts.ttl
@@ -7,12 +7,12 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix annotations: <http://emmo.info/emmo/top/annotations#> .
-@base <http://emmo.info/BattINFO/generic-properties> .
+@base <http://emmo.info/emmo/generic-concepts> .
 
-<http://emmo.info/BattINFO/generic-properties> rdf:type owl:Ontology ;
-                                                owl:versionIRI <http://emmo.info/BattINFO/0.0.1/generic-properties> ;
+<http://emmo.info/emmo/generic-concepts> rdf:type owl:Ontology ;
+                                                owl:versionIRI <http://emmo.info/emmo/1.0.0-beta/generic-concepts> ;
                                                 owl:imports <https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta/emmo-inferred-chemistry.ttl> ;
-                                                dcterms:abstract """Generic properties that are intended to eventually be moved into EMMO middle.
+                                                dcterms:abstract """Generic concepts that are intended to eventually be moved into EMMO middle.
 
 Released under the Creative Commons license Attribution 4.0 International (CC BY 4.0)."""@en ;
                                                 dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;


### PR DESCRIPTION
To not restrict concepts we eventually think should be included in EMMO middle to just properties.