### PR TITLE
Fix example links by including '../examples/' prefix

### DIFF
--- a/docs/pages/examples.rst
+++ b/docs/pages/examples.rst
@@ -1,10 +1,10 @@
 .. toctree::
    :hidden:
       
-   example_linked_data_battery_cell_metadata.ipynb
-   example_linked_data_custom_battery_cell_metadata.ipynb
-   example_linked_data_timeseries_battery_data.ipynb
-   example_linked_data_zinc_powder.ipynb
+   ../examples/example_linked_data_battery_cell_metadata.ipynb
+   ../examples/example_linked_data_custom_battery_cell_metadata.ipynb
+   ../examples/example_linked_data_timeseries_battery_data.ipynb
+   ../examples/example_linked_data_zinc_powder.ipynb
 
 Examples
 ========
@@ -14,14 +14,14 @@ Here are some examples to help you get started. You are free to re-use or modify
 .. grid::
 
     .. grid-item-card::
-        :link: example_linked_data_battery_cell_metadata.html
+        :link: ../examples/example_linked_data_battery_cell_metadata.html
 
         :octicon:`diff;1em;sd-text-info`  Simple Battery Cell Metadata
         ^^^^^^^^^^^
         Metadata for a simple CR2032 coin cell. Also includes exercises for understanding Linked Data basics and fetching additional information from the Wikidata knowledge graph.
 
     .. grid-item-card::
-        :link: example_linked_data_custom_battery_cell_metadata.html
+        :link: ../examples/example_linked_data_custom_battery_cell_metadata.html
 
         :octicon:`diff;1em;sd-text-info`  Custom Battery Cell Metadata
         ^^^^^^^^^^^
@@ -30,14 +30,14 @@ Here are some examples to help you get started. You are free to re-use or modify
 .. grid::
 
     .. grid-item-card::
-        :link: example_linked_data_timeseries_battery_data.html
+        :link: ../examples/example_linked_data_timeseries_battery_data.html
 
         :octicon:`graph;1em;sd-text-info`  Time Series Battery Data
         ^^^^^^^^^^^
         Metadata for a csv file containing timeseries battery data. Also includes examples of how to read and process it based on understanding from ontology terms.
 
     .. grid-item-card::
-        :link: example_linked_data_zinc_powder.html
+        :link: ../examples/example_linked_data_zinc_powder.html
 
         :octicon:`ruby;1em;sd-text-info`  Zinc Powder
         ^^^^^^^^^^^
@@ -46,14 +46,14 @@ Here are some examples to help you get started. You are free to re-use or modify
 .. grid::
 
     .. grid-item-card::
-        :link: example_aqueous_electrolyte_KOH.html
+        :link: ../examples/example_aqueous_electrolyte_KOH.html
 
         :octicon:`plus-circle;1em;sd-text-info`  Aqueous KOH Electrolyte
         ^^^^^^^^
         An aqueous potassium hydroxide electrolyte with some properties. 
 
     .. grid-item-card::
-        :link: example_alkaline_electrochemical_cell.html
+        :link: ../examples/example_alkaline_electrochemical_cell.html
 
         :octicon:`zap;1em;sd-text-info`  Alkaline Electrochemical Cell
         ^^^^^^^^^^
@@ -62,14 +62,14 @@ Here are some examples to help you get started. You are free to re-use or modify
 .. grid::
 
     .. grid-item-card::
-        :link: example_cyclic_voltammetry.html
+        :link: ../examples/example_cyclic_voltammetry.html
 
         :octicon:`pulse;1em;sd-text-info`  Cyclic Voltammetry Data
         ^^^^^^^^
         Raw data from a cyclic voltammetry measurement. 
 
     .. grid-item-card::
-        :link: example_eis_nyquist.html
+        :link: ../examples/example_eis_nyquist.html
 
         :octicon:`graph;1em;sd-text-info`  EIS Nyquist Plot Data
         ^^^^^^^^^^


### PR DESCRIPTION
The examples links return a 404 as the actual examples are not in the pages directory.