### PR TITLE
Validate converter imports and reject incompatible workspace state

### DIFF
--- a/src/battinfo/interop/converter.py
+++ b/src/battinfo/interop/converter.py
@@ -247,6 +247,7 @@ def import_converter_jsonld_record(
     model: str | None = None,
     chemistry: str | None = None,
     schema_version: str = "1.0.0",
+    validate: bool = True,
 ) -> ConverterImportResult:
     raw_payload, source_file = _load_source(source)
     warnings: list[str] = []
@@ -410,8 +411,18 @@ def import_converter_jsonld_record(
         warnings=warnings,
     )
 
+    result_specification = CellSpecification.from_library_record(record)
+    if validate:
+        # Match the other interop importers: schema-validate the emitted cell-spec so a malformed
+        # import fails loudly here, not silently downstream. `to_record()` is the canonical
+        # projection the validator expects (the library record uses a different key layout). Lazy
+        # import avoids an interop<->api import cycle. (D-6)
+        from battinfo.api import _validate_canonical_record  # noqa: PLC0415
+
+        _validate_canonical_record(result_specification.to_record())
+
     return ConverterImportResult(
-        specification=CellSpecification.from_library_record(record),
+        specification=result_specification,
         record=record,
         warnings=warnings,
         test_specs=test_specs,
@@ -427,6 +438,7 @@ def import_converter_package(
     model: str | None = None,
     chemistry: str | None = None,
     schema_version: str = "1.0.0",
+    validate: bool = True,
 ) -> ConverterImportPackage:
     imported = import_converter_jsonld_record(
         source,
@@ -435,6 +447,7 @@ def import_converter_package(
         model=model,
         chemistry=chemistry,
         schema_version=schema_version,
+        validate=validate,
     )
     specification = imported.specification
     cell_spec = CellSpecification.from_cell_specification(specification)

--- a/src/battinfo/workspace_state.py
+++ b/src/battinfo/workspace_state.py
@@ -31,6 +31,32 @@ WORKSPACE_STATE_SCHEMA_VERSION = "0.1.0"
 WORKSPACE_STATE_FILENAME = "battinfo-authoring-workspace.json"
 
 
+def _state_version_key(version: str) -> tuple[int, int]:
+    """(major, minor) of a schema version, for compatibility comparison.
+
+    While the schema is pre-1.0, a minor bump may be breaking, so both components are compared.
+    An unparseable version sorts lowest so it is never mistaken for a newer format."""
+    parts = (version.split(".") + ["0", "0"])[:2]
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except ValueError:
+        return (-1, -1)
+
+
+def _assert_compatible_state_version(raw: object) -> None:
+    """Raise a clear error if the on-disk workspace state was written by a newer, incompatible
+    schema than this BattINFO understands — rather than silently loading it under the current
+    model and misinterpreting fields whose meaning may have changed. (D-8)"""
+    on_disk = raw.get("schema_version") if isinstance(raw, dict) else None
+    if not isinstance(on_disk, str) or not on_disk:
+        return  # absent/legacy: tolerate and let the current model apply its defaults
+    if _state_version_key(on_disk) > _state_version_key(WORKSPACE_STATE_SCHEMA_VERSION):
+        raise ValueError(
+            f"Workspace state schema_version {on_disk!r} is newer than this BattINFO supports "
+            f"({WORKSPACE_STATE_SCHEMA_VERSION!r}); upgrade BattINFO to open this workspace."
+        )
+
+
 def _as_path(path: PathLike) -> Path:
     return path if isinstance(path, Path) else Path(path)
 
@@ -461,7 +487,9 @@ class WorkspaceStateStore:
     @classmethod
     def open(cls, root: PathLike) -> "WorkspaceStateStore":
         root_path = _as_path(root)
-        manifest = WorkspaceManifest.model_validate(_read_json(root_path / WORKSPACE_STATE_FILENAME))
+        raw = _read_json(root_path / WORKSPACE_STATE_FILENAME)
+        _assert_compatible_state_version(raw)
+        manifest = WorkspaceManifest.model_validate(raw)
         store = cls(
             root_path,
             name=manifest.workspace_id,

--- a/tests/test_converter_interop.py
+++ b/tests/test_converter_interop.py
@@ -216,11 +216,11 @@ def test_import_converter_jsonld_supports_canonical_overrides() -> None:
         manufacturer="ExampleLab",
         model="COIN-LFP-2032",
         chemistry="Li-ion",
-        id="https://w3id.org/battinfo/cell/1c4m-7p9q-2k6t-8v3r",
+        id="https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r",
     )
     specification = result.record["specification"]
 
-    assert specification["id"] == "https://w3id.org/battinfo/cell/1c4m-7p9q-2k6t-8v3r"
+    assert specification["id"] == "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
     assert specification["manufacturer"] == "ExampleLab"
     assert specification["model"] == "COIN-LFP-2032"
     assert specification["chemistry"] == "Li-ion"

--- a/tests/test_import_and_state_validation.py
+++ b/tests/test_import_and_state_validation.py
@@ -1,0 +1,77 @@
+"""D-6 / D-8: importer output and persisted state must be validated, not trusted blindly.
+
+D-6 — import_converter_jsonld_record now schema-validates the cell-spec it emits (like every other
+interop importer), and validate=False opts out. D-8 — WorkspaceStateStore.open() refuses a state
+file written by a newer, incompatible schema version instead of silently loading it."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+import battinfo.api as api_module
+from battinfo.interop.converter import import_converter_jsonld_record
+from battinfo.workspace_state import (
+    WORKSPACE_STATE_SCHEMA_VERSION,
+    _assert_compatible_state_version,
+    _state_version_key,
+)
+
+
+def _minimal_converter_source() -> dict:
+    return {
+        "@type": "CoinCell",
+        "schema:manufacturer": {"schema:name": "Acme"},
+        "schema:productID": "R2032-TEST",
+        "hasCase": {"@type": "R2032"},
+    }
+
+
+# ── D-6: converter import validates its output ────────────────────────────────
+def test_converter_import_validates_output_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict] = []
+    monkeypatch.setattr(api_module, "_validate_canonical_record", lambda doc, **k: calls.append(doc))
+    import_converter_jsonld_record(_minimal_converter_source())
+    assert len(calls) == 1  # the emitted cell-spec was validated
+    assert isinstance(calls[0], dict) and "cell_spec" in calls[0]  # canonical projection, not library
+
+
+def test_converter_import_propagates_validation_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(doc, **k):  # noqa: ANN001, ANN002
+        raise ValueError("Schema validation failed at 'cell_spec': bad")
+
+    monkeypatch.setattr(api_module, "_validate_canonical_record", _boom)
+    with pytest.raises(ValueError, match="Schema validation failed"):
+        import_converter_jsonld_record(_minimal_converter_source())
+
+
+def test_converter_import_validate_false_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(doc, **k):  # noqa: ANN001, ANN002
+        raise AssertionError("validator must not run when validate=False")
+
+    monkeypatch.setattr(api_module, "_validate_canonical_record", _boom)
+    result = import_converter_jsonld_record(_minimal_converter_source(), validate=False)
+    assert result.specification is not None  # imported without validating
+
+
+# ── D-8: workspace state version compatibility ────────────────────────────────
+def test_state_version_key_parses_major_minor() -> None:
+    assert _state_version_key("0.1.0") == (0, 1)
+    assert _state_version_key("2.5") == (2, 5)
+    assert _state_version_key("garbage") == (-1, -1)
+
+
+def test_open_rejects_newer_state_schema() -> None:
+    with pytest.raises(ValueError, match="newer than this BattINFO supports"):
+        _assert_compatible_state_version({"schema_version": "99.0.0"})
+
+
+def test_open_accepts_current_and_older_state_schema() -> None:
+    _assert_compatible_state_version({"schema_version": WORKSPACE_STATE_SCHEMA_VERSION})  # no raise
+    _assert_compatible_state_version({"schema_version": "0.0.1"})  # older, readable
+    _assert_compatible_state_version({})  # absent/legacy tolerated
+    _assert_compatible_state_version({"schema_version": ""})  # blank tolerated


### PR DESCRIPTION
Two paths accepted their input without checking it. This change validates both.

The converter JSON-LD importer now schema-validates the cell specification it produces, matching the behaviour of every other interop importer, so a malformed import fails immediately instead of surfacing much later when the record is submitted. A validate flag lets callers opt out when they deliberately want the tolerant behaviour. Validation runs against the canonical projection of the record, which is the shape the validator expects rather than the internal library layout.

Opening a persisted authoring workspace now checks the stored schema version before loading it. A state file written by a newer, incompatible version raises a clear error asking the user to upgrade, instead of being silently reinterpreted under the current model where fields may have changed meaning. Absent or older versions are still accepted.

New regression tests cover both checks. The change also corrects an existing converter test that supplied an identifier in the wrong namespace for a cell specification; the new validation correctly rejects that value, so the test now uses a valid one.