### PR TITLE
Deploy ontologies to onto-ns.com

### DIFF
--- a/.deploy-onto-config.yml
+++ b/.deploy-onto-config.yml
@@ -1,5 +1,37 @@
 # Configuration file for deploying ontologies on onto-ns.com
+
+# Directories, in which ontology files are present that should be published.
+# It should be relative to the root of the repository, e.g., "." for the root
+# and "ontologies/publish" for the repository sub-directory `publish` under the
+# root repository directory of `ontologies`.
 ontology_dirs: ["."]
+
+# List of namespaces, which should not be published.
+# If it is a "top" namespace, e.g., `BattINFO`, then all ontologies under that
+# namespace will not be published (e.g., `BattINFO/battery`).
+# To define a sub-namespace, one must also supply the "top" namespace.
+# E.g., to avoid publishing `electrochemicalquantities`, but keep `electrochemistry`
+# one can write add "electrochemistry/electrochemicalquantities".
 avoid_namespaces: []
+
+# The directory in which the `catalog-v001.xml` file is found.
+# "." means the root directory of the repository.
+# This value should be relative to the root of the repository, similar to the values
+# of `ontology_dirs`.
 catalog_file_dir: "."
+
+# The branch to be used as the source of the ontologies to be published.
+# This value will be retrieved from the default branch (`master` for `BIG-MAP/BattINFO`)
+# and has no meaning in the actual branch of deployment.
+# This means that this configuration option is only respected by the Deploy Onto! App
+# when it is read from the project's default branch.
+#
+# The workflow is the following for the App:
+#   1. Detect a push
+#   2. Retrieve this config file from the default branch
+#      (`master` for `BIG-MAP/BattINFO`)
+#   3. Check whether the push was to the value of `deploy_branch`
+#      (defaults to "main" in the App)
+#   4. Retrieve and publish ontologies from the `deploy_branch`
+#      (or stop if the push was not to the `deploy_branch`)
 deploy_branch: "master"

--- a/.deploy-onto-config.yml
+++ b/.deploy-onto-config.yml
@@ -1,0 +1,5 @@
+# Configuration file for deploying ontologies on onto-ns.com
+ontology_dirs: ["."]
+avoid_namespaces: []
+catalog_file_dir: "."
+deploy_branch: "master"


### PR DESCRIPTION
The configuration file specifies all the current available configuration options.
They are all currently equal to the defaults, except `deploy_branch`, which is different from the default (default being `main`).

This is the workflow in its essence:
- Pushes to the `deploy_branch`, i.e., `master`.
- The ["Deploy Onto!" GitHub App](https://github.com/apps/deploy-onto) service will retrieve the repository's `master` branch.
- Go through all the Turtle files (`.ttl`) in the root of the repository.
- Extract the version IRI and from it deduct every ontology's namespace and version.
- Publish the ontology to: `http://onto.onto-ns.com/<TOP>/<VERSION>/<NAME>`.

Here `<TOP>` is the top namespace, e.g., `BattINFO` or `emmo`.
`<VERSION>` is the given ontology's version, e.g., `0.1.0`.
`<NAME>` is the sub-namespace name, e.g., `battery` or `generic-concepts`.

Not all ontologies have `<NAME>`, e.g., the BattINFO ontology itself, which imports all the sub-ontologies, does _not_ have a `<NAME>`, but is simply found at `http://onto.onto-ns.com/BattINFO/0.1.0/battinfo.ttl`.

> **Note**: It is the intent that the following URLs will render the same result (assuming the _latest_ version is `0.1.0`:
> - `http://onto.onto-ns.com/BattINFO`
> - `http://onto.onto-ns.com/BattINFO/battinfo.ttl`
> - `http://onto.onto-ns.com/BattINFO/0.1.0`
> - `http://onto.onto-ns.com/BattINFO/0.1.0/battinfo.ttl`
> 
> However, this is not yet setup.

For a bit more technical detail, one can go to [api.onto-ns.com](http://api.onto-ns.com) to see the technical documentation for the service that is the engine behind the Deploy Onto! GitHub App.