### PR TITLE
Harden/package batch iri disambiguation

### DIFF
--- a/src/battinfo/contribution.py
+++ b/src/battinfo/contribution.py
@@ -1106,6 +1106,12 @@ def package_batch(
 
     entries: list[ZenodoDatasetEntry] = []
     file_sets: list[tuple[Path | None, Path | None]] = []
+    # Fail closed on duplicate cell IRIs across folders (e.g. two cells sharing a
+    # serial / cell_name): publishing both would silently overwrite one on ingest.
+    # A unique cell IRI is necessary but NOT sufficient — distinct data files within one
+    # cell can still mint colliding test IRIs, so the test seed below carries a per-file
+    # discriminator and build_zenodo_package asserts test/dataset @id uniqueness.
+    seen_cell_iris: dict[str, str] = {}
 
     for cell_dir in cell_dirs:
         cell_manifest = yaml.safe_load(
@@ -1124,6 +1130,15 @@ def package_batch(
             ),
         )
         ci = _finalize_cell_instance(raw_ci, cell_spec=cell_spec, dataset_dir=cell_dir)
+        if ci.id is not None:
+            prior = seen_cell_iris.get(ci.id)
+            if prior is not None:
+                raise ValueError(
+                    f"Cell folders {prior!r} and {cell_dir.name!r} resolve to the same cell IRI "
+                    f"({ci.id}) — two cells must not share a serial / cell_name within a batch, or "
+                    "one would silently overwrite the other on ingest. Give each cell a unique serial."
+                )
+            seen_cell_iris[ci.id] = cell_dir.name
 
         pairs = _collect_data_files(cell_dir)
         if not pairs:
@@ -1132,12 +1147,11 @@ def package_batch(
         for raw_path, bdf_path in pairs:
             subdir_name = raw_path.parent.name
             test_kind = _test_kind_from_path(raw_path, subdir_name)
-            date_text = DATE_RE.search(raw_path.name)
-            date_str = date_text.group("date") if date_text else None
-
-            test_name = f"{ci.name or cell_dir.name} {test_kind}"
-            if date_str:
-                test_name = f"{test_name} {date_str}"
+            # raw_path.stem is unique per file in the folder, so two same-kind data files
+            # in one cell mint distinct test IRIs. The filename date alone is insufficient:
+            # undated same-kind files previously collided onto one test @id and overwrote
+            # each other on ingest.
+            test_name = f"{ci.name or cell_dir.name} {test_kind} {raw_path.stem}"
 
             raw_test = Test(
                 cell_instance_id=ci.id,

--- a/src/battinfo/contribution.py
+++ b/src/battinfo/contribution.py
@@ -741,6 +741,7 @@ def init_batch(
 
     # ── per-cell folders ───────────────────────────────────────────────────────
     cells: list[dict[str, Any]] = []
+    seen_folders: dict[str, str] = {}
     for i in range(count):
         sn = serial_numbers[i].strip() if serial_numbers else None
         cell_iri = (
@@ -749,6 +750,17 @@ def init_batch(
             else _generate_cell_iri(cell_spec_iri, batch_id, i, sn)
         )
         folder_name = _cell_folder_name(cell_iri, manufacturer, model, sn)
+        # Fail closed on a within-batch folder collision: two cells that slug to the same
+        # folder (e.g. duplicate serials) would otherwise reuse the dir (mkdir exist_ok)
+        # and the second cell's manifest would silently overwrite the first's on disk.
+        prior = seen_folders.get(folder_name)
+        if prior is not None:
+            raise ValueError(
+                f"Cells {prior!r} and {sn or folder_name!r} both map to folder "
+                f"{folder_name!r} — a duplicate serial / cell name would overwrite one "
+                "cell's manifest on disk. Give each cell a unique serial."
+            )
+        seen_folders[folder_name] = sn or folder_name
         cell_name = sn or folder_name
 
         cell_dir = output_dir / folder_name

--- a/src/battinfo/publication.py
+++ b/src/battinfo/publication.py
@@ -2374,6 +2374,24 @@ def build_zenodo_package(
             f"length ({len(record.datasets)})."
         )
 
+    # Fail closed if two distinct records minted the same test/dataset IRI: writing both
+    # to one @id silently overwrites one on harvest/ingest (the archive is source of
+    # truth). Cells legitimately repeat across entries (one cell, many tests), so only
+    # test and dataset @ids — which must be globally distinct — are checked here.
+    minted_iris: dict[str, str] = {}
+    for entry in record.datasets:
+        for kind, obj in (("test", entry.test), ("dataset", entry.dataset)):
+            iri = getattr(obj, "id", None)
+            if iri is None:
+                continue
+            if iri in minted_iris:
+                raise ValueError(
+                    f"Duplicate {kind} IRI {iri}: two records would overwrite each other on "
+                    "ingest. Ensure cells have unique serials and data files within a cell "
+                    "have distinct names."
+                )
+            minted_iris[iri] = kind
+
     staging = _as_path(staging_dir)
     staging.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_batch_package.py
+++ b/tests/test_batch_package.py
@@ -48,6 +48,13 @@ def _make_batch(tmp_path: Path, n_cells: int = 2, n_files_per_cell: int = 2) -> 
     return batch_dir
 
 
+def test_init_batch_rejects_duplicate_serials(tmp_path: Path) -> None:
+    # Two cells with the same serial slug to the same folder; init_batch must fail closed
+    # instead of silently overwriting the first cell's manifest on disk (mkdir exist_ok).
+    with pytest.raises(ValueError, match="unique serial"):
+        init_batch(tmp_path / "batch", "Energizer CR2032", 2, serial_numbers=["SN1", "SN1"])
+
+
 # ── _collect_data_files ────────────────────────────────────────────────────────
 
 class TestCollectDataFiles:

--- a/tests/test_batch_package.py
+++ b/tests/test_batch_package.py
@@ -151,6 +151,44 @@ class TestPackageBatch:
         assert result["cell_count"] == 2
         assert result["entry_count"] == 6
 
+    def test_rejects_duplicate_cell_iri_across_folders(self, tmp_path: Path) -> None:
+        # Two cells sharing a serial / cell_name resolve to the same IRI; publishing
+        # both would silently overwrite one on ingest, so package_batch must fail closed
+        # (the second IRI-minting path the Phase 3 review flagged as a known gap).
+        import yaml
+
+        from battinfo.contribution import CONTRIBUTION_MANIFEST
+
+        batch = _make_batch(tmp_path, n_cells=2)
+        cell_dirs = sorted(
+            d for d in batch.iterdir() if d.is_dir() and (d / CONTRIBUTION_MANIFEST).exists()
+        )
+        assert len(cell_dirs) == 2
+        m0 = yaml.safe_load((cell_dirs[0] / CONTRIBUTION_MANIFEST).read_text(encoding="utf-8"))
+        m1_path = cell_dirs[1] / CONTRIBUTION_MANIFEST
+        m1 = yaml.safe_load(m1_path.read_text(encoding="utf-8"))
+        m1["cell_iri"] = m0["cell_iri"]  # force the duplicate-serial collision
+        m1_path.write_text(yaml.safe_dump(m1), encoding="utf-8")
+        with pytest.raises(ValueError, match="same cell IRI"):
+            package_batch(batch, creators=CREATORS)
+
+    def test_same_kind_undated_files_get_distinct_test_iris(self, tmp_path: Path) -> None:
+        # Multiple same-kind, undated data files in ONE cell must mint distinct test IRIs
+        # (the test seed now carries a per-file discriminator). Previously they collapsed
+        # onto a single test @id and overwrote each other on ingest, despite a unique cell IRI.
+        import re
+
+        batch_dir = tmp_path / "batch"
+        result = init_batch(batch_dir, "Energizer CR2032", 1, batch_id="LOT", lab="L", operator="O")
+        cell = batch_dir / result["cells"][0]["folder"]
+        for n in (1, 2, 3):
+            (cell / f"cycling_00{n}.csv").write_text("time,voltage\n0,3.0\n1,2.9\n", encoding="utf-8")
+        pkg = package_batch(batch_dir, creators=CREATORS)
+        assert pkg["entry_count"] == 3
+        bundle_text = (Path(pkg["staging_dir"]) / ZENODO_CELL_RECORD_FILENAME).read_text(encoding="utf-8")
+        test_ids = set(re.findall(r"https://w3id\.org/battinfo/test/[a-z0-9-]+", bundle_text))
+        assert len(test_ids) == 3, "undated same-kind tests in one cell collided onto one IRI"
+
     def test_bundle_json_parseable(self, tmp_path: Path) -> None:
         batch = _make_batch(tmp_path)
         result = package_batch(batch, creators=CREATORS)


### PR DESCRIPTION
The batch / Zenodo publish path no longer silently conflates distinct records onto one IRI (which overwrote on harvest/ingest). Duplicate cell serials now fail closed at both init_batch (was overwriting a manifest on disk) and package_batch; the test IRI seed gains a per-file discriminator so multiple same-kind files in one cell stay distinct; and build_zenodo_package asserts test/dataset @id uniqueness as a backstop.