### PR TITLE
harden: importer fidelity

### DIFF
--- a/src/battinfo/interop/battery_data_commons.py
+++ b/src/battinfo/interop/battery_data_commons.py
@@ -108,6 +108,7 @@ class BdcRecordImport:
     cell_spec: dict[str, Any]
     cell_instance: dict[str, Any]
     tests: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -180,6 +181,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     material-specs across records; pass nothing for a standalone call.
     """
     materials = _materials if _materials is not None else {}
+    warnings: list[str] = []
     # Drop null/blank category entries rather than coercing them to the literal
     # keyword 'None' (which would survive validation and land in dataset.keywords).
     categories = [str(c).strip() for c in (record.get("categories") or []) if c is not None and str(c).strip()]
@@ -229,6 +231,11 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     cap = reported.get("rated_capacity_Ah")
     if isinstance(cap, (int, float)) and not isinstance(cap, bool) and cap > 0:
         specs["nominal_capacity"] = {"value": cap, "unit": "Ah"}
+    elif cap is not None:
+        warnings.append(
+            f"BDC record {bdc_id}: dropped rated_capacity_Ah={cap!r} (not a usable positive "
+            "number); nominal_capacity omitted."
+        )
 
     notes = [f"Imported from Battery Data Commons record {bdc_id}."]
     if source_meta.get("data_modality"):
@@ -300,7 +307,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
         citation=citation,
     )))
 
-    return BdcRecordImport(bdc_id, dataset, cell_spec, cell_instance, tests)
+    return BdcRecordImport(bdc_id, dataset, cell_spec, cell_instance, tests, warnings=warnings)
 
 
 def batch_import_bdc(source: PathLike, *, limit: int | None = None,
@@ -330,7 +337,11 @@ def batch_import_bdc(source: PathLike, *, limit: int | None = None,
         if imp is not None:
             imports.append(imp)
 
-    return BdcImportPackage(material_specs=list(materials.values()), imports=imports, warnings=[])
+    return BdcImportPackage(
+        material_specs=list(materials.values()),
+        imports=imports,
+        warnings=[w for imp in imports for w in imp.warnings],
+    )
 
 
 # ── BattINFO → BDC ──────────────────────────────────────────────────────────

--- a/src/battinfo/interop/discovery.py
+++ b/src/battinfo/interop/discovery.py
@@ -154,6 +154,27 @@ def _qty(value: float, unit: str | None) -> dict[str, Any]:
     return q
 
 
+def _dedupe_solvents(solvents: list[tuple[str, float | None]]) -> list[tuple[str, float | None]]:
+    """Merge repeated solvent names into one component, summing known volume fractions.
+
+    A malformed token like ``EC:EC=1:1`` (or a stray colon code) would otherwise emit two
+    components for the same solvent; collapse them so the importer never invents a phantom
+    duplicate.
+    """
+    merged: dict[str, float | None] = {}
+    for name, frac in solvents:
+        if name not in merged:
+            merged[name] = frac
+            continue
+        prev = merged[name]
+        if prev is None:
+            merged[name] = frac
+        elif frac is not None:
+            merged[name] = round(prev + frac, 4)
+        # else both None — keep the single None entry
+    return list(merged.items())
+
+
 def _parse_electrolyte(name: str) -> dict[str, Any]:
     """Parse '1M LiPF6 EC:EMC=3:7wt%' → salt, concentration, solvent fractions."""
     out: dict[str, Any] = {"family": "organic", "name": name}
@@ -168,10 +189,12 @@ def _parse_electrolyte(name: str) -> dict[str, Any]:
         names = solv.group(1).split(":")
         ratios = [float(x) for x in solv.group(2).split(":")] if solv.group(2) and ":" in solv.group(2) else []
         total = sum(ratios) if ratios else 0.0
+        solvents: list[tuple[str, float | None]]
         if ratios and len(ratios) == len(names) and total > 0:
-            out["solvents"] = [(n, round(r / total, 4)) for n, r in zip(names, ratios)]
+            solvents = [(n, round(r / total, 4)) for n, r in zip(names, ratios)]
         else:
-            out["solvents"] = [(n, None) for n in names]
+            solvents = [(n, None) for n in names]
+        out["solvents"] = _dedupe_solvents(solvents)
     return out
 
 

--- a/tests/test_bdc_interop.py
+++ b/tests/test_bdc_interop.py
@@ -37,6 +37,29 @@ def _record(name: str) -> dict:
 # ── BDC → BattINFO ───────────────────────────────────────────────────────────
 
 
+def test_bdc_warns_on_non_numeric_capacity() -> None:
+    rec = import_bdc_record({
+        "id": "bdc_x", "categories": ["dataset"],
+        "overview": {"battery_model": "X", "manufacturer": "M", "case": "cylindrical"},
+        "electrodes": {"positive": "NMC", "negative": "graphite"},
+        "reported_values": {"rated_capacity_Ah": "45"},  # present but not a usable number
+    }, validate=False)
+    assert rec is not None
+    assert any("rated_capacity_Ah" in w for w in rec.warnings), "a dropped capacity was not surfaced"
+
+
+def test_batch_import_bdc_aggregates_warnings(tmp_path: Path) -> None:
+    rec = {
+        "id": "bdc_bad", "record_status": "active", "categories": ["dataset"],
+        "overview": {"battery_model": "X", "manufacturer": "M", "case": "cylindrical"},
+        "electrodes": {"positive": "NMC", "negative": "graphite"},
+        "reported_values": {"rated_capacity_Ah": "not-a-number"},
+    }
+    (tmp_path / "bdc_bad.json").write_text(json.dumps(rec), encoding="utf-8")
+    pkg = batch_import_bdc(tmp_path, validate=False)
+    assert any("rated_capacity_Ah" in w for w in pkg.warnings), "BdcImportPackage.warnings stayed empty"
+
+
 def test_batch_import_skips_software_and_builds_chains() -> None:
     pkg = batch_import_bdc(FX, validate=True)
     ids = {imp.bdc_id for imp in pkg.imports}

--- a/tests/test_discovery_interop.py
+++ b/tests/test_discovery_interop.py
@@ -51,6 +51,27 @@ def _strip_import_stamps(records: list[dict]) -> list[dict]:
 # ── RO-Crate (.eln) ──────────────────────────────────────────────────────────
 
 
+def test_electrolyte_parser_dedupes_solvents() -> None:
+    from battinfo.interop.discovery import _parse_electrolyte
+
+    merged = _parse_electrolyte("1M LiPF6 EC:EC=1:1")["solvents"]
+    assert [n for n, _ in merged] == ["EC"], "a malformed EC:EC token minted a duplicate solvent"
+    normal = _parse_electrolyte("1M LiPF6 EC:EMC=3:7")["solvents"]
+    assert [n for n, _ in normal] == ["EC", "EMC"], "distinct solvents must be unaffected"
+
+
+def test_find_property_drops_non_finite_value() -> None:
+    from battinfo.interop.discovery import _find_property
+
+    nan_node = {"hasProperty": [{"@type": "MassLoading",
+                                 "hasNumericalPart": {"hasNumericalValue": "NaN"}}]}
+    assert _find_property(nan_node, "MassLoading") is None, "a NaN value must be dropped, never coerced"
+    ok_node = {"hasProperty": [{"@type": "MassLoading",
+                                "hasNumericalPart": {"hasNumericalValue": "2.5"}}]}
+    prop = _find_property(ok_node, "MassLoading")
+    assert prop is not None and prop["value"] == 2.5
+
+
 def test_eln_builds_linked_spec_graph() -> None:
     pkg = import_discovery_eln(ELN, validate=True)
     assert pkg.source == "eln"


### PR DESCRIPTION
Importers fail loud instead of silent. BDC import_bdc_record surfaces a present-but-unusable rated_capacity_Ah as a warning (now aggregated in BdcImportPackage.warnings, previously hardcoded []), and the Discovery electrolyte parser merges repeated solvents (e.g. a malformed EC:EC=1:1) instead of minting phantom duplicate components. +4 pins.