### PR TITLE
Corrected catalog files

### DIFF
--- a/battinfo.ttl
+++ b/battinfo.ttl
@@ -12,7 +12,7 @@
 @base <https://big-map.github.io/BattINFO/ontology/BattINFO> .
 
 <https://big-map.github.io/BattINFO/ontology/BattINFO> rdf:type owl:Ontology ;
-                                                        owl:versionIRI <https://big-map.github.io/BattINFO/ontology/BattINFO/0.5.0/battinfo.ttl> ;
+                                                        owl:versionIRI <https://big-map.github.io/BattINFO/ontology/BattINFO/0.5.0/battinfo> ;
                                                         owl:imports <http://emmo.info/battery/0.5.0/battery> ;
                                                         dcterms:abstract """A battery interface domain ontology based on EMMO.
 This file is intended to be empty and merely collecting the other ontologies.

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="http://emmo.info/material/0.1.0/material" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/material_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/unitsextension_bigmap.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4" uri="https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.5.0/electrochemistry" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/battery/0.5.0/batteryquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/batteryquantities.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/battery/0.5.0/battery" uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/battery.ttl"/>
-    <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-        <uri name="https://big-map.github.io/BattINFO/ontology/BattINFO/0.5.0/battinfo.ttl" uri="battinfo.ttl"/>
+	<group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
+        <uri name="https://big-map.github.io/BattINFO/ontology/BattINFO/0.5.0/battinfo" uri="./battinfo.ttl"/>
+	<uri name="http://emmo.info/battery/0.5.0/battery"    				uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/battery.ttl"/>
+	
+        <!-- The uris below should be removed when EMMOntoPy reads catalog files for imported ontologies correctly. -->
+         <!-- All the ontologies below are imported from battery.ttl and not directly from here.-->
+	<uri name="http://emmo.info/battery/0.5.0/batteryquantities"    		uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/batteryquantities.ttl"/>
+	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemistry"            uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl"/>
+	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities"            uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>
+
+        <!-- The uris below should be removed when EMMOntoPy reads catalog files for imported ontologies correctly. -->
+        <!-- All the ontologies below are imported from electrochemistry and not directly from here.-->
+	<uri name="http://emmo.info/emmo/1.0.0-beta4"                                    uri="https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta4/emmo-inferred.ttl"/>
+        <uri name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_bigmap"                   uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap.ttl"/>
+        <uri name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap"         uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/unitsextension_bigmap.ttl"/>
+        <uri name="http://emmo.info/material/0.1.0/material"                             uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/material_bigmap_temp.ttl"/>
     </group>
 </catalog>


### PR DESCRIPTION
Imported ontologies from imported ontologies are included in the current catalog file, as a fix is required in EMMOntoPy.

Note that tests still fail, but now at a later stage, not on import of subontologies.

Imports will fail until pr 18 in domain-battery is merged.