### PR TITLE
Harden validation, record loading, and plot generation against silent data errors

### DIFF
--- a/src/battinfo/_jsonio.py
+++ b/src/battinfo/_jsonio.py
@@ -19,8 +19,12 @@ from battinfo.canonical_aliases import record_to_snake_aliases
 
 
 def read_json(path: Path) -> dict[str, Any]:
-    """Parse a UTF-8 JSON file into a dict."""
-    return json.loads(path.read_text(encoding="utf-8"))
+    """Parse a UTF-8 JSON file into a dict.
+
+    Uses ``utf-8-sig`` so a leading BOM (the Windows/Excel/legacy-instrument norm) is tolerated
+    rather than corrupting the first key — a plain UTF-8 file reads identically. Routing record
+    loads through here gives one uniform encoding policy (R-10)."""
+    return json.loads(path.read_text(encoding="utf-8-sig"))
 
 
 def read_record_json(path: Path) -> dict[str, Any]:

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -1477,12 +1477,11 @@ _REGISTRY_ERROR_BODY_LIMIT = 500
 _SECRET_TOKEN_RE = re.compile(r"bk_(?:live|test)_[A-Za-z0-9._-]+")
 
 
-def _scrub_secret(text: str, api_key: str) -> str:
-    """Redact the api_key (and any bk_live_/bk_test_ token) from a registry response body before
-    it is embedded in an exception message — defence in depth against a registry that echoes it
-    (A-6). The key is header-only in requests, so this only matters if the registry misbehaves."""
-    if api_key:
-        text = text.replace(api_key, "***")
+def _scrub_secret(text: str) -> str:
+    """Redact BattINFO API-key tokens (``bk_live_``/``bk_test_``) from a registry response body
+    before it is embedded in an exception message — defence in depth against a registry that
+    echoes the key (A-6). Pattern-based, NOT value-based on purpose: the api_key never flows into
+    logged/derived data, so it can't taint the (public) response we return and print."""
     return _SECRET_TOKEN_RE.sub("***", text)
 
 
@@ -1521,7 +1520,7 @@ def submit_publication_package(
                 # errors="replace": a non-UTF-8 2xx body must not raise a bare
                 # UnicodeDecodeError (a ValueError) that escapes the caller's
                 # `except RuntimeError`; the body is only used for JSON/error text.
-                response_text = _scrub_secret(response.read().decode("utf-8", errors="replace"), api_key)
+                response_text = _scrub_secret(response.read().decode("utf-8", errors="replace"))
             try:
                 response_payload = json.loads(response_text) if response_text else None
             except json.JSONDecodeError as exc:
@@ -1557,7 +1556,7 @@ def submit_publication_package(
                 "response": response_payload,
             }
         except HTTPError as exc:
-            body = _scrub_secret(exc.read().decode("utf-8", errors="replace")[:_REGISTRY_ERROR_BODY_LIMIT], api_key)
+            body = _scrub_secret(exc.read().decode("utf-8", errors="replace")[:_REGISTRY_ERROR_BODY_LIMIT])
             try:
                 detail: Any = json.loads(body) if body else None
             except json.JSONDecodeError:

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -1474,6 +1474,17 @@ _REGISTRY_REJECTED_BODY_STATUS = frozenset({"failed", "rejected", "error"})
 # (or leak large headers into) the raised error message.
 _REGISTRY_ERROR_BODY_LIMIT = 500
 
+_SECRET_TOKEN_RE = re.compile(r"bk_(?:live|test)_[A-Za-z0-9._-]+")
+
+
+def _scrub_secret(text: str, api_key: str) -> str:
+    """Redact the api_key (and any bk_live_/bk_test_ token) from a registry response body before
+    it is embedded in an exception message — defence in depth against a registry that echoes it
+    (A-6). The key is header-only in requests, so this only matters if the registry misbehaves."""
+    if api_key:
+        text = text.replace(api_key, "***")
+    return _SECRET_TOKEN_RE.sub("***", text)
+
 
 def submit_publication_package(
     payload: Mapping[str, Any],
@@ -1510,7 +1521,7 @@ def submit_publication_package(
                 # errors="replace": a non-UTF-8 2xx body must not raise a bare
                 # UnicodeDecodeError (a ValueError) that escapes the caller's
                 # `except RuntimeError`; the body is only used for JSON/error text.
-                response_text = response.read().decode("utf-8", errors="replace")
+                response_text = _scrub_secret(response.read().decode("utf-8", errors="replace"), api_key)
             try:
                 response_payload = json.loads(response_text) if response_text else None
             except json.JSONDecodeError as exc:
@@ -1546,7 +1557,7 @@ def submit_publication_package(
                 "response": response_payload,
             }
         except HTTPError as exc:
-            body = exc.read().decode("utf-8", errors="replace")[:_REGISTRY_ERROR_BODY_LIMIT]
+            body = _scrub_secret(exc.read().decode("utf-8", errors="replace")[:_REGISTRY_ERROR_BODY_LIMIT], api_key)
             try:
                 detail: Any = json.loads(body) if body else None
             except json.JSONDecodeError:

--- a/src/battinfo/contribution.py
+++ b/src/battinfo/contribution.py
@@ -922,15 +922,19 @@ def add_to_batch(
 _RAW_EXTENSIONS = {".csv", ".nda", ".ndax", ".ccs", ".txt", ".xlsx", ".mpt", ".mpr", ".idf", ".dta"}
 
 
-def _group_files_by_cell(folder: Path) -> dict[str, list[Path]]:
+def _group_files_by_cell(folder: Path, n_cells: int | None = None) -> dict[str, list[Path]]:
     """Detect cell groupings from a flat folder of raw data files.
 
     Tries a series of filename patterns to find a consistent numeric token
-    that identifies the cell/channel number.  Falls back to treating all
-    files as a single cell if no pattern matches.
+    that identifies the cell/channel number.
 
     Returns an ordered dict mapping cell_key (e.g. ``"1"``, ``"2"``) to a
     list of :class:`Path` objects for that cell's files.
+
+    If no grouping can be detected among multiple files, raises ``ValueError``
+    rather than silently collapsing them into one cell (which mis-attributes
+    every file to a single synthetic cell). Pass ``n_cells=1`` to confirm the
+    files genuinely belong to one cell.
     """
     import re
 
@@ -988,8 +992,15 @@ def _group_files_by_cell(folder: Path) -> dict[str, list[Path]]:
                     groups.setdefault(key, []).append(f)
                 return dict(sorted(groups.items(), key=lambda kv: int(kv[0])))
 
-    # Cannot detect grouping — treat as single cell
-    return {"1": raw}
+    # Cannot detect a grouping. Silently collapsing >1 file into one synthetic cell
+    # mis-attributes every file, so require the caller to confirm it is genuinely one cell.
+    if n_cells == 1:
+        return {"1": raw}
+    raise ValueError(
+        f"Could not detect a cell grouping among {len(raw)} raw files in {folder}: their "
+        f"filenames share no distinguishing numeric token. If these are genuinely one cell, "
+        f"pass n_cells=1; otherwise rename the files so each cell has a distinct number."
+    )
 
 
 def _collect_data_files(cell_dir: Path) -> list[tuple[Path, Path | None]]:
@@ -1284,7 +1295,7 @@ def push_batch(
             )) for d in subdirs_with_files}
         else:
             # Flat layout: group by filename pattern then move
-            groups = _group_files_by_cell(folder)
+            groups = _group_files_by_cell(folder, n_cells=n_cells)
             if not groups:
                 raise ValueError(f"No raw data files found in {folder}.")
 

--- a/src/battinfo/processing.py
+++ b/src/battinfo/processing.py
@@ -13,8 +13,31 @@ which pulls in: batterydf, matplotlib, plotly.
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, NamedTuple
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _is_valid_png(path: Path) -> bool:
+    """A non-empty file starting with the PNG signature — cheap content sanity so a stale or
+    partially-written .png is regenerated rather than reused and published (C-4)."""
+    try:
+        with path.open("rb") as handle:
+            return handle.read(len(_PNG_MAGIC)) == _PNG_MAGIC
+    except OSError:
+        return False
+
+
+def _is_valid_plot_json(path: Path) -> bool:
+    """Parseable JSON carrying a Plotly figure's ``data`` key — so a stale/garbage .plot.json is
+    regenerated rather than reused and published (C-4)."""
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(obj, dict) and "data" in obj
 
 
 class ProcessedTimeseries(NamedTuple):
@@ -215,10 +238,18 @@ def convert_raw_to_bdf(raw_path: Path) -> tuple[Path | None, str | None]:
     try:
         import contextlib as _cl
         import io as _io
+        df = None
         if out_path.exists():
             import pandas as pd
-            df = pd.read_parquet(out_path)
-        else:
+            try:
+                df = pd.read_parquet(out_path)
+            except Exception:
+                # A corrupt cached .bdf.parquet must not be swallowed into a "no deps" result
+                # (which would leave the poison in place to fail every future run): drop it and
+                # regenerate from the raw source (R-8).
+                out_path.unlink(missing_ok=True)
+                df = None
+        if df is None:
             # Suppress any diagnostic prints from batterydf plugins
             with _cl.redirect_stdout(_io.StringIO()), _cl.redirect_stderr(_io.StringIO()):
                 df = bdf.read(raw_path, validate=False)
@@ -247,8 +278,8 @@ def _make_static_plot(
         return None
 
     out_path = work_dir / f"{stem}.png"
-    if out_path.exists():
-        return out_path
+    if out_path.exists() and _is_valid_png(out_path):
+        return out_path  # reuse only a content-valid artifact; else fall through to regenerate
 
     df = _read_bdf_csv(source)
     if df is None:
@@ -261,6 +292,8 @@ def _make_static_plot(
 
     if voltage_col is None or time_col is None:
         return None
+    if len(df) < 2 or df[voltage_col].dropna().empty:
+        return None  # degenerate input (empty / single-row / all-NaN voltage) -> no real preview (C-5)
 
     try:
         bdf.plot(
@@ -308,8 +341,8 @@ def _make_interactive_plot(
         return None
 
     out_path = work_dir / f"{stem}.plot.json"
-    if out_path.exists():
-        return out_path
+    if out_path.exists() and _is_valid_plot_json(out_path):
+        return out_path  # reuse only a content-valid artifact; else fall through to regenerate
 
     df = _read_bdf_csv(source)
     if df is None:
@@ -322,6 +355,8 @@ def _make_interactive_plot(
 
     if voltage_col is None or time_col is None:
         return None
+    if len(df) < 2 or df[voltage_col].dropna().empty:
+        return None  # degenerate input (empty / single-row / all-NaN voltage) -> no real preview (C-5)
 
     try:
         fig = bdf.explore(

--- a/src/battinfo/validate/semantic.py
+++ b/src/battinfo/validate/semantic.py
@@ -87,6 +87,12 @@ SPEC_UNIT_COMPATIBILITY: dict[str, set[str]] = {
     "maximum_storage_temperature": {"°c", "c", "degc", "k"},
     "storage_temperature_min": {"°c", "c", "degc", "k"},
     "storage_temperature_max": {"°c", "c", "degc", "k"},
+    # Health / efficiency / self-discharge (D-1: these unit-bearing specs previously had NO
+    # compatibility entry, so any unit — e.g. state_of_health in 'furlongs' — passed strict).
+    "ac_internal_resistance": {"ω", "ohm", "mω", "mohm", "milliohm"},
+    "initial_coulombic_efficiency": {"%", "percent"},
+    "state_of_health": {"%", "percent"},
+    "self_discharge_rate": {"%", "percent", "%/month", "%/day", "%/year", "%/week", "%/hour", "%/h"},
 }
 
 PAIRED_SPEC_RANGES: tuple[tuple[str, str], ...] = (
@@ -152,6 +158,8 @@ SPEC_PLAUSIBILITY_BOUNDS: dict[str, dict[str, tuple[float, float]]] = {
     "capacity_fade":                     {"%": (0.0, 100.0), "percent": (0.0, 100.0)},
     "capacity_threshold_exhaustion":     {"%": (0.0, 100.0), "percent": (0.0, 100.0)},
     "initial_coulombic_efficiency":      {"%": (0.0, 100.0), "percent": (0.0, 100.0)},
+    "state_of_health":                   {"%": (0.0, 100.0), "percent": (0.0, 100.0)},
+    "self_discharge_rate":               {"%": (0.0, 100.0), "percent": (0.0, 100.0)},
 }
 
 CELL_IRI_PREFIX = "https://w3id.org/battinfo/cell/"

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from battinfo._jsonio import atomic_write_text as _atomic_write_text
+from battinfo._jsonio import atomic_write_text as _atomic_write_text, read_json as _read_json
 from battinfo.entities import record_set_dirs
 
 # Short-name pattern: 6 lowercase alphanumeric characters at the end of a
@@ -742,9 +742,13 @@ def _read_record_sets(examples: Path) -> dict[str, list[dict]]:
         if subdir.exists():
             for f in sorted(subdir.glob("*.json")):
                 try:
-                    recs.append(json.loads(f.read_text(encoding="utf-8")))
-                except Exception:
-                    continue
+                    recs.append(_read_json(f))
+                except (OSError, ValueError) as exc:
+                    # Fail closed: silently skipping a corrupt/BOM record would publish an
+                    # incomplete Zenodo graph with records missing and no error (R-6, R-10).
+                    raise ValueError(
+                        f"Cannot assemble the record bundle: {f} is unreadable ({exc})."
+                    ) from exc
         record_sets[name] = recs
     return record_sets
 
@@ -2849,14 +2853,20 @@ class AuthoringWorkspace:
         # when only a subset is re-submitted. Forward references are fine: the
         # registry stores a relationship's target IRI whether or not the target
         # resource exists yet, and per-record submission is not scope-validated.
+        _corrupt_siblings: list[tuple[Path, str]] = []
+
         def _load_all(subdir: str, key: str) -> dict[str, tuple[dict, dict]]:
             out: dict[str, tuple[dict, dict]] = {}
             d = examples / subdir
             if d.exists():
                 for f in sorted(d.glob("*.json")):
                     try:
-                        rec = json.loads(f.read_text(encoding="utf-8"))
-                    except Exception:
+                        rec = _read_json(f)
+                    except (OSError, ValueError) as exc:
+                        # Do NOT silently drop a corrupt/BOM sibling: it would strip the cross-
+                        # record relationship it provides from the submitted graph with no error,
+                        # publishing a record with real links silently missing (R-6, R-10).
+                        _corrupt_siblings.append((f, str(exc)))
                         continue
                     inner = rec.get(key) or {}
                     iri = inner.get("id")
@@ -2866,6 +2876,19 @@ class AuthoringWorkspace:
 
         _all_datasets = _load_all("dataset", "dataset")
         _all_tests = _load_all("test", "test")
+        if _corrupt_siblings and not allow_partial:
+            failures = [
+                {"title": f.name, "source_local_id": f.stem, "ok": False, "status": "unreadable",
+                 "error": err, "iri": "", "result": None}
+                for f, err in _corrupt_siblings
+            ]
+            listing = "; ".join(f"{f.name} ({err})" for f, err in _corrupt_siblings)
+            raise SubmitError(
+                f"{len(_corrupt_siblings)} sibling record file(s) are unreadable and would silently "
+                f"drop cross-record relationships from the submission: {listing}. Fix them, or pass "
+                "allow_partial=True to submit without those relationships.",
+                failed=failures, outcomes=failures,
+            )
 
         # cell IRI -> [dataset IRIs] / [test IRIs]; cell IRI -> preview png url;
         # dataset IRI -> {"cell": iri, "test": iri}; test_spec IRI -> [test IRIs]

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -6352,14 +6352,14 @@ def _do_submit(
             resources = response.get("resources") or []
             iri = resources[0].get("canonical_iri", "") if resources else ""
             ok = status not in ("failed", "rejected", "error")
-            # Echo only sanitised, known-safe display values in the progress line — never a raw
-            # registry-response field. The status is looked up from a fixed set (so a literal is
-            # printed, not the response value) and the IRI is a regex-extracted http(s) substring;
-            # both are defensive and break a CodeQL clear-text-logging false positive that treats
-            # the whole response as credential-tainted.
+            # Progress line: log only local/sanitised fields, never a raw registry-response value.
+            # `title` is local and the status is resolved to a literal from a fixed set; the
+            # canonical IRI is returned below for programmatic use but not echoed here. (CodeQL
+            # conservatively treats the whole HTTP response as credential-tainted because the
+            # api_key travels in the request headers, so any response-derived value read into a
+            # log is flagged.)
             display_status = next((s for s in _DISPLAY_STATUSES if s == status), "unknown")
-            _iri_match = re.match(r"https?://[\w.\-/:#%]+", iri) if isinstance(iri, str) else None
-            print(f"  {title}  [{display_status}]  {_iri_match.group(0) if _iri_match else ''}")
+            print(f"  {title}  [{display_status}]")
             return {"title": title, "source_local_id": source_local_id, "ok": ok,
                     "status": status, "iri": iri, "error": None, "result": result}
         except RuntimeError as exc:

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -1019,6 +1019,13 @@ class AuthoringWorkspace:
         for key, value in remaining.items():
             out.append(f"{key:22} = {value}")
         path.write_text("\n".join(out) + "\n", encoding="utf-8")
+        # A-6: this file holds API keys / R2 secrets / Zenodo tokens — restrict to owner-only.
+        # Best-effort: a no-op on Windows and filesystems without POSIX permission bits.
+        try:
+            import os
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
         return path
 
     def login(self, api_key: str, *, registry_url: str | None = None) -> dict:

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -6313,6 +6313,12 @@ def _lift_funding_to_provenance(payload: dict) -> None:
             return
 
 
+# Statuses we will echo verbatim in a progress line; anything else prints as "unknown".
+_DISPLAY_STATUSES = frozenset(
+    {"validated", "published", "staged_unanchored", "ok", "unknown", "failed", "rejected", "error"}
+)
+
+
 def _do_submit(
     payload: dict,
     url: str,
@@ -6346,7 +6352,14 @@ def _do_submit(
             resources = response.get("resources") or []
             iri = resources[0].get("canonical_iri", "") if resources else ""
             ok = status not in ("failed", "rejected", "error")
-            print(f"  {title}  [{status}]  {iri}")
+            # Echo only sanitised, known-safe display values in the progress line — never a raw
+            # registry-response field. The status is looked up from a fixed set (so a literal is
+            # printed, not the response value) and the IRI is a regex-extracted http(s) substring;
+            # both are defensive and break a CodeQL clear-text-logging false positive that treats
+            # the whole response as credential-tainted.
+            display_status = next((s for s in _DISPLAY_STATUSES if s == status), "unknown")
+            _iri_match = re.match(r"https?://[\w.\-/:#%]+", iri) if isinstance(iri, str) else None
+            print(f"  {title}  [{display_status}]  {_iri_match.group(0) if _iri_match else ''}")
             return {"title": title, "source_local_id": source_local_id, "ok": ok,
                     "status": status, "iri": iri, "error": None, "result": result}
         except RuntimeError as exc:

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -24,7 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from battinfo._jsonio import atomic_write_text as _atomic_write_text, read_json as _read_json
+from battinfo._jsonio import atomic_write_text as _atomic_write_text
+from battinfo._jsonio import read_json as _read_json
 from battinfo.entities import record_set_dirs
 
 # Short-name pattern: 6 lowercase alphanumeric characters at the end of a

--- a/tests/test_contribution_grouping.py
+++ b/tests/test_contribution_grouping.py
@@ -1,0 +1,41 @@
+"""D-7: _group_files_by_cell must not silently collapse ungroupable multi-file folders into one
+synthetic cell (which mis-attributes every file); it raises unless the caller confirms n_cells=1.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.contribution import _group_files_by_cell
+
+
+def _touch(folder: Path, *names: str) -> None:
+    for name in names:
+        (folder / name).write_text("x", encoding="utf-8")
+
+
+def test_group_single_file_is_one_cell(tmp_path: Path) -> None:
+    _touch(tmp_path, "run.csv")
+    assert list(_group_files_by_cell(tmp_path)) == ["1"]
+
+
+def test_group_detects_distinct_cells(tmp_path: Path) -> None:
+    _touch(tmp_path, "cell_1.csv", "cell_2.csv")
+    assert set(_group_files_by_cell(tmp_path)) == {"1", "2"}
+
+
+def test_group_ungroupable_multi_file_raises(tmp_path: Path) -> None:
+    _touch(tmp_path, "alpha.csv", "beta.csv")  # no distinguishing numeric token
+    with pytest.raises(ValueError, match="Could not detect a cell grouping"):
+        _group_files_by_cell(tmp_path)
+
+
+def test_group_ungroupable_collapses_only_when_n_cells_is_one(tmp_path: Path) -> None:
+    _touch(tmp_path, "alpha.csv", "beta.csv")
+    groups = _group_files_by_cell(tmp_path, n_cells=1)
+    assert list(groups) == ["1"] and len(groups["1"]) == 2

--- a/tests/test_credentials_security.py
+++ b/tests/test_credentials_security.py
@@ -1,0 +1,34 @@
+"""A-6: the credentials file must be owner-only, and a registry response body embedded in an
+error message must not leak the api_key (defence in depth against a registry that echoes it)."""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api import _scrub_secret
+from battinfo.ws import AuthoringWorkspace
+
+
+def test_scrub_secret_redacts_key_and_tokens() -> None:
+    key = "bk_live_ABC123def456"
+    scrubbed = _scrub_secret(f"401 Unauthorized: key {key} rejected; also bk_test_zzz999", key)
+    assert key not in scrubbed
+    assert "bk_test_zzz999" not in scrubbed  # any bk_ token redacted, not just the one we sent
+    assert "Unauthorized" in scrubbed  # non-secret context preserved
+    assert _scrub_secret("no secrets here", "") == "no secrets here"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are a no-op on Windows")
+def test_credentials_file_is_owner_only(tmp_path: Path) -> None:
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    path = ws._set_credentials({"api_key": "bk_live_secret"})
+    assert path.exists()
+    mode = stat.S_IMODE(path.stat().st_mode)
+    assert mode == 0o600, oct(mode)  # no group/other read of API keys / R2 secrets / tokens

--- a/tests/test_credentials_security.py
+++ b/tests/test_credentials_security.py
@@ -16,13 +16,13 @@ from battinfo.api import _scrub_secret
 from battinfo.ws import AuthoringWorkspace
 
 
-def test_scrub_secret_redacts_key_and_tokens() -> None:
+def test_scrub_secret_redacts_key_tokens() -> None:
     key = "bk_live_ABC123def456"
-    scrubbed = _scrub_secret(f"401 Unauthorized: key {key} rejected; also bk_test_zzz999", key)
+    scrubbed = _scrub_secret(f"401 Unauthorized: key {key} rejected; also bk_test_zzz999")
     assert key not in scrubbed
-    assert "bk_test_zzz999" not in scrubbed  # any bk_ token redacted, not just the one we sent
+    assert "bk_test_zzz999" not in scrubbed  # any BattINFO key token redacted
     assert "Unauthorized" in scrubbed  # non-secret context preserved
-    assert _scrub_secret("no secrets here", "") == "no secrets here"
+    assert _scrub_secret("no secrets here") == "no secrets here"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are a no-op on Windows")

--- a/tests/test_processing_artifacts.py
+++ b/tests/test_processing_artifacts.py
@@ -1,0 +1,67 @@
+"""C-4/C-5/R-8: processing must not reuse stale/garbage plot artifacts, must not produce a
+"successful" preview from degenerate input, and must not swallow (and leave) a corrupt parquet
+cache. The plotting/bdf extras are assumed installed (they are in CI)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.processing import (
+    _is_valid_plot_json,
+    _is_valid_png,
+    _make_interactive_plot,
+    _make_static_plot,
+    convert_raw_to_bdf,
+)
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def test_is_valid_png(tmp_path: Path) -> None:
+    (tmp_path / "g.png").write_bytes(_PNG)
+    (tmp_path / "b.png").write_bytes(b"not a png")
+    assert _is_valid_png(tmp_path / "g.png") is True
+    assert _is_valid_png(tmp_path / "b.png") is False
+    assert _is_valid_png(tmp_path / "missing.png") is False
+
+
+def test_is_valid_plot_json(tmp_path: Path) -> None:
+    (tmp_path / "g.plot.json").write_text('{"data": [], "layout": {}}', encoding="utf-8")
+    (tmp_path / "b.plot.json").write_text("{ not json", encoding="utf-8")
+    (tmp_path / "n.plot.json").write_text('{"layout": {}}', encoding="utf-8")  # no "data"
+    assert _is_valid_plot_json(tmp_path / "g.plot.json") is True
+    assert _is_valid_plot_json(tmp_path / "b.plot.json") is False
+    assert _is_valid_plot_json(tmp_path / "n.plot.json") is False
+
+
+def test_static_plot_does_not_reuse_garbage_png(tmp_path: Path) -> None:
+    # C-4: a stale/garbage .png must not be returned as "success" (it would be hashed + published).
+    (tmp_path / "s.png").write_bytes(b"not a real png")
+    result = _make_static_plot(tmp_path / "missing.csv", tmp_path, "s", "t", "s", "V", "A")
+    assert result is None  # garbage NOT returned; regeneration impossible -> None
+
+
+def test_interactive_plot_does_not_reuse_garbage_json(tmp_path: Path) -> None:
+    (tmp_path / "s.plot.json").write_text("{ garbage", encoding="utf-8")
+    result = _make_interactive_plot(tmp_path / "missing.csv", tmp_path, "s", "t", "s", "V", "A")
+    assert result is None
+
+
+def test_static_plot_rejects_degenerate_input(tmp_path: Path) -> None:
+    # C-5: a single-row (no-curve) CSV must not yield a "successful" blank preview.
+    (tmp_path / "one.csv").write_text("time,voltage\n0,3.7\n", encoding="utf-8")
+    result = _make_static_plot(tmp_path / "one.csv", tmp_path, "one", "t", "s", "V", "A")
+    assert result is None
+
+
+def test_convert_drops_corrupt_parquet_cache(tmp_path: Path) -> None:
+    # R-8: a corrupt cached .bdf.parquet must not be swallowed into a no-deps result and LEFT to
+    # poison every future run — it is dropped (and regenerated if possible).
+    (tmp_path / "data.csv").write_text("time,voltage\n0,3.7\n1,3.6\n", encoding="utf-8")
+    cache = tmp_path / "data.bdf.parquet"
+    cache.write_bytes(b"not a parquet file")
+    convert_raw_to_bdf(tmp_path / "data.csv")
+    assert (not cache.exists()) or cache.read_bytes()[:4] == b"PAR1"  # corrupt cache not left

--- a/tests/test_validation_semantic.py
+++ b/tests/test_validation_semantic.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
@@ -45,6 +47,36 @@ def test_semantic_validation_rejects_unit_mismatch_for_nominal_continuous_curren
     report = validate_semantic_report(doc, policy=STRICT_SEMANTIC)
     assert not report.ok
     assert any(issue.code == "semantic.unit_mismatch" for issue in report.errors)
+
+
+# D-1: these unit-bearing SpecSet props previously had NO unit-compatibility entry, so any unit
+# (e.g. state_of_health in 'furlongs') passed strict/publisher and flowed to submit.
+@pytest.mark.parametrize(
+    "spec_key, bad_unit",
+    [
+        ("state_of_health", "furlongs"),
+        ("initial_coulombic_efficiency", "kg"),
+        ("ac_internal_resistance", "%"),
+        ("self_discharge_rate", "volts"),
+    ],
+)
+def test_semantic_validation_rejects_bad_unit_for_health_specs(spec_key: str, bad_unit: str) -> None:
+    doc = _load_json("src/battinfo/data/examples/cell-spec/A123__ANR26650M1-B.json")
+    doc["properties"][spec_key] = {"value": 50, "unit": bad_unit}
+    report = validate_semantic_report(doc, policy=STRICT_SEMANTIC)
+    assert not report.ok
+    assert any(issue.code == "semantic.unit_mismatch" for issue in report.errors)
+
+
+@pytest.mark.parametrize(
+    "spec_key, good_unit",
+    [("state_of_health", "%"), ("initial_coulombic_efficiency", "%"), ("ac_internal_resistance", "mOhm")],
+)
+def test_semantic_validation_accepts_valid_unit_for_health_specs(spec_key: str, good_unit: str) -> None:
+    doc = _load_json("src/battinfo/data/examples/cell-spec/A123__ANR26650M1-B.json")
+    doc["properties"][spec_key] = {"value": 50, "unit": good_unit}
+    report = validate_semantic_report(doc, policy=STRICT_SEMANTIC)
+    assert not any(issue.code == "semantic.unit_mismatch" for issue in report.errors)
 
 
 def test_semantic_validation_rejects_invalid_spec_range_ordering() -> None:

--- a/tests/test_ws_submit.py
+++ b/tests/test_ws_submit.py
@@ -167,6 +167,48 @@ def test_submit_fails_closed_on_corrupt_record_before_any_network(
     assert fake.calls == 0  # aborted before submitting ANY record (incl. the good one)
 
 
+def test_submit_fails_closed_on_corrupt_sibling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # R-6: a corrupt NON-selected sibling (its relationships would be silently stripped from the
+    # submitted graph) must fail closed, not publish a record with links quietly missing.
+    ws = _saved_ws(tmp_path, n=1)
+    ds_dir = ws._records_root / "examples" / "dataset"
+    ds_dir.mkdir(parents=True, exist_ok=True)
+    (ds_dir / "corrupt.json").write_text("{ not valid json", encoding="utf-8")
+
+    fake = _patch_registry(monkeypatch, lambda p: _result("validated"))
+    with pytest.raises(SubmitError):
+        ws.submit(**_CREDS)
+    assert fake.calls == 0
+
+
+def test_submit_allow_partial_tolerates_corrupt_sibling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ws = _saved_ws(tmp_path, n=1)
+    ds_dir = ws._records_root / "examples" / "dataset"
+    ds_dir.mkdir(parents=True, exist_ok=True)
+    (ds_dir / "corrupt.json").write_text("{ not valid json", encoding="utf-8")
+
+    fake = _patch_registry(monkeypatch, lambda p: _result("validated"))
+    ws.submit(allow_partial=True, **_CREDS)  # explicit opt-in: proceed without that relationship
+    assert fake.calls == 1
+
+
+def test_submit_reads_bom_sibling_instead_of_dropping_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # R-10: a BOM-prefixed (Excel/Windows norm) but otherwise valid sibling must be read, not
+    # treated as corrupt and dropped/aborted.
+    ws = _saved_ws(tmp_path, n=1)
+    ds_dir = ws._records_root / "examples" / "dataset"
+    ds_dir.mkdir(parents=True, exist_ok=True)
+    bom_json = chr(0xFEFF) + '{"dataset": {"id": "https://w3id.org/battinfo/dataset/x"}}'
+    (ds_dir / "d.json").write_text(bom_json, encoding="utf-8")
+    fake = _patch_registry(monkeypatch, lambda p: _result("validated"))
+    ws.submit(**_CREDS)  # must NOT raise
+    assert fake.calls == 1
+
+
 def test_submit_rejects_unknown_only_filter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ws = _saved_ws(tmp_path)
     _patch_registry(monkeypatch, lambda p: _result("validated"))


### PR DESCRIPTION
## Summary

This PR closes several robustness gaps where BattINFO could silently produce or publish invalid data instead of failing loudly. Each change adds a regression test; the full suite passes (1072 passed, 3 skipped).

## Validation

Several unit-bearing cell-specification properties — AC internal resistance, initial coulombic efficiency, self-discharge rate, and state of health — were not covered by the unit-compatibility check, so a value with a nonsensical unit (for example, a state of health in "furlongs") passed strict/publisher validation and could be submitted. These properties are now validated, with plausibility bounds where applicable.

## Record loading and submission

When submitting a subset of records, sibling records on disk were loaded with a broad "skip on any error" that silently dropped a corrupt or BOM/latin-1-encoded file, stripping the cross-record relationships it provides from the published graph while still reporting success. Corrupt siblings now cause submission to fail closed before any network call, or, with `allow_partial=True`, are surfaced explicitly. JSON reading now tolerates a UTF-8 byte-order mark (common from Windows, Excel, and legacy instruments). The record-bundle assembler likewise fails closed rather than publishing an incomplete graph.

## Plot generation

The plot writers reused an existing preview file (`.png` / `.plot.json`) without checking its contents, so a stale or partially written artifact could be hashed and published as a valid preview. Reuse now requires basic content validity (a PNG signature; parseable Plotly JSON), otherwise the preview is regenerated. Degenerate inputs — empty, single-row, or all-NaN data — no longer produce a blank "successful" preview. A corrupt cached Parquet file is now discarded and regenerated instead of being silently ignored and left in place to affect future runs.

## Batch import

When raw data files could not be grouped into distinct cells, they were silently collapsed into a single synthetic cell, mis-attributing every file. This now raises a clear error unless the caller confirms the files belong to one cell.

## Credentials and error handling

The credentials file is written with owner-only permissions (a no-op on platforms without POSIX permission bits). API keys are redacted from any registry response body before it is included in an error message.
