### PR TITLE
fix darkmode within json-ld playground iframe

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -66,3 +66,9 @@ hr {
     border-top: 1px solid #ccc;
     margin: 20px 0;
 }
+
+/* this fixes darkmode within the json-ld playground iframe
+by inverting all colors if darkmode is active */
+html[data-theme="dark"] iframe[src*="json-ld.org/playground"] {
+   filter: invert(0.9);
+}


### PR DESCRIPTION
this should fix darkmode issue with jsonld playground.

Hiding the header section will require some javascript