### PR TITLE
Make record save and re-submission surface identity conflicts

### DIFF
--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -2872,6 +2872,21 @@ def _resolve_references_for_save(doc: dict[str, Any], source_root: Path) -> None
     raise ValueError(report.errors[0].message)
 
 
+def _record_content_differs(existing_path: PathLike, new_doc: Mapping[str, Any]) -> bool:
+    """True if the record already on disk differs from *new_doc* in a meaningful way.
+
+    Volatile timestamps and identity scaffolding (see ``_strip_volatile``) are ignored, so an
+    idempotent re-save of unchanged content reports False and a real edit reports True. A
+    missing or unreadable existing file is treated as "differs" (the write is not a no-op)."""
+    from battinfo._workspace import _strip_volatile
+
+    try:
+        existing = _load_json(_as_path(existing_path))
+    except (OSError, ValueError):
+        return True
+    return _strip_volatile(existing) != _strip_volatile(dict(new_doc))
+
+
 def save_record(
     record: dict[str, Any] | PathLike,
     *,
@@ -2921,12 +2936,19 @@ def save_record(
         )
 
     operation = "updated" if existing_path is not None else "created"
+    # An upsert that replaces an existing record with genuinely different content (ignoring
+    # volatile timestamps) is reported explicitly, so a same-IRI overwrite is never silent —
+    # the caller can surface it or choose mode='create_only' to refuse it. (A-4)
+    content_changed = False
+    if existing_path is not None and mode_normalized == REGISTER_MODE_UPSERT:
+        content_changed = _record_content_differs(existing_path, doc)
     payload: dict[str, Any] = {
         "status": "dry-run" if dry_run else operation,
         "id": entity_id,
         "entity_type": entity_type,
         "path": str(target_path),
         "mode": mode_normalized,
+        "content_changed": content_changed,
         "published": False,
     }
 

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -1968,16 +1968,22 @@ class AuthoringWorkspace:
             "via ws.add('test', data=...)."
         )
 
-    def save(self, validation_policy: str = "strict") -> dict:
+    def save(self, validation_policy: str = "strict", mode: str = "upsert") -> dict:
         """Save all records and rebuild the workspace index.
 
         Returns a summary dict with counts of written records.
         Only the records saved in this call will be submitted by the next
         ``ws.submit()`` — records left over from previous sessions in the
         same directory are ignored.
+
+        ``mode`` controls how an existing on-disk record with the same IRI is
+        treated. The default ``"upsert"`` updates it in place (the normal
+        edit-and-resave loop). Pass ``"create_only"`` to instead refuse to touch
+        any record that already exists, so a fresh authoring run cannot silently
+        overwrite records left by a previous session.
         """
         result = self._ws.save(
-            mode="upsert",
+            mode=mode,
             resolve_references=False,
             validation_policy=validation_policy,
         )
@@ -6381,6 +6387,7 @@ def _do_submit(
     if validation is not None:
         payload["validation"] = validation  # the real verdict, not the builder's ok=True default
     _lift_funding_to_provenance(payload)
+    bumped_version: str | None = None
     for attempt in range(2):
         try:
             result = submit_publication_package(payload, registry_base_url=url, api_key=key)
@@ -6398,22 +6405,33 @@ def _do_submit(
             display_status = next((s for s in _DISPLAY_STATUSES if s == status), "unknown")
             print(f"  {title}  [{display_status}]")
             return {"title": title, "source_local_id": source_local_id, "ok": ok,
-                    "status": status, "iri": iri, "error": None, "result": result}
+                    "status": status, "iri": iri, "error": None, "result": result,
+                    "version_bumped": bumped_version}
         except RuntimeError as exc:
-            if attempt == 0 and "409" in str(exc):
-                # Payload changed since last submission — bump source_version and retry.
+            # Prefer the structured status code (RegistryClientError.status_code) over matching
+            # the string "409", which could appear anywhere in an error/response body.
+            is_conflict = getattr(exc, "status_code", None) == 409 or "409" in str(exc)
+            if attempt == 0 and is_conflict:
+                # The registry already holds a record for this identity. It de-duplicates an
+                # identical re-submission on its side, so a 409 here means the content genuinely
+                # differs — bump source_version and retry as a new version. This is surfaced
+                # (printed + returned as version_bumped) rather than silently proliferating -vN.
                 payload = copy.deepcopy(payload)
                 ver = payload.get("source_version", "")
-                payload["source_version"] = _bump_version(ver)
+                bumped_version = _bump_version(ver)
+                payload["source_version"] = bumped_version
                 if "resource" in payload:
-                    payload["resource"]["source_version"] = payload["source_version"]  # type: ignore[index]
+                    payload["resource"]["source_version"] = bumped_version  # type: ignore[index]
+                print(f"  {title}  [conflict — retrying as version {bumped_version}]")
                 continue
             print(f"  ERROR: {title} — {exc}")
             return {"title": title, "source_local_id": source_local_id, "ok": False,
-                    "status": "error", "iri": "", "error": str(exc), "result": None}
+                    "status": "error", "iri": "", "error": str(exc), "result": None,
+                    "version_bumped": bumped_version}
     # Unreachable in practice (the loop returns on every path); defensive for mypy.
     return {"title": title, "source_local_id": source_local_id, "ok": False,
-            "status": "error", "iri": "", "error": "submission failed after retry", "result": None}
+            "status": "error", "iri": "", "error": "submission failed after retry", "result": None,
+            "version_bumped": bumped_version}
 
 
 def _bump_version(ver: str) -> str:

--- a/tests/test_authoring_identity.py
+++ b/tests/test_authoring_identity.py
@@ -1,0 +1,140 @@
+"""A-3 / A-4: authoring identity must not silently duplicate or overwrite.
+
+A-4 — save() exposes ``mode`` so the create-only guard is reachable (a fresh run can refuse to
+touch records left by a previous session), and an upsert that replaces genuinely different content
+is reported (content_changed) rather than overwriting silently.
+
+A-3 — a registry 409 is detected by its status code, not by matching the string "409" anywhere in
+an error body, and the version bump it triggers is surfaced (printed + version_bumped) instead of
+silently proliferating -vN copies."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import ws as ws_module
+from battinfo.api import (
+    REGISTER_MODE_CREATE_ONLY,
+    REGISTER_MODE_UPSERT,
+    RegistryClientError,
+    _record_content_differs,
+    save_record,
+)
+
+EXAMPLE = ROOT / "src/battinfo/data/examples/cell-spec/A123__ANR26650M1-B.json"
+
+
+# ── A-4: content-change detection ─────────────────────────────────────────────
+def _write(path: Path, doc: dict) -> Path:
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+def test_record_content_differs_ignores_volatile_only_changes(tmp_path: Path) -> None:
+    base = {"specification": {"id": "x", "nominal_capacity": {"value": 2.5, "unit": "Ah"}}}
+    existing = _write(tmp_path / "a.json", {**base, "generated_at": "2026-01-01T00:00:00Z"})
+    same_but_newer = {**base, "generated_at": "2026-07-02T09:00:00Z"}
+    assert _record_content_differs(existing, same_but_newer) is False
+
+
+def test_record_content_differs_on_real_change(tmp_path: Path) -> None:
+    existing = _write(tmp_path / "a.json", {"specification": {"nominal_capacity": {"value": 2.5}}})
+    changed = {"specification": {"nominal_capacity": {"value": 3.0}}}
+    assert _record_content_differs(existing, changed) is True
+
+
+def test_record_content_differs_when_existing_missing(tmp_path: Path) -> None:
+    assert _record_content_differs(tmp_path / "nope.json", {"a": 1}) is True
+
+
+def test_save_record_reports_content_changed_on_upsert(tmp_path: Path) -> None:
+    doc = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    first = save_record(doc, source_root=tmp_path, mode=REGISTER_MODE_UPSERT, publish=False)
+    assert first["status"] == "created"
+    assert first["content_changed"] is False  # nothing was there before
+
+    # Re-save identical content: an idempotent upsert, not a meaningful overwrite.
+    again = save_record(doc, source_root=tmp_path, mode=REGISTER_MODE_UPSERT, publish=False)
+    assert again["status"] == "updated"
+    assert again["content_changed"] is False
+
+    # Change a value and upsert: the overwrite is flagged, not silent.
+    edited = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    edited.setdefault("properties", {})["nominal_capacity"] = {"value": 99.9, "unit": "Ah"}
+    changed = save_record(edited, source_root=tmp_path, mode=REGISTER_MODE_UPSERT, publish=False)
+    assert changed["status"] == "updated"
+    assert changed["content_changed"] is True
+
+
+def test_save_record_create_only_guard_is_reachable(tmp_path: Path) -> None:
+    doc = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    save_record(doc, source_root=tmp_path, mode=REGISTER_MODE_UPSERT, publish=False)
+    with pytest.raises(ValueError, match="already exists"):
+        save_record(doc, source_root=tmp_path, mode=REGISTER_MODE_CREATE_ONLY, publish=False)
+
+
+# ── A-3: 409 conflict handling ────────────────────────────────────────────────
+def _ok_result(iri: str = "iri-x") -> dict:
+    return {"status": "ok", "status_code": 200,
+            "response": {"status": "validated", "resources": [{"canonical_iri": iri}]}}
+
+
+def _payload() -> dict:
+    return {"source_version": "2026-07-02", "resource": {"source_version": "2026-07-02"}}
+
+
+def _run_do_submit(monkeypatch: pytest.MonkeyPatch, behavior) -> dict:
+    monkeypatch.setattr("battinfo.api.submit_publication_package", behavior)
+    return ws_module._do_submit(_payload(), "https://registry.example", "k", "Cell X")
+
+
+def test_conflict_bumps_version_and_surfaces_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str | None] = []
+    state = {"n": 0}
+
+    def behavior(payload, **kw):  # noqa: ANN001
+        state["n"] += 1
+        seen.append(payload.get("source_version"))
+        if state["n"] == 1:
+            raise RegistryClientError("Registry submission failed with HTTP 409: conflict",
+                                      status_code=409)
+        return _ok_result()
+
+    out = _run_do_submit(monkeypatch, behavior)
+    assert out["ok"] is True
+    assert out["version_bumped"] == "2026-07-02-v2"
+    assert seen == ["2026-07-02", "2026-07-02-v2"]  # retried once, with the bumped version
+
+
+def test_conflict_detected_by_status_code_not_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"n": 0}
+
+    def behavior(payload, **kw):  # noqa: ANN001
+        state["n"] += 1
+        if state["n"] == 1:
+            raise RegistryClientError("resource already exists", status_code=409)  # no "409" text
+        return _ok_result()
+
+    out = _run_do_submit(monkeypatch, behavior)
+    assert out["ok"] is True
+    assert out["version_bumped"] == "2026-07-02-v2"
+
+
+def test_non_conflict_error_does_not_bump(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"n": 0}
+
+    def behavior(payload, **kw):  # noqa: ANN001
+        state["n"] += 1
+        raise RegistryClientError("Registry submission failed with HTTP 422: invalid",
+                                  status_code=422)
+
+    out = _run_do_submit(monkeypatch, behavior)
+    assert out["ok"] is False
+    assert out["version_bumped"] is None
+    assert state["n"] == 1  # a non-conflict error is not retried


### PR DESCRIPTION
When a record's identity was reused, saving and submitting could quietly duplicate or overwrite data. Both paths now make that situation visible instead of resolving it silently.

The workspace save() method exposes a mode argument. It still defaults to updating an existing record in place, which is the normal edit-and-resave loop, but a caller can now pass create_only so that a fresh authoring run refuses to touch records left by a previous session rather than overwriting them. save_record additionally reports whether an in-place update actually changed the stored content, ignoring volatile timestamps, so a real overwrite is distinguishable from an idempotent re-save.

On the submission side, a registry conflict response is recognised by its HTTP status code rather than by matching digits in an error string, which avoids both false positives from unrelated text and missed conflicts when the code is not echoed in the message. When a conflict does lead to a new version, that outcome is printed and returned to the caller instead of silently producing another versioned copy.

New regression tests cover the content-change detection, the now-reachable create-only guard, and the conflict handling including status-code detection and the no-retry path for non-conflict errors. The full test suite passes.