### PR TITLE
harden: atomic durable writes + registry exception/retry contract

### DIFF
--- a/src/battinfo/_jsonio.py
+++ b/src/battinfo/_jsonio.py
@@ -10,6 +10,8 @@ pretty-printed UTF-8 JSON, creating parent directories as needed.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -26,7 +28,42 @@ def read_record_json(path: Path) -> dict[str, Any]:
     return record_to_snake_aliases(read_json(path))
 
 
-def write_json(path: Path, payload: Mapping[str, Any]) -> None:
-    """Write ``payload`` as pretty-printed UTF-8 JSON, creating parent dirs."""
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Atomically write ``text`` to ``path``, creating parent dirs as needed.
+
+    Writes to a temporary file in the same directory, flushes + ``fsync``s it,
+    then ``os.replace``s it into place (atomic on POSIX and Windows). An
+    interrupted write — Ctrl-C, crash, disk-full, or a cloud-sync race — therefore
+    leaves the *previous* file fully intact instead of a truncated or empty record.
+
+    Newline handling matches :meth:`pathlib.Path.write_text` (text mode, default
+    translation), so the on-disk bytes are identical to the previous non-atomic
+    implementation and no line-ending churn is introduced.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        # Best-effort cleanup so an interrupted write never leaks a temp file or
+        # fd, and never masks the original exception. If os.fdopen itself failed,
+        # the raw fd is still open and must be closed before the temp can be
+        # unlinked on Windows (else the unlink hits WinError 32).
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically write ``payload`` as pretty-printed UTF-8 JSON, creating parent dirs."""
+    atomic_write_text(path, json.dumps(payload, indent=2, ensure_ascii=False) + "\n")

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -7,6 +7,7 @@ import html
 import json
 import re
 import secrets
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Literal, Mapping, Sequence
@@ -1438,6 +1439,42 @@ def build_curated_cell_spec_submission(
     }
 
 
+class RegistryError(RuntimeError):
+    """Base class for registry submission failures.
+
+    Subclasses :class:`RuntimeError` so existing ``except RuntimeError`` handlers
+    (e.g. ``ws._do_submit``) keep working unchanged.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None, response_body: str | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class RegistryClientError(RegistryError):
+    """Terminal client-side failure (HTTP 4xx except 429, or a malformed response).
+
+    The request will not succeed if retried as-is, so it is raised immediately.
+    """
+
+
+class RegistryTransientError(RegistryError):
+    """Transient failure (connection error, timeout, HTTP 429/5xx).
+
+    Safe to retry; raised only after the retry budget is exhausted.
+    """
+
+
+# HTTP statuses worth retrying: rate-limiting plus the standard transient 5xx set.
+_REGISTRY_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+# Body-level statuses that mean "the registry rejected this record" even on a 2xx.
+_REGISTRY_REJECTED_BODY_STATUS = frozenset({"failed", "rejected", "error"})
+# Cap embedded response bodies so a misbehaving/echoing registry can't blow up
+# (or leak large headers into) the raised error message.
+_REGISTRY_ERROR_BODY_LIMIT = 500
+
+
 def submit_publication_package(
     payload: Mapping[str, Any],
     *,
@@ -1445,38 +1482,99 @@ def submit_publication_package(
     api_key: str,
     api_key_header: str = "X-Battinfo-API-Key",
     timeout_sec: float = 30.0,
+    max_attempts: int = 3,
+    backoff_sec: float = 0.5,
 ) -> dict[str, Any]:
+    """POST a publication package to the registry, defending against a hostile/cold registry.
+
+    Retries transient failures (connection/timeout, HTTP 429/5xx) with exponential
+    backoff up to ``max_attempts``; never retries other 4xx (raised immediately as
+    :class:`RegistryClientError`). A 2xx with a non-JSON body, or a body-level
+    ``failed``/``rejected``/``error`` status, is surfaced rather than reported as a
+    blanket success. Every failure raises a :class:`RegistryError` subclass — which
+    is a :class:`RuntimeError`, so existing callers keep working.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
     request_url = registry_base_url.rstrip("/") + "/publication-packages"
     request_payload = dict(payload)
     request_body = json.dumps(request_payload, ensure_ascii=False).encode("utf-8")
-    request = UrlRequest(
-        request_url,
-        data=request_body,
-        headers={
-            "Content-Type": "application/json",
-            api_key_header: api_key,
-        },
-        method="POST",
-    )
-    try:
-        with urlopen(request, timeout=timeout_sec) as response:
-            response_text = response.read().decode("utf-8")
-            response_payload = json.loads(response_text) if response_text else None
+    headers = {"Content-Type": "application/json", api_key_header: api_key}
+
+    last_transient: RegistryTransientError | None = None
+    for attempt in range(max_attempts):
+        request = UrlRequest(request_url, data=request_body, headers=headers, method="POST")
+        try:
+            with urlopen(request, timeout=timeout_sec) as response:
+                status_code = response.getcode()
+                # errors="replace": a non-UTF-8 2xx body must not raise a bare
+                # UnicodeDecodeError (a ValueError) that escapes the caller's
+                # `except RuntimeError`; the body is only used for JSON/error text.
+                response_text = response.read().decode("utf-8", errors="replace")
+            try:
+                response_payload = json.loads(response_text) if response_text else None
+            except json.JSONDecodeError as exc:
+                # A 2xx carrying an HTML/proxy/cold-start body is NOT a success.
+                raise RegistryClientError(
+                    f"Registry returned a non-JSON response (HTTP {status_code}): "
+                    f"{response_text[:_REGISTRY_ERROR_BODY_LIMIT]!r}",
+                    status_code=status_code,
+                    response_body=response_text[:_REGISTRY_ERROR_BODY_LIMIT],
+                ) from exc
+            if response_payload is not None and not isinstance(response_payload, dict):
+                # A 2xx whose JSON body is a scalar/list rather than an object is not
+                # a valid submission response; surface it as a typed RuntimeError
+                # rather than passing a non-mapping through to callers that do
+                # `(result["response"] or {}).get(...)` (which would raise AttributeError
+                # and escape the caller's `except RuntimeError`, aborting the batch).
+                raise RegistryClientError(
+                    f"Registry returned a non-object JSON response (HTTP {status_code}): "
+                    f"{response_text[:_REGISTRY_ERROR_BODY_LIMIT]!r}",
+                    status_code=status_code,
+                    response_body=response_text[:_REGISTRY_ERROR_BODY_LIMIT],
+                )
+            body_status = None
+            if isinstance(response_payload, dict):
+                raw_status = response_payload.get("status")
+                if isinstance(raw_status, str):
+                    body_status = raw_status.lower()
+            outer_status = "failed" if body_status in _REGISTRY_REJECTED_BODY_STATUS else "ok"
             return {
-                "status": "ok",
+                "status": outer_status,
                 "url": request_url,
-                "status_code": response.getcode(),
+                "status_code": status_code,
                 "response": response_payload,
             }
-    except HTTPError as exc:
-        response_text = exc.read().decode("utf-8")
-        try:
-            detail = json.loads(response_text) if response_text else None
-        except json.JSONDecodeError:
-            detail = response_text
-        raise RuntimeError(f"Registry submission failed with HTTP {exc.code}: {detail}") from exc
-    except URLError as exc:
-        raise RuntimeError(f"Registry submission failed: {exc.reason}") from exc
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")[:_REGISTRY_ERROR_BODY_LIMIT]
+            try:
+                detail: Any = json.loads(body) if body else None
+            except json.JSONDecodeError:
+                detail = body
+            message = f"Registry submission failed with HTTP {exc.code}: {detail}"
+            if exc.code in _REGISTRY_RETRYABLE_STATUS:
+                last_transient = RegistryTransientError(message, status_code=exc.code, response_body=body)
+            else:
+                # Other 4xx (incl. 409 conflict, 422 validation) won't succeed on a
+                # retry; raise now. The "HTTP <code>" text is preserved so the
+                # caller's existing 409 handling still matches.
+                raise RegistryClientError(message, status_code=exc.code, response_body=body) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            # Read-timeouts surface as a bare socket.timeout/TimeoutError (an OSError,
+            # NOT a URLError), so the original URLError-only catch let them escape and
+            # abort the whole batch. OSError is the safe superset.
+            reason = getattr(exc, "reason", exc)
+            last_transient = RegistryTransientError(f"Registry submission failed (network/timeout): {reason}")
+
+        # Reached only on a transient failure: back off, then the loop retries
+        # unless the attempt budget is exhausted.
+        if attempt + 1 < max_attempts and backoff_sec > 0:
+            time.sleep(backoff_sec * (2 ** attempt))
+    # Only reachable via the transient path. Use an explicit raise (not assert,
+    # which `python -O` strips) since this is load-bearing control flow.
+    if last_transient is None:  # pragma: no cover - defensive; max_attempts >= 1
+        raise RegistryClientError("Registry submission made no attempts")
+    raise last_transient
 
 
 def publish_curated_cell_spec(
@@ -5445,6 +5543,9 @@ def index_stats(index: dict[str, Any] | PathLike) -> dict[str, Any]:
 
 
 __all__ = [
+    "RegistryError",
+    "RegistryClientError",
+    "RegistryTransientError",
     "CellSpecificationInput",
     "CellInstanceInput",
     "MaterialSpecInput",

--- a/src/battinfo/interop/battery_data_commons.py
+++ b/src/battinfo/interop/battery_data_commons.py
@@ -189,9 +189,12 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     bdc_id = str(record.get("id") or "bdc_unknown")
     # Tolerate type-drift in external records: a scalar/list where a mapping is
     # expected becomes {} rather than crashing later on `.get` with a bare AttributeError.
-    overview = record.get("overview") if isinstance(record.get("overview"), Mapping) else {}
-    electrodes = record.get("electrodes") if isinstance(record.get("electrodes"), Mapping) else {}
-    reported = record.get("reported_values") if isinstance(record.get("reported_values"), Mapping) else {}
+    _overview = record.get("overview")
+    overview = _overview if isinstance(_overview, Mapping) else {}
+    _electrodes = record.get("electrodes")
+    electrodes = _electrodes if isinstance(_electrodes, Mapping) else {}
+    _reported = record.get("reported_values")
+    reported = _reported if isinstance(_reported, Mapping) else {}
     source_meta = record.get("source_metadata") or {}
     citation = _first([p.get("url") for p in (record.get("publications") or []) if isinstance(p, Mapping)]) \
         or _first(record.get("source_urls"))

--- a/src/battinfo/workspace_state.py
+++ b/src/battinfo/workspace_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import mimetypes
+import os
 import shutil
 import tempfile
 from datetime import datetime, timezone
@@ -43,6 +44,31 @@ def _relative_to(root: Path, path: Path) -> str:
         return path.relative_to(root).as_posix()
     except ValueError:
         return path.as_posix()
+
+
+def _swap_dir(staging: Path, target: Path) -> None:
+    """Atomically replace directory ``target`` with ``staging``.
+
+    Renames the existing ``target`` aside, moves ``staging`` into place, then
+    removes the old copy. Both moves are atomic renames; on failure the original
+    ``target`` is restored. This never destroys a live directory before its
+    replacement is durably in place (cf. ``shutil.rmtree`` then re-write, which
+    loses the whole group if interrupted in between).
+    """
+    backup: Path | None = None
+    if target.exists():
+        backup = target.with_name(staging.name + ".bak")
+        if backup.exists():
+            shutil.rmtree(backup, ignore_errors=True)
+        os.replace(target, backup)
+    try:
+        os.replace(staging, target)
+    except BaseException:
+        if backup is not None and not target.exists():
+            os.replace(backup, target)  # roll back to the original
+        raise
+    if backup is not None:
+        shutil.rmtree(backup, ignore_errors=True)
 
 
 def _guess_media_type(path: str | None) -> str | None:
@@ -534,15 +560,29 @@ class WorkspaceStateStore:
             "tests": self.root / manifest.paths.tests,
             "datasets": self.root / manifest.paths.datasets,
         }
-        for path in roots.values():
-            if path.exists():
-                shutil.rmtree(path)
-            path.mkdir(parents=True, exist_ok=True)
-
-        for key, items in record_groups.items():
-            for record in items:
-                filename = f"{self._record_short_id(key, record)}.json"
-                _write_json(roots[key] / filename, record)
+        # Stage each record group into a fresh sibling directory and atomically
+        # swap it into place. We never rmtree a live record directory *before* its
+        # replacement is durably written — a crash/Ctrl-C mid-write would otherwise
+        # wipe the entire group with no recovery.
+        staging_dirs: dict[str, Path] = {}
+        try:
+            for key, root in roots.items():
+                root.parent.mkdir(parents=True, exist_ok=True)
+                staging_dirs[key] = Path(
+                    tempfile.mkdtemp(dir=str(root.parent), prefix=f".{root.name}.staging-")
+                )
+            for key, items in record_groups.items():
+                staging = staging_dirs[key]
+                for record in items:
+                    filename = f"{self._record_short_id(key, record)}.json"
+                    _write_json(staging / filename, record)
+            for key, root in roots.items():
+                _swap_dir(staging_dirs[key], root)
+        finally:
+            # Swapped staging dirs are already consumed (renamed); un-swapped ones
+            # are cleaned up here so an error path never leaks a staging directory.
+            for staging in staging_dirs.values():
+                shutil.rmtree(staging, ignore_errors=True)
 
         dataset_by_id = {dataset.id: dataset for dataset in self.datasets if dataset.id is not None}
         artifacts_root = self.root / manifest.artifacts_dir / "dataset"
@@ -651,13 +691,24 @@ class WorkspaceStateStore:
             "tests": target_root / "test",
             "datasets": target_root / "dataset",
         }
-        for key, path in groups.items():
-            if path.exists():
-                shutil.rmtree(path)
-            path.mkdir(parents=True, exist_ok=True)
-            for record in records[key]:
-                filename = f"{self._record_short_id(key, record)}.json"
-                _write_json(path / filename, record)
+        # Stage each group then atomically swap, so an interrupted write never
+        # destroys an existing group before its replacement is durable (R-5).
+        staging_dirs: dict[str, Path] = {}
+        try:
+            for key, path in groups.items():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                staging_dirs[key] = Path(
+                    tempfile.mkdtemp(dir=str(path.parent), prefix=f".{path.name}.staging-")
+                )
+            for key, staging in staging_dirs.items():
+                for record in records[key]:
+                    filename = f"{self._record_short_id(key, record)}.json"
+                    _write_json(staging / filename, record)
+            for key, path in groups.items():
+                _swap_dir(staging_dirs[key], path)
+        finally:
+            for staging in staging_dirs.values():
+                shutil.rmtree(staging, ignore_errors=True)
 
     @staticmethod
     def _load_records(directory: Path) -> list[dict[str, Any]]:

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from battinfo._jsonio import atomic_write_text as _atomic_write_text
 from battinfo.entities import record_set_dirs
 
 # Short-name pattern: 6 lowercase alphanumeric characters at the end of a
@@ -1274,8 +1275,7 @@ class AuthoringWorkspace:
                 if record.get("funding") == block:
                     continue
                 record["funding"] = block
-                p.write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n",
-                             encoding="utf-8")
+                _atomic_write_text(p, json.dumps(record, indent=2, ensure_ascii=False) + "\n")
                 stamped += 1
         return stamped
 
@@ -1401,7 +1401,7 @@ class AuthoringWorkspace:
                     continue
                 contributors.append(person)
                 record["contributor"] = contributors
-                p.write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+                _atomic_write_text(p, json.dumps(record, indent=2, ensure_ascii=False) + "\n")
                 stamped += 1
         return stamped
 
@@ -3121,7 +3121,7 @@ class AuthoringWorkspace:
 
             ds["distributions"] = dists
             raw["dataset"] = ds
-            record_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False), encoding="utf-8")
+            _atomic_write_text(record_path, json.dumps(raw, indent=2, ensure_ascii=False))
 
         print(f"\nGenerated {len(written)} preview file(s) across the datasets.")
         return written
@@ -3293,7 +3293,7 @@ class AuthoringWorkspace:
             urls.append(primary_url or new_dists[0]["content_url"])
             raw["dataset"]["access_url"] = primary_url or new_dists[0]["content_url"]
             raw["dataset"]["distributions"] = new_dists
-            record_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False), encoding="utf-8")
+            _atomic_write_text(record_path, json.dumps(raw, indent=2, ensure_ascii=False))
 
             # Keep session paths in sync so submit() picks up the updated record
             self._session_paths.add(record_path)

--- a/tests/test_api_submit.py
+++ b/tests/test_api_submit.py
@@ -1,0 +1,212 @@
+"""Regression tests for the registry submission contract (hardening plan Phase 2.4).
+
+Pins ``submit_publication_package`` against a hostile / cold-starting registry:
+- a 2xx with a non-JSON body is surfaced, not raised as ``JSONDecodeError`` (R-3);
+- a read-timeout / network error is a typed transient error, not a bare
+  ``TimeoutError`` that escapes the caller's ``except RuntimeError`` (R-4);
+- a body-level ``rejected``/``failed`` status on a 2xx is not reported as ok (C-7);
+- transient HTTP 5xx/429 are retried with backoff, other 4xx are not (A-1);
+- a 409 still raises a ``RuntimeError`` whose message contains "409" and is not
+  retried, so ``ws._do_submit``'s version-bump handling keeps working.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api import (  # noqa: E402
+    RegistryClientError,
+    RegistryTransientError,
+    submit_publication_package,
+)
+
+# backoff_sec=0 keeps the retry tests instant.
+_KW = dict(registry_base_url="https://registry.example", api_key="k", backoff_sec=0)
+
+
+class _FakeResp:
+    """Minimal stand-in for the urlopen() context manager on the success path."""
+
+    def __init__(self, code: int, body: str | bytes) -> None:
+        self._code = code
+        self._body = body
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def getcode(self) -> int:
+        return self._code
+
+    def read(self) -> bytes:
+        return self._body if isinstance(self._body, bytes) else self._body.encode("utf-8")
+
+
+def _http_error(code: int, body: str = "") -> HTTPError:
+    return HTTPError(
+        "https://registry.example/publication-packages",
+        code,
+        "error",
+        {},  # type: ignore[arg-type]
+        io.BytesIO(body.encode("utf-8")),
+    )
+
+
+def _patch_urlopen(monkeypatch: pytest.MonkeyPatch, actions: list[object]) -> dict[str, int]:
+    """Replace battinfo.api.urlopen with a scripted sequence.
+
+    Each element is either a ``_FakeResp`` (returned) or a ``BaseException``
+    (raised). The last element repeats if there are more attempts than actions.
+    """
+    calls = {"n": 0}
+
+    def fake_urlopen(_request: object, timeout: float | None = None) -> _FakeResp:
+        idx = min(calls["n"], len(actions) - 1)
+        calls["n"] += 1
+        action = actions[idx]
+        if isinstance(action, BaseException):
+            raise action
+        return action  # type: ignore[return-value]
+
+    monkeypatch.setattr("battinfo.api.urlopen", fake_urlopen)
+    return calls
+
+
+def test_non_json_2xx_raises_client_error_not_jsondecodeerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_urlopen(monkeypatch, [_FakeResp(200, "<html>502 Bad Gateway</html>")])
+    with pytest.raises(RegistryClientError):
+        submit_publication_package({"kind": "x"}, **_KW)
+
+
+def test_read_timeout_raises_transient_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_urlopen(monkeypatch, [TimeoutError("timed out")])
+    with pytest.raises(RegistryTransientError):
+        submit_publication_package({"kind": "x"}, max_attempts=3, **_KW)
+    assert calls["n"] == 3  # the full retry budget was used
+
+
+def test_timeout_error_is_a_runtimeerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ws._do_submit catches RuntimeError; the transient error must qualify.
+    _patch_urlopen(monkeypatch, [TimeoutError("timed out")])
+    with pytest.raises(RuntimeError):
+        submit_publication_package({"kind": "x"}, max_attempts=1, **_KW)
+
+
+def test_body_status_rejected_is_not_reported_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_urlopen(monkeypatch, [_FakeResp(200, json.dumps({"status": "rejected", "resources": []}))])
+    result = submit_publication_package({"kind": "x"}, **_KW)
+    assert result["status"] == "failed"
+
+
+def test_body_status_published_is_ok_and_preserves_inner(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_urlopen(monkeypatch, [_FakeResp(200, json.dumps({"status": "published", "resources": []}))])
+    result = submit_publication_package({"kind": "x"}, **_KW)
+    assert result["status"] == "ok"
+    assert result["response"]["status"] == "published"  # inner body status passes through untouched
+
+
+def test_body_status_validated_is_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Only failed/rejected/error flip the outer status; other non-2xx-reject bodies stay ok.
+    _patch_urlopen(monkeypatch, [_FakeResp(200, json.dumps({"status": "validated"}))])
+    result = submit_publication_package({"kind": "x"}, **_KW)
+    assert result["status"] == "ok"
+
+
+def test_retries_5xx_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_urlopen(
+        monkeypatch,
+        [_http_error(503, "down"), _FakeResp(200, json.dumps({"status": "published"}))],
+    )
+    result = submit_publication_package({"kind": "x"}, max_attempts=3, **_KW)
+    assert result["status"] == "ok"
+    assert calls["n"] == 2  # one retry, then success
+
+
+def test_does_not_retry_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_urlopen(monkeypatch, [_http_error(422, json.dumps({"detail": "bad"}))])
+    with pytest.raises(RegistryClientError):
+        submit_publication_package({"kind": "x"}, max_attempts=3, **_KW)
+    assert calls["n"] == 1  # a client error is terminal
+
+
+def test_409_is_runtimeerror_with_code_and_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_urlopen(monkeypatch, [_http_error(409, "conflict")])
+    with pytest.raises(RegistryClientError) as exc_info:
+        submit_publication_package({"kind": "x"}, max_attempts=3, **_KW)
+    assert isinstance(exc_info.value, RuntimeError)
+    assert "409" in str(exc_info.value)  # ws._do_submit keys its version-bump retry on this
+    assert calls["n"] == 1
+
+
+def test_non_utf8_2xx_raises_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A non-UTF-8 2xx body must surface as a RegistryClientError (a RuntimeError),
+    # NOT a bare UnicodeDecodeError (a ValueError) that escapes except RuntimeError.
+    _patch_urlopen(monkeypatch, [_FakeResp(200, b"\xff\xfe not utf-8 garbage")])
+    with pytest.raises(RegistryClientError):
+        submit_publication_package({"kind": "x"}, **_KW)
+
+
+def test_connection_error_raises_transient_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_urlopen(monkeypatch, [URLError("Connection refused")])
+    with pytest.raises(RegistryTransientError):
+        submit_publication_package({"kind": "x"}, max_attempts=3, **_KW)
+    assert calls["n"] == 3
+
+
+def test_max_attempts_below_one_raises_valueerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_urlopen(monkeypatch, [_FakeResp(200, json.dumps({"status": "published"}))])
+    with pytest.raises(ValueError):
+        submit_publication_package({"kind": "x"}, max_attempts=0, **_KW)
+
+
+def test_do_submit_retries_on_409_with_version_bump(monkeypatch: pytest.MonkeyPatch) -> None:
+    # End-to-end: a 409 RegistryClientError must still drive ws._do_submit's
+    # version-bump retry (the load-bearing reason it subclasses RuntimeError and
+    # keeps "409" in its message), then succeed on the second attempt.
+    import battinfo.ws as ws_module
+
+    calls = _patch_urlopen(
+        monkeypatch,
+        [
+            _http_error(409, "conflict"),
+            _FakeResp(200, json.dumps({"status": "published", "resources": [{"canonical_iri": "iri-1"}]})),
+        ],
+    )
+    payload = {
+        "source_version": "2026-06-27",
+        "provenance": {},
+        "resource": {"source_version": "2026-06-27"},
+    }
+    result = ws_module._do_submit(payload, "https://registry.example", "k", "Test Record")
+    assert calls["n"] == 2  # 409, then a bumped-version retry that succeeds
+    assert result and result[0]["status_code"] == 200
+
+
+@pytest.mark.parametrize("body", [b"42", b'"ok"', b"[1, 2]"])
+def test_non_dict_json_2xx_raises_client_error(monkeypatch: pytest.MonkeyPatch, body: bytes) -> None:
+    # A 2xx whose JSON body is a scalar/list (not an object) must surface as a
+    # RegistryClientError, not pass a non-mapping through to callers.
+    _patch_urlopen(monkeypatch, [_FakeResp(200, body)])
+    with pytest.raises(RegistryClientError):
+        submit_publication_package({"kind": "x"}, **_KW)
+
+
+def test_do_submit_scalar_2xx_body_does_not_abort_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The scalar-body case must be recorded as one failed record (return []), not an
+    # AttributeError that escapes _do_submit's except RuntimeError and aborts the batch.
+    import battinfo.ws as ws_module
+
+    _patch_urlopen(monkeypatch, [_FakeResp(200, b"42")])
+    payload = {"source_version": "v1", "provenance": {}, "resource": {"source_version": "v1"}}
+    result = ws_module._do_submit(payload, "https://registry.example", "k", "Test Record")
+    assert result == []

--- a/tests/test_atomic_persistence.py
+++ b/tests/test_atomic_persistence.py
@@ -1,0 +1,209 @@
+"""Regression tests for atomic durable writes (hardening plan Phase 3.3 / review R-5).
+
+These pin the contract that an interrupted write never destroys a prior good
+record: ``_jsonio.write_json`` is atomic (temp + fsync + ``os.replace``), and
+``WorkspaceStateStore._write_workspace`` stages-then-swaps instead of
+rmtree-before-write.
+
+The failure modes are injected *after* the code commits to writing (during the
+flush or the atomic commit), not before serialization — a test that only makes
+``json.dumps`` raise would pass even against the old, non-atomic implementation.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import Workspace, _jsonio, quantity, workspace_state
+from battinfo._jsonio import read_json, write_json
+from battinfo.workspace_state import _swap_dir
+
+# ── _jsonio.write_json atomicity ──────────────────────────────────────────────
+
+def test_write_json_roundtrips_and_leaves_no_temp(tmp_path: Path) -> None:
+    path = tmp_path / "rec.json"
+    write_json(path, {"a": 1, "b": "x"})
+    assert read_json(path) == {"a": 1, "b": "x"}
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["rec.json"]
+
+
+def test_write_json_preserves_prior_record_when_commit_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "rec.json"
+    write_json(path, {"original": True})
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated crash at the atomic commit")
+
+    monkeypatch.setattr(_jsonio.os, "replace", boom)
+    with pytest.raises(OSError):
+        write_json(path, {"original": False})
+
+    # The prior good record survives a failed write, and the temp is cleaned up.
+    assert read_json(path) == {"original": True}
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["rec.json"]
+
+
+def test_write_json_preserves_prior_record_when_flush_interrupted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "rec.json"
+    write_json(path, {"original": True})
+
+    def boom(_fd):
+        raise OSError("simulated interruption during flush")
+
+    monkeypatch.setattr(_jsonio.os, "fsync", boom)
+    with pytest.raises(OSError):
+        write_json(path, {"original": False})
+
+    assert read_json(path) == {"original": True}
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["rec.json"]
+
+
+# ── _swap_dir atomic directory replacement ────────────────────────────────────
+
+def test_swap_dir_replaces_contents_with_no_residue(tmp_path: Path) -> None:
+    target = tmp_path / "records"
+    target.mkdir()
+    (target / "old.json").write_text("OLD", encoding="utf-8")
+    staging = tmp_path / ".records.staging"
+    staging.mkdir()
+    (staging / "new.json").write_text("NEW", encoding="utf-8")
+
+    _swap_dir(staging, target)
+
+    assert {p.name for p in target.iterdir()} == {"new.json"}
+    assert not staging.exists()
+    assert not any(p.name.endswith(".bak") for p in tmp_path.iterdir())
+
+
+def test_swap_dir_restores_target_when_swap_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "records"
+    target.mkdir()
+    (target / "old.json").write_text("OLD", encoding="utf-8")
+    staging = tmp_path / ".records.staging"
+    staging.mkdir()
+    (staging / "new.json").write_text("NEW", encoding="utf-8")
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 2:  # the staging -> target move fails mid-swap
+            raise OSError("simulated crash mid-swap")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(workspace_state.os, "replace", flaky_replace)
+    with pytest.raises(OSError):
+        _swap_dir(staging, target)
+
+    # The rollback restores the original target content.
+    assert {p.name for p in target.iterdir()} == {"old.json"}
+    assert (target / "old.json").read_text(encoding="utf-8") == "OLD"
+
+
+# ── WorkspaceStateStore._write_workspace stages-then-swaps (no rmtree-first) ───
+
+def _build_workspace(workspace_root: Path, tmp_path: Path) -> Workspace:
+    dataset = tmp_path / "inputs" / "cyc.csv"
+    dataset.parent.mkdir(parents=True, exist_ok=True)
+    dataset.write_text("cycle,capacity_ah\n0,2.50\n1,2.48\n", encoding="utf-8")
+    ws = Workspace(
+        workspace_root,
+        name="interrupt-demo",
+        title="Interrupt Demo",
+        description="durable-write regression",
+        tenant="t",
+        publisher="p",
+        version="0.1.0",
+    )
+    spec = ws.cell_spec(
+        manufacturer="A123",
+        model="ANR26650M1-B",
+        format="cylindrical",
+        chemistry="Li-ion",
+        size_code="R26650",
+        positive_electrode_basis="LFP",
+        negative_electrode_basis="graphite",
+        specs={"nominal_voltage": quantity(3.3, "V")},
+        source_file="a123-anr26650m1-b.manual.json",
+    )
+    cell = ws.cell(spec, serial_number="interrupt-001", batch_id="B1", source_type="lab")
+    test = ws.test(cell, kind="cycling", protocol="1C", instrument="VSP-300", status="completed")
+    ws.dataset(cell, title="Cycle life", description="d", test=test, path=dataset, license="CC-BY-4.0")
+    return ws
+
+
+def test_interrupted_save_preserves_existing_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    ws = _build_workspace(workspace_root, tmp_path)
+    assert ws.save_workspace()["status"] == "ok"
+
+    before = {
+        p.relative_to(workspace_root).as_posix(): p.read_text(encoding="utf-8")
+        for p in workspace_root.rglob("*.json")
+    }
+    assert before, "expected the first save to persist record files"
+
+    # Simulate a crash during the second save's directory swap. The old
+    # rmtree-before-write would have wiped the record directories here.
+    def boom(_staging, _target):
+        raise OSError("simulated crash during swap")
+
+    monkeypatch.setattr(workspace_state, "_swap_dir", boom)
+    with pytest.raises(OSError):
+        ws.save_workspace()
+
+    after = {
+        p.relative_to(workspace_root).as_posix(): p.read_text(encoding="utf-8")
+        for p in workspace_root.rglob("*.json")
+    }
+    for rel, content in before.items():
+        assert rel in after, f"record {rel} was destroyed by an interrupted save"
+        assert after[rel] == content
+    # No staging directory leaked onto disk.
+    assert not any(".staging-" in p.name for p in workspace_root.rglob("*"))
+
+
+def test_atomic_write_text_bytes_match_legacy(tmp_path: Path) -> None:
+    # atomic_write_text must produce byte-identical output to the previous
+    # Path.write_text(text, encoding="utf-8") so there is zero line-ending churn.
+    from battinfo._jsonio import atomic_write_text
+
+    text = json.dumps({"a": 1, "nested": {"b": [1, 2, 3]}, "s": "café"}, indent=2, ensure_ascii=False) + "\n"
+    atomic_path = tmp_path / "atomic.json"
+    legacy_path = tmp_path / "legacy.json"
+    atomic_write_text(atomic_path, text)
+    legacy_path.write_text(text, encoding="utf-8")  # the previous, non-atomic implementation
+    assert atomic_path.read_bytes() == legacy_path.read_bytes()
+
+
+def test_write_json_cleans_up_when_fdopen_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # If os.fdopen fails after mkstemp, the raw fd must be closed and the temp
+    # removed — no orphaned .tmp and no leaked fd (else Windows unlink hits WinError 32).
+    path = tmp_path / "rec.json"
+    write_json(path, {"original": True})
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated fdopen failure")
+
+    monkeypatch.setattr(_jsonio.os, "fdopen", boom)
+    with pytest.raises(OSError):
+        write_json(path, {"original": False})
+
+    assert read_json(path) == {"original": True}
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["rec.json"]

--- a/tests/test_ws_contributor.py
+++ b/tests/test_ws_contributor.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(ROOT / "src"))
 from battinfo.ws import (  # noqa: E402
     AuthoringWorkspace,
     ContributorRef,
+    ProjectRef,
     _normalize_orcid,
 )
 
@@ -151,6 +152,54 @@ def test_save_stamps_contributor_on_every_record(tmp_path: Path) -> None:
     assert records, "expected record files"
     for rec in records:
         assert ORCID_URL in _contributor_orcids(rec), f"missing contributor: {rec.keys()}"
+
+
+def test_interrupted_contributor_stamp_leaves_records_valid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The contributor stamp rewrites canonical record files in place; an
+    # interrupted stamp must never leave a truncated/half-written record (R-5).
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    _populate(ws, tmp_path)
+    ws.contributor(ORCID, name="Jane Researcher")
+    ws.save(validation_policy="strict")
+
+    record_files = [p for p in ws._records_root.rglob("*.json") if "index" not in p.name]
+    assert record_files
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated crash during contributor stamp")
+
+    monkeypatch.setattr("battinfo.ws._atomic_write_text", boom)
+    with pytest.raises(OSError):
+        ws.save(validation_policy="strict")
+
+    # Every record on disk is still valid JSON — never truncated by the failed stamp.
+    for p in record_files:
+        json.loads(p.read_text(encoding="utf-8"))
+
+
+def test_interrupted_funding_stamp_leaves_records_valid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Same R-5 guarantee for the funding (project) stamp path (ws.py:_stamp_project_funding).
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    _populate(ws, tmp_path)
+    ws._set_project(ProjectRef(identifier="101103997", name="DigiBatt", funder="EU"))
+    ws.save(validation_policy="strict")
+
+    record_files = [p for p in ws._records_root.rglob("*.json") if "index" not in p.name]
+    assert record_files
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated crash during funding stamp")
+
+    monkeypatch.setattr("battinfo.ws._atomic_write_text", boom)
+    with pytest.raises(OSError):
+        ws.save(validation_policy="strict")
+
+    for p in record_files:
+        json.loads(p.read_text(encoding="utf-8"))
 
 
 def test_resave_does_not_duplicate_contributor(tmp_path: Path) -> None:


### PR DESCRIPTION
Improve the robustness of record handling with record durability and contract exception handling. 

- _jsonio.atomic_write_text (temp + fsync + os.replace) now backs write_json; ws.py dataset + funding/contributor stamp writes use it.
- workspace_state._write_workspace / _write_record_groups stage-then-swap via _swap_dir instead of rmtree-before-write.
- Typed RegistryError/RegistryClientError/RegistryTransientError (RuntimeError subclasses); retry-with-backoff on 429/5xx/timeout, not other 4xx; guard non-JSON / non-UTF-8 / non-dict 2xx bodies; surface body-level reject status; catch read-timeouts; validate max_attempts.