### PR TITLE
Keep unmapped units and identifiers out of exported RDF as file:// leaks

### DIFF
--- a/src/battinfo/jsonld.py
+++ b/src/battinfo/jsonld.py
@@ -221,7 +221,13 @@ def _quantity(value: Any, unit: str) -> dict:
     """
     node: dict = {"hasNumericalPart": {"hasNumberValue": value}}
     unit_iri = _UNIT_MAP.get(unit)
-    node["hasMeasurementUnit"] = {"@id": unit_iri} if unit_iri else unit
+    if unit_iri:
+        node["hasMeasurementUnit"] = {"@id": unit_iri}
+    elif unit:
+        # Unmapped unit: emit a plain-text literal. hasMeasurementUnit is @id-typed in the
+        # records context, so a bare symbol there is coerced to a cwd-relative file:// IRI on
+        # RDF export — a portability leak. schema:unitText keeps the symbol as a literal (D-2).
+        node["schema:unitText"] = unit
     return node
 
 

--- a/src/battinfo/publication.py
+++ b/src/battinfo/publication.py
@@ -1255,9 +1255,13 @@ def _cell_spec_property_node(name: str, quantity: Any) -> dict[str, Any] | None:
         "@type": type_name,
         "hasNumericalPart": {"@type": "RealData", "hasNumberValue": value},
     }
-    unit_iri = UNIT_IRI_MAP.get(unit, unit)
+    unit_iri = UNIT_IRI_MAP.get(unit)
     if unit_iri:
         node["hasMeasurementUnit"] = unit_iri
+    elif unit:
+        # Unmapped unit: emit a plain-text literal rather than a bare symbol under the @id-typed
+        # hasMeasurementUnit (which would export to a cwd-relative file:// IRI). D-2.
+        node["schema:unitText"] = unit
     return node
 
 

--- a/src/battinfo/validate/jsonld.py
+++ b/src/battinfo/validate/jsonld.py
@@ -260,6 +260,42 @@ def _walk_relative_type_errors(node: Any, path: str, errors: list[str]) -> None:
             _walk_relative_type_errors(item, next_path, errors)
 
 
+def _is_bare_relative_id(value: str) -> bool:
+    """True if this ``@id`` is a bare token that silently resolves to a machine-local IRI.
+
+    A usable ``@id`` is an absolute IRI carrying a scheme (``http:``, ``urn:``, …), a compact
+    CURIE (``prefix:local``), or a blank-node label (``_:b0``). A bare token with none of these —
+    e.g. ``c1`` or an unmapped unit symbol — has no scheme and no CURIE colon, so rdflib resolves
+    it against the document base (the current working directory on export), silently producing
+    ``file:///…/token`` and leaking the authoring machine's filesystem into the record. (Explicit
+    ``file:`` IRIs are left alone: the offline DCAT bundle links its sibling data files that way
+    by design.)
+    """
+    if not value or value.startswith(("_:", "@")):
+        return False  # blank node / JSON-LD keyword — not a resolvable IRI
+    return ":" not in value
+
+
+def _walk_relative_id_errors(node: Any, path: str, errors: list[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            next_path = f"{path}.{key}" if path else key
+            if key == "@context":
+                continue
+            if key == "@id":
+                if isinstance(value, str) and _is_bare_relative_id(value):
+                    errors.append(
+                        f"{next_path}: bare @id '{value}' has no scheme or CURIE prefix and "
+                        "would export to a cwd-relative file:// IRI"
+                    )
+                continue
+            _walk_relative_id_errors(value, next_path, errors)
+    elif isinstance(node, list):
+        for idx, item in enumerate(node):
+            next_path = f"{path}[{idx}]" if path else f"[{idx}]"
+            _walk_relative_id_errors(item, next_path, errors)
+
+
 def _parse_materialization_issues(data: dict[str, Any]) -> list[ValidationIssue]:
     issues: list[ValidationIssue] = []
     # rdflib 7.x emits DeprecationWarning for internal APIs (Dataset.default_context,
@@ -452,6 +488,25 @@ def validate_jsonld_report(
                 path=path if _ else "",
                 message=message if _ else rendered,
                 validator="@type",
+                resource_type="jsonld",
+            )
+        )
+    # @id portability is enforced only for publication: mid-pipeline authoring and staging forms
+    # legitimately carry local ids and file:// staging links that are rewritten to their final
+    # w3id/Zenodo IRIs before a record is published. At publish time (publisher policy) any such
+    # value that survived is a real leak — a cwd-relative or file:// IRI in the released RDF.
+    id_errors: list[str] = []
+    if resolved_policy.name == "publisher":
+        _walk_relative_id_errors(data, "", id_errors)
+    for rendered in id_errors:
+        path, _, message = rendered.partition(": ")
+        issues.append(
+            ValidationIssue(
+                code="jsonld.id_not_portable",
+                severity="error",
+                path=path if _ else "",
+                message=message if _ else rendered,
+                validator="@id",
                 resource_type="jsonld",
             )
         )

--- a/tests/test_rdf_iri_safety.py
+++ b/tests/test_rdf_iri_safety.py
@@ -1,0 +1,84 @@
+"""D-2 / D-3: exported RDF must not silently leak the authoring machine's filesystem.
+
+D-2 — an unmapped unit must be emitted as a plain-text literal (schema:unitText), never as a bare
+symbol under the @id-typed hasMeasurementUnit (which rdflib coerces into a cwd-relative file://
+IRI). D-3 — when validating a record for publication, a bare-token @id (no scheme, no CURIE) is
+rejected, because it would resolve against the cwd on export; local/staging validation and
+legitimate file:// bundle links are left untouched."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.jsonld import _quantity
+from battinfo.validate.core import DEFAULT_POLICY, PUBLISHER_POLICY, STRICT_POLICY
+from battinfo.validate.jsonld import validate_jsonld_report
+
+
+# ── D-2: unit emission ────────────────────────────────────────────────────────
+def test_quantity_maps_known_unit_to_id() -> None:
+    node = _quantity(3.7, "V")
+    unit = node["hasMeasurementUnit"]
+    assert isinstance(unit, dict) and "@id" in unit  # mapped -> @id reference
+    assert "schema:unitText" not in node
+
+
+def test_quantity_emits_unmapped_unit_as_literal_not_bare_id() -> None:
+    node = _quantity(50, "furlongs")
+    # The @id-typed hasMeasurementUnit must NOT carry the bare symbol (that becomes a file:// IRI).
+    assert node.get("hasMeasurementUnit") != "furlongs"
+    assert "hasMeasurementUnit" not in node
+    assert node["schema:unitText"] == "furlongs"
+
+
+def test_publication_property_node_emits_unmapped_unit_as_literal() -> None:
+    from battinfo.publication import PROPERTY_TYPE_MAP, UNIT_IRI_MAP, _cell_spec_property_node
+
+    name = next(iter(PROPERTY_TYPE_MAP))
+    bad_unit = "furlongs"
+    assert bad_unit not in UNIT_IRI_MAP
+    node = _cell_spec_property_node(name, {"value": 1.0, "unit": bad_unit})
+    assert node is not None
+    assert node.get("hasMeasurementUnit") != bad_unit  # not a bare @id-typed leak
+    assert node.get("schema:unitText") == bad_unit
+
+
+# ── D-3: @id portability sweep ────────────────────────────────────────────────
+def _bare_id_doc() -> dict:
+    return {"@graph": [{"@id": "c1", "@type": "battinfo:Cell"}]}
+
+
+def _has_id_error(report) -> bool:  # noqa: ANN001
+    return any(i.code == "jsonld.id_not_portable" for i in report.issues)
+
+
+def test_bare_id_rejected_under_publisher_policy() -> None:
+    report = validate_jsonld_report(_bare_id_doc(), policy=PUBLISHER_POLICY)
+    assert _has_id_error(report)
+
+
+def test_bare_id_ignored_under_authoring_policies() -> None:
+    # Mid-pipeline authoring/strict validation must not flag local ids that get namespaced later.
+    assert not _has_id_error(validate_jsonld_report(_bare_id_doc(), policy=DEFAULT_POLICY))
+    assert not _has_id_error(validate_jsonld_report(_bare_id_doc(), policy=STRICT_POLICY))
+
+
+def test_portable_ids_pass_under_publisher_policy() -> None:
+    doc = {
+        "@graph": [
+            {"@id": "https://w3id.org/battinfo/spec/abcd", "@type": "battinfo:Cell"},
+            {"@id": "battinfo:hasProperty"},  # compact CURIE
+            {"@id": "_:b0"},  # blank node
+        ]
+    }
+    assert not _has_id_error(validate_jsonld_report(doc, policy=PUBLISHER_POLICY))
+
+
+def test_file_scheme_id_tolerated_for_offline_bundle() -> None:
+    # The offline DCAT bundle links sibling data files with absolute file:// @ids by design;
+    # the sweep targets bare tokens, not explicit file:// IRIs.
+    doc = {"@graph": [{"@id": "file:///tmp/bundle/data.csv", "@type": "schema:Dataset"}]}
+    assert not _has_id_error(validate_jsonld_report(doc, policy=PUBLISHER_POLICY))


### PR DESCRIPTION
Two fields in a record are declared as IRI references in the JSON-LD context, which means any plain string placed in them is expanded relative to the current working directory when the record is serialized to RDF. The result is a file:///... IRI that silently embeds the authoring machine's local filesystem path into the exported data.

The first case is measurement units. When a unit symbol had no entry in the unit map, it was written as a bare symbol under the IRI-typed hasMeasurementUnit, so an unmapped unit such as a typo or a novel symbol turned into a local file path on export. Unmapped units are now written as a schema:unitText text literal, which remains a plain string, and both quantity serializers share this behaviour.

The second case is node identifiers. Publication validation now rejects an @id that is a bare token with no scheme and no compact-prefix colon, since such a value resolves against the working directory on export. The check runs only when a record is validated for publication, so intermediate authoring and staging representations, which legitimately carry short local identifiers and deliberate file:// links to bundled data files, are left unchanged.

New regression tests cover the literal unit emission for both serializers and the identifier check across the authoring, strict, and publication policies. The full test suite passes.