### PR TITLE
harden: fix IRI-collision data loss + non-finite guards

### DIFF
--- a/src/battinfo/_workspace.py
+++ b/src/battinfo/_workspace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import mimetypes
 import shutil
 from collections.abc import Sequence
@@ -143,33 +144,76 @@ def _with_default(value: str | None, fallback: str) -> str:
     return text or fallback
 
 
+# Fields that vary across runs (or are the IRI itself) and must NOT influence a
+# content-derived disambiguation seed — otherwise a re-minted IRI would be unstable
+# across re-runs (e.g. a finalize-time ``retrieved_at`` timestamp).
+_VOLATILE_SEED_KEYS = frozenset(
+    {"id", "uid", "retrieved_at", "created_at", "modified_at", "generated_at", "imported_at"}
+)
+
+
+def _strip_volatile(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _strip_volatile(v) for k, v in value.items() if k not in _VOLATILE_SEED_KEYS}
+    if isinstance(value, list):
+        return [_strip_volatile(v) for v in value]
+    return value
+
+
+def _content_seed(entity: Any) -> str:
+    """A stable, order-independent seed from an entity's distinguishing content
+    (its canonical record minus the IRI and volatile timestamps)."""
+    data = entity.model_dump(mode="json", exclude_none=True)
+    return json.dumps(_strip_volatile(data), sort_keys=True, ensure_ascii=False)
+
+
 def _disambiguate_entity_ids(entities: Sequence[Any], entity_type: str) -> None:
     """Ensure auto-minted IRIs are unique across distinct authored entities.
 
     Deterministic IRIs are seeded from a record's identity fields, so two
     genuinely-distinct entities whose identity fields happen to match — e.g. two
-    unnamed cycling tests on one cell, or two cells from one batch with no serial
-    number — mint the *same* IRI. On save each record is written to a file named
-    after its IRI, so the duplicate silently overwrote its sibling and one record
-    was lost. Re-mint any collisions with a stable ordinal-seeded IRI so every
-    distinct record persists. Records whose IRI is already unique are untouched,
-    keeping the blast radius to the (rare) colliding case only.
+    cell-specs for one manufacturer+model with different capacities, or two unnamed
+    cycling tests on one cell — mint the *same* IRI. On save each record is written
+    to a file named after its IRI, so the duplicate silently overwrote its sibling
+    and one record was lost.
+
+    When >=2 entities collide on one IRI, re-mint *every* member of that group from a
+    hash of its distinguishing content (``{iri}::{content}``). This is
+    order-independent — a given record keeps the same IRI regardless of sibling order
+    or re-run — and guarantees distinct content can never overwrite. A genuine
+    full-content duplicate (identical content) falls back to a stable ordinal suffix
+    so it still persists. Entities whose IRI is already unique are untouched,
+    preserving the idempotent identity-seeded IRI for the common single-record case.
+
+    Note: adding an identity-colliding sibling later re-mints a previously-unique record
+    to a content-seeded IRI — the deliberate cost of order-independence. This loses no
+    data within a workspace, since save() stages-then-swaps the full finalized set.
     """
+    by_id: dict[str, list[Any]] = {}
+    for entity in entities:
+        current = getattr(entity, "id", None)
+        if current is not None:
+            by_id.setdefault(current, []).append(entity)
+
     seen: set[str] = set()
     for entity in entities:
         current = getattr(entity, "id", None)
         if current is None:
             continue
-        if current not in seen:
-            seen.add(current)
-            continue
-        ordinal = 1
-        candidate = _entity_iri(entity_type, f"{current}::{ordinal}")
-        while candidate in seen:
-            ordinal += 1
-            candidate = _entity_iri(entity_type, f"{current}::{ordinal}")
-        entity.id = candidate
-        seen.add(candidate)
+        group = by_id.get(current)
+        if group is not None and len(group) > 1:
+            # Distinct entities sharing an IRI: re-seed from content (order-independent).
+            current = _entity_iri(entity_type, f"{current}::{_content_seed(entity)}")
+        if current in seen:
+            # Genuine full-content duplicate — keep both with a stable ordinal suffix.
+            ordinal = 1
+            candidate = _entity_iri(entity_type, f"{current}::dup{ordinal}")
+            while candidate in seen:
+                ordinal += 1
+                candidate = _entity_iri(entity_type, f"{current}::dup{ordinal}")
+            current = candidate
+        entity.id = current
+        seen.add(current)
 
 
 def _as_path(path: PathLike) -> Path:
@@ -1743,6 +1787,11 @@ class Workspace:
     def _finalize(self) -> dict[str, list[Any]]:
         finalized_cell_specs = [self._finalize_cell_spec(item) for item in self.cell_specs]
         cell_spec_map = {id(original): finalized for original, finalized in zip(self.cell_specs, finalized_cell_specs, strict=True)}
+        # Break cell-spec IRI collisions before cells link to them: distinct specs that
+        # share identity fields must not overwrite each other on save, and each cell must
+        # link to its own spec (cell_spec_map holds the same objects, so in-place
+        # re-minting propagates into _finalize_cell's cell_spec_id lookup below).
+        _disambiguate_entity_ids(finalized_cell_specs, "cell-spec")
 
         finalized_cells = [self._finalize_cell(item, cell_spec_map) for item in self.cells]
         cell_map = {id(original): finalized for original, finalized in zip(self.cells, finalized_cells, strict=True)}
@@ -1754,6 +1803,8 @@ class Workspace:
         test_spec_map = {
             id(original): finalized for original, finalized in zip(self.test_specs, finalized_test_specs, strict=True)
         }
+        # Break test-spec IRI collisions before tests link to them via conformsTo.
+        _disambiguate_entity_ids(finalized_test_specs, "test-protocol")
 
         finalized_tests = [self._finalize_test(item, cell_map, test_spec_map) for item in self.tests]
         test_map = {id(original): finalized for original, finalized in zip(self.tests, finalized_tests, strict=True)}

--- a/src/battinfo/interop/protocols.py
+++ b/src/battinfo/interop/protocols.py
@@ -11,6 +11,7 @@ summary; the linked artifact remains the executable source of truth.
 from __future__ import annotations
 
 import json
+import math
 import time
 from pathlib import Path
 from typing import Any
@@ -52,13 +53,19 @@ def _looks_like_path(source: Any) -> bool:
 
 
 def _num(value: Any) -> float | None:
-    """aurora-unicycler JSON stores numbers as strings; coerce leniently."""
+    """aurora-unicycler JSON stores numbers as strings; coerce leniently.
+
+    A non-finite result (NaN / +-Infinity) is rejected as ``None``: it is never a
+    valid measurement and is not JSON-serialisable (RFC 8259), so it must never be
+    coerced into a quantity that later survives validation and fails on export.
+    """
     if value is None:
         return None
     try:
-        return float(value)
+        result = float(value)
     except (TypeError, ValueError):
         return None
+    return result if math.isfinite(result) else None
 
 
 def _q(value: float, unit: str) -> Quantity:

--- a/src/battinfo/validate/semantic.py
+++ b/src/battinfo/validate/semantic.py
@@ -417,20 +417,9 @@ def _validate_specs(
     for spec_name, spec_value in specs.items():
         if not isinstance(spec_value, Mapping):
             continue
-        # A non-finite numeric (NaN / +-Infinity) is never a valid measurement and
-        # is not JSON-serialisable per RFC 8259 — always a hard error, regardless of
-        # policy, so it can never be persisted or published.
-        for value_key in ("value", "typical_value", "min_value", "max_value"):
-            raw = spec_value.get(value_key)
-            if isinstance(raw, (int, float)) and not isinstance(raw, bool) and not math.isfinite(raw):
-                _append_issue(
-                    issues,
-                    code="semantic.value_not_finite",
-                    severity="error",
-                    path=f"specs.{spec_name}.{value_key}",
-                    message=f"value for '{spec_name}.{value_key}' is not finite (NaN/Infinity); not a valid measurement.",
-                    resource_type=resource_type,
-                )
+        # Non-finite numerics (NaN / +-Infinity) are caught record-wide by
+        # _walk_non_finite (called from validate_semantic_report), so nested
+        # quantities are covered too, not just flat specs.
         unit = _unit_token(spec_value)
         if unit is not None and spec_name in SPEC_UNIT_COMPATIBILITY:
             normalized = _normalized_unit(unit)
@@ -603,6 +592,39 @@ def _validate_test_semantics(
         )
 
 
+def _walk_non_finite(
+    value: Any,
+    path: str,
+    issues: list[ValidationIssue],
+    resource_type: str | None,
+) -> None:
+    """Recursively flag any non-finite float (NaN / +-Infinity) anywhere in the record.
+
+    Non-finite numerics are never valid measurements and are not JSON-serialisable
+    (RFC 8259), so they are a hard error regardless of policy or nesting depth. This
+    catches values a flat specs check misses — e.g. an electrode coating's nested
+    ``property.loading.value`` reached via create_component_spec.
+    """
+    if isinstance(value, bool):
+        return
+    if isinstance(value, float) and not math.isfinite(value):
+        label = path or "<root>"
+        _append_issue(
+            issues,
+            code="semantic.value_not_finite",
+            severity="error",
+            path=label,
+            message=f"value at '{label}' is not finite (NaN/Infinity); not a valid measurement.",
+            resource_type=resource_type,
+        )
+    elif isinstance(value, Mapping):
+        for key, sub in value.items():
+            _walk_non_finite(sub, f"{path}.{key}" if path else str(key), issues, resource_type)
+    elif isinstance(value, (list, tuple)):
+        for index, sub in enumerate(value):
+            _walk_non_finite(sub, f"{path}[{index}]", issues, resource_type)
+
+
 def validate_semantic_report(
     doc: dict[str, Any],
     *,
@@ -621,6 +643,10 @@ def validate_semantic_report(
     _validate_identifier_consistency(doc, issues, resource_type, hard_issue_severity)
     _validate_controlled_values(doc, issues, resource_type)
     _validate_size_code(doc, issues, resource_type, hard_issue_severity)
+    # Non-finite numerics are invalid anywhere in the record (RFC 8259); walk the
+    # whole doc so nested quantities (electrode coating, etc.) are caught, not just
+    # flat specs.
+    _walk_non_finite(doc, "", issues, resource_type)
 
     specs = doc.get("properties")
     if isinstance(specs, Mapping):

--- a/tests/test_iri_disambiguation.py
+++ b/tests/test_iri_disambiguation.py
@@ -1,0 +1,163 @@
+"""Phase 3 / review C-1 + C-2: distinct entities that share identity fields must get
+distinct, order-independent IRIs — never silently overwrite each other on save.
+
+Two cell-specs for one manufacturer+model with different capacities have the same
+identity seed (manufacturer::model::format::chemistry::size_code), so before the fix
+they minted the same IRI and one overwrote the other on save. The fix re-mints every
+member of a collision group from its content, deterministically and order-independently.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import Workspace, quantity  # noqa: E402
+
+
+def _ws(root: Path) -> Workspace:
+    return Workspace(root, name="t", title="T", description="d", tenant="x", publisher="p", version="0.1.0")
+
+
+def _spec(ws: Workspace, capacity: float) -> None:
+    ws.cell_spec(
+        manufacturer="Acme", model="X1", format="cylindrical", chemistry="Li-ion", size_code="R26650",
+        positive_electrode_basis="LFP", negative_electrode_basis="graphite",
+        specs={"nominal_capacity": quantity(capacity, "Ah")}, source_file=f"x-{capacity}.json",
+    )
+
+
+def test_colliding_cell_specs_get_distinct_ids(tmp_path: Path) -> None:
+    ws = _ws(tmp_path / "ws")
+    _spec(ws, 2.5)
+    _spec(ws, 3.5)
+    ws._finalize()
+    ids = [s.id for s in ws.cell_specs]
+    assert ids[0] != ids[1], "two distinct cell-specs collided onto one IRI (C-1 data loss)"
+    assert all(i and "/spec/" in i for i in ids)
+
+
+def test_colliding_cell_specs_persist_as_two_distinct_records(tmp_path: Path) -> None:
+    root = tmp_path / "ws"
+    ws = _ws(root)
+    _spec(ws, 2.5)
+    _spec(ws, 3.5)
+    ws.save_workspace()
+    ids: set[str] = set()
+    for f in root.rglob("*.json"):
+        try:
+            doc = json.loads(f.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(doc, dict) and isinstance(doc.get("cell_spec"), dict) and doc["cell_spec"].get("id"):
+            ids.add(doc["cell_spec"]["id"])
+    assert len(ids) == 2, "a distinct cell-spec was overwritten on save (C-1)"
+
+
+def test_spec_disambiguation_is_order_independent(tmp_path: Path) -> None:
+    def author(order: list[float]) -> dict[float, str]:
+        ws = _ws(tmp_path / ("ws-" + "-".join(str(c) for c in order)))
+        for cap in order:
+            _spec(ws, cap)
+        ws._finalize()
+        return {cap: ws.cell_specs[i].id for i, cap in enumerate(order)}
+
+    a = author([2.5, 3.5])
+    b = author([3.5, 2.5])
+    assert a[2.5] == b[2.5] and a[3.5] == b[3.5], "the same spec got a different IRI when sibling order changed (C-2)"
+
+
+def test_single_spec_keeps_idempotent_identity_iri(tmp_path: Path) -> None:
+    # No collision -> the identity-seeded IRI is preserved, so re-authoring the same
+    # content (in a fresh workspace) yields the same IRI (idempotent upsert).
+    ws_a = _ws(tmp_path / "a")
+    _spec(ws_a, 2.5)
+    ws_a._finalize()
+
+    ws_b = _ws(tmp_path / "b")
+    _spec(ws_b, 2.5)
+    ws_b._finalize()
+
+    assert ws_a.cell_specs[0].id == ws_b.cell_specs[0].id
+
+
+def test_cells_link_to_their_own_colliding_spec(tmp_path: Path) -> None:
+    # The cascade fix: two cells, each built on a distinct (identity-colliding) spec,
+    # must end up referencing their OWN spec, not whichever survived.
+    ws = _ws(tmp_path / "ws")
+    s1 = _ws_spec(ws, 2.5)
+    s2 = _ws_spec(ws, 3.5)
+    ws.cell(s1, serial_number="c1", source_type="lab")
+    ws.cell(s2, serial_number="c2", source_type="lab")
+    ws._finalize()
+    spec_ids = {s.id for s in ws.cell_specs}
+    cell_spec_links = {c.cell_spec_id for c in ws.cells}
+    assert len(spec_ids) == 2
+    assert cell_spec_links == spec_ids, "cells did not each link to their own distinct spec (C-1 cascade)"
+
+
+def _ws_spec(ws: Workspace, capacity: float):
+    return ws.cell_spec(
+        manufacturer="Acme", model="X1", format="cylindrical", chemistry="Li-ion", size_code="R26650",
+        positive_electrode_basis="LFP", negative_electrode_basis="graphite",
+        specs={"nominal_capacity": quantity(capacity, "Ah")}, source_file=f"x-{capacity}.json",
+    )
+
+
+def test_colliding_test_specs_get_distinct_ids_and_tests_link_own(tmp_path: Path) -> None:
+    # The test-spec disambiguation path (the new _finalize call for finalized_test_specs)
+    # plus the conformsTo/protocol_id cascade — a regression here silently conflates two
+    # distinct protocols into one canonical record.
+    ws = _ws(tmp_path / "ws")
+    cell = ws.cell(_ws_spec(ws, 2.5), serial_number="c1", source_type="lab")
+    ts1 = ws.test_spec(name="Cycling", type="cycling", version="1",
+                       experiment=["Charge at 1C until 4.2 V", "Discharge at 1C until 2.5 V"])
+    ts2 = ws.test_spec(name="Cycling", type="cycling", version="1",
+                       experiment=["Charge at C/2 until 4.2 V", "Discharge at C/2 until 2.5 V"])
+    ws.test(cell, type="cycling", protocol_ref=ts1, status="completed")
+    ws.test(cell, type="cycling", protocol_ref=ts2, status="completed")
+    ws._finalize()
+    spec_ids = {p.id for p in ws.test_specs}
+    assert len(spec_ids) == 2, "two distinct test-specs collided onto one IRI (C-1)"
+    assert all(i and "/spec/" in i for i in spec_ids)
+    assert {t.protocol_id for t in ws.tests} == spec_ids, "tests did not each link to their own test-spec"
+
+
+def test_colliding_spec_iri_is_stable_across_runs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A colliding spec's content-seeded IRI must be stable across runs with different
+    # finalize timestamps — i.e. every finalize-time-varying field is stripped from the
+    # content seed. If retrieved_at (or any new auto-timestamp) leaked in, the IRI would
+    # drift and break the idempotent upsert on the collision path.
+    def author(clock: int) -> dict[float, str]:
+        monkeypatch.setattr("battinfo._workspace._now_unix", lambda: clock)
+        ws = _ws(tmp_path / f"ws-{clock}")
+        _spec(ws, 2.5)
+        _spec(ws, 3.5)
+        ws._finalize()
+        return {2.5: ws.cell_specs[0].id, 3.5: ws.cell_specs[1].id}
+
+    assert author(1000) == author(9_999_999)
+
+
+def test_full_content_duplicate_specs_both_persist(tmp_path: Path) -> None:
+    # Two genuinely identical specs collide AND hash identically; the ordinal "::dupN"
+    # fallback must keep both rather than overwrite one.
+    ws = _ws(tmp_path / "ws")
+    _spec(ws, 2.5)
+    _spec(ws, 2.5)
+    ws._finalize()
+    ids = [s.id for s in ws.cell_specs]
+    assert ids[0] != ids[1], "an identical-content duplicate overwrote its sibling"
+
+
+def test_three_way_collision_gives_distinct_ids(tmp_path: Path) -> None:
+    ws = _ws(tmp_path / "ws")
+    for cap in (2.5, 3.0, 3.5):
+        _spec(ws, cap)
+    ws._finalize()
+    assert len({s.id for s in ws.cell_specs}) == 3

--- a/tests/test_nonfinite_guards.py
+++ b/tests/test_nonfinite_guards.py
@@ -55,3 +55,35 @@ def test_validation_rejects_non_finite_spec_value() -> None:
     result = validate_record(doc, policy="strict")
     assert result.ok is False
     assert any(i.code == "semantic.value_not_finite" for i in result.issues)
+
+
+def test_num_rejects_non_finite() -> None:
+    # The shared protocol/discovery/converter numeric coercion must reject non-finite
+    # rather than coercing NaN/Inf into a quantity that later fails json.dumps.
+    from battinfo.interop.protocols import _num
+
+    assert _num("NaN") is None
+    assert _num("Infinity") is None
+    assert _num("-inf") is None
+    assert _num(float("nan")) is None
+    assert _num("3.5") == 3.5
+
+
+def test_validation_rejects_nested_non_finite_quantity() -> None:
+    # The flat specs check missed deeply-nested quantities (e.g. an electrode
+    # coating's property.loading.value); the recursive walk catches them.
+    from battinfo.validate.semantic import validate_semantic_report
+
+    doc = {"electrode_spec": {"coating": {"property": {"loading": {"value": float("nan"), "unit": "mg/cm2"}}}}}
+    result = validate_semantic_report(doc, policy="strict")
+    assert any(i.code == "semantic.value_not_finite" for i in result.issues)
+
+
+def test_walk_non_finite_no_false_positive_on_clean_record() -> None:
+    # The whole-record non-finite walk must not flag any value in a clean shipped record.
+    from battinfo.validate.semantic import validate_semantic_report
+
+    doc = json.loads((ROOT / "src/battinfo/data/examples/cell-spec/cell-spec-0hpw-gkhk-gcg8-23x1.json")
+                     .read_text(encoding="utf-8"))
+    result = validate_semantic_report(doc, policy="strict")
+    assert not any(i.code == "semantic.value_not_finite" for i in result.issues)


### PR DESCRIPTION
Canonical-record correctness: the archive is source of truth, so a wrong or lost record is permanent.

Deterministic IRIs are seeded from a record's identity fields, so two distinct entities sharing identity (e.g. two cell-specs for one manufacturer+model with different capacities) minted the same IRI and one silently overwrote the other on save. _disambiguate_entity_ids now re-mints every member of a collision group from a content-derived seed (order-independent; distinct content -> distinct IRI; genuine full-content duplicates fall back to ::dupN), and is applied to cell-specs and test-specs in _finalize before cells/tests link, so the re-minted spec id cascades correctly. Non-colliding entities keep their idempotent identity IRI.

_num() rejects non-finite (math.isfinite), closing the discovery/converter/protocols importers that coerced "NaN" into a quantity. The flat specs-only non-finite check is replaced by a recursive walk over the whole record, so nested quantities (electrode coating property.loading) are caught too.

Tests: new tests/test_iri_disambiguation.py (collision / order-independence / idempotency / cross-run stability / ::dupN / 3-way, for cell- and test-specs) + non-finite pins. Full suite 1025 passing, ruff + mypy clean.

Known deferred gap (pre-existing, not touched here): the package_batch / build_zenodo_package second IRI-minting path still collides cell+test IRIs when two folders share a serial.