### PR TITLE
upgrade to EMMO v.10.0-beta4

### DIFF
--- a/battinfo.ttl
+++ b/battinfo.ttl
@@ -12,8 +12,8 @@
 @base <https://big-map.github.io/BattINFO/ontology/BattINFO> .
 
 <https://big-map.github.io/BattINFO/ontology/BattINFO> rdf:type owl:Ontology ;
-                                                        owl:versionIRI <https://big-map.github.io/BattINFO/ontology/BattINFO/0.4.0/battinfo.ttl> ;
-                                                        owl:imports <https://raw.githubusercontent.com/emmo-repo/domain-battery/master/battery.ttl> ;
+                                                        owl:versionIRI <https://big-map.github.io/BattINFO/ontology/BattINFO/0.5.0/battinfo.ttl> ;
+                                                        owl:imports <http://emmo.info/battery/0.5.0/battery> ;
                                                         dcterms:abstract """A battery interface domain ontology based on EMMO.
 This file is intended to be empty and merely collecting the other ontologies.
 Released under the Creative Commons license Attribution 4.0 International (CC BY 4.0)."""@en ;
@@ -42,7 +42,7 @@ Released under the Creative Commons license Attribution 4.0 International (CC BY
 Simon Clark
 SINTEF Industry
 email: simon.clark@sintef.no"""@en ;
-                                                        owl:versionInfo "0.4.0" .
+                                                        owl:versionInfo "0.5.0" .
 
 #################################################################
 #    Annotation properties

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/disciplines/isq_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/disciplines/units_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/units_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/disciplines/computerscience_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/computerscience_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.4.0/electrochemicalquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/reference/1.0.0-beta3" uri="https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta3/emmo-reference-inferred.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.4.0/electrochemistry.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/v0.4.0/electrochemistry.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/battery/0.4.0/batteryquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/batteryquantities.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/battery/0.4.0/battery.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/battery.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/material/0.1.0/material" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/material_bigmap_temp.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/unitsextension_bigmap.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4" uri="https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.5.0/electrochemistry" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/battery/0.5.0/batteryquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/batteryquantities.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://emmo.info/battery/0.5.0/battery" uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/battery.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-        <uri name="https://big-map.github.io/BattINFO/ontology/BattINFO/0.4.0/battinfo.ttl" uri="battinfo.ttl"/>
+        <uri name="https://big-map.github.io/BattINFO/ontology/BattINFO/0.5.0/battinfo.ttl" uri="battinfo.ttl"/>
     </group>
 </catalog>


### PR DESCRIPTION
upgrades the EMMO to the pre-inferred version of v1.0.0-beta4. Raise version number to 0.5.0