### PR TITLE
Fail closed on Zenodo publish/preview; make reads resilient

### DIFF
--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -3666,6 +3666,7 @@ class AuthoringWorkspace:
         published  = False
 
         if publish:
+            self._assert_publishable(jsonld)  # fail closed BEFORE minting an irreversible DOI (R-7)
             pub = client.publish_deposit(deposit_id)
             doi = pub.get("doi", prereserved_doi)
             published = True
@@ -3863,14 +3864,11 @@ class AuthoringWorkspace:
         )
 
         out = Path(output) if output else self._root / "battinfo.preview.jsonld"
-        out.write_text(json.dumps(jsonld, indent=2, ensure_ascii=False), encoding="utf-8")
-        print(f"  Written: {out}")
-        print(f"  Graph nodes: {len(jsonld.get('@graph', []))}")
-        print(f"  Data files:  {len(data_filenames)}")
 
-        # Gold-standard review: run the FULL publication validator (JSON-LD + structural
-        # + SHACL), not just the syntactic JSON-LD check, so a metadata-poor or
-        # non-conformant preview is surfaced here rather than discovered after upload.
+        # Gold-standard review runs BEFORE the file is written, so a metadata-poor or
+        # non-conformant record is surfaced up front rather than after an authoritative-looking
+        # file has already been produced (D-4). Uses the FULL publication validator (JSON-LD +
+        # structural + SHACL), not just the syntactic JSON-LD check.
         try:
             from battinfo.validate import validate_publication_report  # noqa: PLC0415
             report = validate_publication_report(jsonld, policy="publisher")
@@ -3885,9 +3883,39 @@ class AuthoringWorkspace:
                     print(f"    ERROR   {i.message}")
                 for i in warnings:
                     print(f"    warning {i.message}")
-        except Exception as exc:  # noqa: BLE001 — preview must still return its path
+        except Exception as exc:  # noqa: BLE001 — preview must still write + return its path
             print(f"  Gold-standard validation could not run: {exc}")
+
+        out.write_text(json.dumps(jsonld, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"  Written: {out}")
+        print(f"  Graph nodes: {len(jsonld.get('@graph', []))}")
+        print(f"  Data files:  {len(data_filenames)}")
         return out
+
+    def _assert_publishable(self, jsonld: dict) -> None:
+        """Fail closed before minting an irreversible DOI: refuse to publish a record that has
+        validation errors, or a distribution whose data file is missing from the deposit (R-7).
+
+        Missing data files are checked from the most recent :meth:`_bundle_data_files` run."""
+        missing = getattr(self, "_missing_data_files", [])
+        if missing:
+            raise RuntimeError(
+                f"Refusing to publish: {len(missing)} distribution data file(s) are missing and were "
+                f"not uploaded, so the deposit would be incomplete: {'; '.join(missing[:5])}. "
+                "Fix the paths (or remove the distributions), then re-run."
+            )
+        try:
+            from battinfo.validate import validate_publication_report  # noqa: PLC0415
+            report = validate_publication_report(jsonld, policy="publisher")
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"Could not validate the record before publishing: {exc}") from exc
+        errors = [i for i in report.issues if i.severity == "error"]
+        if errors:
+            raise RuntimeError(
+                f"Refusing to publish: {len(errors)} validation error(s) in the record "
+                "(run ws.preview_jsonld() to see them, or leave the deposit as a draft): "
+                + "; ".join(i.message for i in errors[:5])
+            )
 
     def _bundle_data_files(self, tmpdir: Path, examples: Path) -> list[str]:
         """Copy data files into *tmpdir*, zipping by test kind when >90 files."""
@@ -3910,6 +3938,7 @@ class AuthoringWorkspace:
 
         # Collect local data file paths
         collected: list[tuple[Path, str]] = []  # (local_path, kind)
+        missing: list[str] = []  # file-scheme distributions whose local file is absent
         ds_dir = examples / "dataset"
         if ds_dir.exists():
             for ds_file in sorted(ds_dir.glob("*.json")):
@@ -3925,8 +3954,16 @@ class AuthoringWorkspace:
                         lp = Path(url.replace("file:///", "").replace("file://", ""))
                         if lp.exists():
                             collected.append((lp, kind))
+                        else:
+                            # Do NOT silently drop a distribution whose data file is missing: the
+                            # deposit would be published incomplete (a distribution pointing at a
+                            # file that was never uploaded). Warn now; block publish later (R-7).
+                            missing.append(str(lp))
+                            print(f"  ⚠️  data file for a distribution is missing (not uploaded): {lp}")
                 except Exception:
                     continue
+        # Surfaced to zenodo()/publish so publishing can fail closed on an incomplete deposit.
+        self._missing_data_files = missing
 
         # Deduplicate (a file may appear in multiple distributions)
         seen: set[str] = set()

--- a/src/battinfo/zenodo.py
+++ b/src/battinfo/zenodo.py
@@ -73,6 +73,7 @@ class ZenodoClient:
         content_type: str = "application/json",
         extra_headers: dict[str, str] | None = None,
         timeout: float = 60.0,
+        max_attempts: int = 3,
     ) -> dict:
         url = self._base.rstrip("/") + path
         headers = {
@@ -80,14 +81,36 @@ class ZenodoClient:
             "Content-Type": content_type,
             **(extra_headers or {}),
         }
-        req = urllib.request.Request(url, data=data, headers=headers, method=method)
-        try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
-                body = resp.read()
-                return json.loads(body) if body else {}
-        except urllib.error.HTTPError as exc:
-            body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
-            raise ZenodoError(f"Zenodo {exc.code} on {method} {url}: {body[:400]}") from exc
+        # Only idempotent reads are retried. A write (POST/PUT/DELETE) is sent exactly once, even on
+        # a timeout, because a retry could duplicate an irreversible action (e.g. double-publish).
+        idempotent = method.upper() in ("GET", "HEAD")
+        attempts = max_attempts if idempotent else 1
+        last_exc: Exception | None = None
+        for attempt in range(attempts):
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
+            try:
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    body = resp.read()
+                    return json.loads(body) if body else {}
+            except urllib.error.HTTPError as exc:
+                body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+                # Retry idempotent reads on transient server states (cold start / rate limit).
+                if idempotent and exc.code in (429, 500, 502, 503, 504) and attempt < attempts - 1:
+                    last_exc = exc
+                    time.sleep(0.5 * (2 ** attempt))
+                    continue
+                raise ZenodoError(f"Zenodo {exc.code} on {method} {url}: {body[:400]}") from exc
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                # Connection reset / DNS / timeout: previously escaped as a raw, opaque exception.
+                # Retry idempotent reads; otherwise surface as a clean ZenodoError.
+                if idempotent and attempt < attempts - 1:
+                    last_exc = exc
+                    time.sleep(0.5 * (2 ** attempt))
+                    continue
+                raise ZenodoError(f"Zenodo request failed ({method} {url}): {exc}") from exc
+        raise ZenodoError(  # pragma: no cover — loop always returns or raises above
+            f"Zenodo request failed after {attempts} attempt(s) ({method} {url}): {last_exc}"
+        )
 
     def _json(self, method: str, path: str, payload: dict | None = None) -> dict:
         body = json.dumps(payload or {}).encode("utf-8")
@@ -123,8 +146,25 @@ class ZenodoClient:
         return self._json("GET", f"/deposit/depositions/{deposit_id}")
 
     def publish_deposit(self, deposit_id: int | str) -> dict:
-        """Publish a draft deposit. This action is irreversible."""
-        return self._json("POST", f"/deposit/depositions/{deposit_id}/actions/publish")
+        """Publish a draft deposit. This action is irreversible.
+
+        The publish POST is never retried (a retry could mint a second DOI). But a transient
+        failure — a timeout or dropped connection — may still have committed server-side, leaving
+        the caller unsure whether the DOI exists. On such a failure we confirm by re-reading the
+        deposit: if it is already published, the publish succeeded and we return it; otherwise the
+        original error is raised so the caller does not believe a draft went out.
+        """
+        try:
+            return self._json("POST", f"/deposit/depositions/{deposit_id}/actions/publish")
+        except ZenodoError as exc:
+            try:
+                deposit = self.get_deposit(deposit_id)
+            except ZenodoError:
+                raise exc from None
+            state = str(deposit.get("state") or "").lower()
+            if state == "done" or deposit.get("submitted") is True:
+                return deposit
+            raise
 
     def discard_deposit(self, deposit_id: int | str) -> None:
         """Discard (delete) an unpublished draft deposit."""

--- a/tests/test_ws_publish_gate.py
+++ b/tests/test_ws_publish_gate.py
@@ -1,0 +1,74 @@
+"""R-7: publishing to Zenodo is irreversible, so the workspace must fail closed BEFORE minting a
+DOI when (a) a file-scheme distribution's local data file is missing (the deposit would be
+incomplete) or (b) the record has validation errors. The check must pass for a clean record."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.ws import AuthoringWorkspace
+
+
+def _issue(severity: str, message: str) -> types.SimpleNamespace:
+    return types.SimpleNamespace(severity=severity, message=message)
+
+
+def _fake_report(*issues: types.SimpleNamespace) -> types.SimpleNamespace:
+    return types.SimpleNamespace(issues=list(issues))
+
+
+def _patch_validator(monkeypatch: pytest.MonkeyPatch, report: types.SimpleNamespace) -> None:
+    import battinfo.validate as v
+
+    monkeypatch.setattr(v, "validate_publication_report", lambda *a, **k: report)
+
+
+def test_publish_refused_when_data_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_validator(monkeypatch, _fake_report())  # no validation errors
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    ws._missing_data_files = ["/data/run_042.csv"]
+    with pytest.raises(RuntimeError, match="missing"):
+        ws._assert_publishable({"@graph": []})
+
+
+def test_publish_refused_when_validation_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_validator(monkeypatch, _fake_report(_issue("error", "missing dataset license")))
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    ws._missing_data_files = []
+    with pytest.raises(RuntimeError, match="validation error"):
+        ws._assert_publishable({"@graph": []})
+
+
+def test_publish_allowed_for_clean_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # warnings alone must not block publishing — only errors do.
+    _patch_validator(monkeypatch, _fake_report(_issue("warning", "consider adding keywords")))
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    ws._missing_data_files = []
+    ws._assert_publishable({"@graph": []})  # must not raise
+
+
+def test_assert_publishable_fails_closed_if_validator_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import battinfo.validate as v
+
+    def _boom(*a: object, **k: object) -> None:
+        raise ImportError("validator broke")
+
+    monkeypatch.setattr(v, "validate_publication_report", _boom)
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    ws._missing_data_files = []
+    with pytest.raises(RuntimeError, match="Could not validate"):
+        ws._assert_publishable({"@graph": []})

--- a/tests/test_zenodo_publish.py
+++ b/tests/test_zenodo_publish.py
@@ -1,0 +1,119 @@
+"""A-5: the Zenodo HTTP layer must (1) retry idempotent reads on transient failures, (2) never
+retry a write (a publish retry could mint a second DOI), (3) surface connection/timeout errors as
+a clean ZenodoError instead of a raw urllib exception, and (4) confirm-on-transient for publish so
+a timed-out-but-committed publish is reported as success rather than a phantom failure."""
+from __future__ import annotations
+
+import io
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import zenodo as zmod
+from battinfo.zenodo import ZenodoClient, ZenodoError
+
+
+class _FakeResp:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        return None
+
+
+def _patch_urlopen(monkeypatch: pytest.MonkeyPatch, handler) -> list[str]:
+    """Route urlopen through *handler(req, calls)*; return the mutable call log."""
+    calls: list[str] = []
+
+    def fake_urlopen(req, timeout=None):  # noqa: ANN001
+        calls.append(f"{req.get_method()} {req.full_url}")
+        return handler(req, calls)
+
+    monkeypatch.setattr(zmod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(zmod.time, "sleep", lambda *_: None)  # no real backoff waits
+    return calls
+
+
+def _client() -> ZenodoClient:
+    return ZenodoClient(token="fake-token", sandbox=True)
+
+
+def test_get_retries_transient_url_error_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(req, calls):  # noqa: ANN001
+        if len(calls) < 3:  # fail the first two attempts
+            raise urllib.error.URLError("connection reset")
+        return _FakeResp(b'{"id": 42, "state": "unsubmitted"}')
+
+    calls = _patch_urlopen(monkeypatch, handler)
+    dep = _client().get_deposit(42)
+    assert dep["id"] == 42
+    assert len(calls) == 3  # two retries, then success
+
+
+def test_get_gives_up_after_max_attempts_as_zenodo_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(req, calls):  # noqa: ANN001
+        raise urllib.error.URLError("dns failure")
+
+    calls = _patch_urlopen(monkeypatch, handler)
+    with pytest.raises(ZenodoError):
+        _client().get_deposit(42)
+    assert len(calls) == 3  # bounded, not infinite
+
+
+def test_write_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(req, calls):  # noqa: ANN001
+        raise urllib.error.URLError("timeout")
+
+    calls = _patch_urlopen(monkeypatch, handler)
+    with pytest.raises(ZenodoError):
+        _client().update_metadata(42, {"title": "x"})  # PUT
+    assert len(calls) == 1  # exactly once — no double-write
+
+
+def test_transient_error_becomes_clean_zenodo_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(req, calls):  # noqa: ANN001
+        raise TimeoutError("read timed out")
+
+    _patch_urlopen(monkeypatch, handler)
+    with pytest.raises(ZenodoError, match="Zenodo request failed"):
+        _client().get_deposit(42)
+
+
+def test_publish_confirms_success_when_transiently_failed_but_committed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # POST publish times out (never retried), but the GET confirms the deposit is published.
+    def handler(req, calls):  # noqa: ANN001
+        if req.get_method() == "POST":
+            raise urllib.error.URLError("timeout after publish accepted")
+        return _FakeResp(b'{"id": 42, "state": "done", "submitted": true}')
+
+    calls = _patch_urlopen(monkeypatch, handler)
+    dep = _client().publish_deposit(42)
+    assert dep["state"] == "done"
+    assert calls[0].startswith("POST")  # publish attempted exactly once
+    assert sum(c.startswith("POST") for c in calls) == 1
+
+
+def test_publish_reraises_when_deposit_not_actually_published(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(req, calls):  # noqa: ANN001
+        if req.get_method() == "POST":
+            raise urllib.error.HTTPError(req.full_url, 400, "Bad Request", {}, io.BytesIO(b"nope"))
+        return _FakeResp(b'{"id": 42, "state": "unsubmitted"}')
+
+    _patch_urlopen(monkeypatch, handler)
+    with pytest.raises(ZenodoError):
+        _client().publish_deposit(42)


### PR DESCRIPTION
Publishing a record to Zenodo mints a DOI and cannot be undone, so this change makes the workspace validate before it commits rather than after.

ws.zenodo(publish=True) now refuses to publish in two cases: when a distribution points at a local data file that is missing, since the resulting deposit would be incomplete, and when the record has validation errors. Both checks run before the publish request is sent. Each missing data file is reported with a warning during bundling instead of being silently dropped. preview_jsonld runs the same full validation before it writes its preview file, so a metadata-poor or non-conformant record is surfaced up front rather than after an authoritative-looking file already exists.

The Zenodo HTTP client is also more resilient to transient network conditions. Idempotent reads are retried a bounded number of times with backoff on timeouts, dropped connections, and temporary server errors, and connection and timeout failures now surface as a single clear error type instead of a raw low-level exception. Writes are still sent exactly once so a retry can never duplicate an irreversible action. Publish itself is never retried, but if the publish request fails transiently the deposit is re-read and reported as successfully published when it in fact committed, so a timed-out request that actually succeeded is no longer misreported as a failure.

New regression tests cover the publish gate, the retry and give-up behaviour of reads, the guarantee that writes are not retried, and the publish confirmation path. The full test suite passes.