### PR TITLE
Make the canonical cell-spec record lossless (keep the datasheet stru…

### DIFF
--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -1308,6 +1308,19 @@ class CellSpecification(BundleJsonModel):
             datasheet_revision=product.get("datasheet_revision"),
             cell_specification_id=cell_specification_id,
             properties=dict(record.get("properties", {})) if isinstance(record.get("properties"), Mapping) else {},
+            construction=copy.deepcopy(record.get("construction", {}))
+            if isinstance(record.get("construction"), Mapping)
+            else {},
+            positive_electrode=copy.deepcopy(record.get("positive_electrode")),
+            negative_electrode=copy.deepcopy(record.get("negative_electrode")),
+            electrolyte=copy.deepcopy(record.get("electrolyte")),
+            separator=copy.deepcopy(record.get("separator")),
+            housing=copy.deepcopy(record.get("housing"))
+            if record.get("housing") is not None
+            else _housing_from_coin_hardware(record.get("coin_hardware")),
+            specification_comment=[str(item) for item in record.get("specification_comment", [])]
+            if isinstance(record.get("specification_comment"), list)
+            else [],
             bibliography=dict(record.get("bibliography", {}))
             if isinstance(record.get("bibliography"), Mapping)
             else {},
@@ -1408,6 +1421,24 @@ class CellSpecification(BundleJsonModel):
             record["bibliography"] = dict(self.bibliography)
         if self.comment:
             record["notes"] = list(self.comment)
+        # Datasheet structure lives at the top level of the canonical record (the schema already
+        # defines these siblings of `cell_spec`). Emitting it here makes to_record()/from_record()
+        # lossless — previously the whole electrode/electrolyte/separator/housing datasheet was
+        # silently dropped on save (the "electrode-drop" data-loss bug).
+        if self.construction:
+            record["construction"] = copy.deepcopy(self.construction)
+        if self.positive_electrode is not None:
+            record["positive_electrode"] = self.positive_electrode.model_dump(mode="json", exclude_none=True)
+        if self.negative_electrode is not None:
+            record["negative_electrode"] = self.negative_electrode.model_dump(mode="json", exclude_none=True)
+        if self.electrolyte is not None:
+            record["electrolyte"] = self.electrolyte.model_dump(mode="json", exclude_none=True)
+        if self.separator is not None:
+            record["separator"] = self.separator.model_dump(mode="json", exclude_none=True)
+        if self.housing is not None:
+            record["housing"] = self.housing.model_dump(mode="json", exclude_none=True)
+        if self.specification_comment:
+            record["specification_comment"] = list(self.specification_comment)
         return record_to_snake_aliases(record)
 
     # ── Datasheet "library" record format (merged from the former CellSpecification) ──

--- a/src/battinfo/data/schemas/cell-spec.schema.json
+++ b/src/battinfo/data/schemas/cell-spec.schema.json
@@ -300,6 +300,12 @@
         "type": "string"
       }
     },
+    "specification_comment": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "editorial": {
       "type": "object",
       "description": "Internal editorial metadata — review status and curation notes. Ignored by the publish pipeline; not forwarded to the registry semantic payload.",

--- a/src/battinfo/data/schemas/modules/components/current-collector.schema.json
+++ b/src/battinfo/data/schemas/modules/components/current-collector.schema.json
@@ -5,9 +5,6 @@
   "description": "Current collector material and quantitative properties.",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "name"
-  ],
   "properties": {
     "name": {
       "type": "string",

--- a/src/battinfo/data/schemas/modules/components/material-component.schema.json
+++ b/src/battinfo/data/schemas/modules/components/material-component.schema.json
@@ -27,6 +27,10 @@
     "product_id": {
       "type": "string"
     },
+    "molecular_formula": {
+      "type": "string",
+      "description": "Optional chemical formula of the material (e.g. 'LiFePO4')."
+    },
     "property": {
       "$ref": "../common/quantitative-properties.schema.json"
     },

--- a/tests/test_record_roundtrip.py
+++ b/tests/test_record_roundtrip.py
@@ -1,0 +1,90 @@
+"""Phase 1a: the canonical record serialization must be LOSSLESS.
+
+Previously CellSpecification.to_record() dropped the entire datasheet structure (electrodes,
+electrolyte, separator, housing, construction) — the "electrode-drop" data-loss bug: authoring a
+rich cell spec and saving it silently discarded the structure on disk. These tests pin that
+to_record()/from_record() now round-trip the full structure and that the emitted record still
+validates against the canonical schema."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import validate_record
+from battinfo.bundle import CellSpecification
+
+_STRUCTURE = ("positive_electrode", "negative_electrode", "electrolyte", "separator", "housing")
+_DETAILED = sorted((ROOT / "src/battinfo/data/examples/cell-spec/research").glob("*detailed*.json"))
+
+
+@pytest.mark.parametrize("path", _DETAILED, ids=lambda p: p.name)
+def test_canonical_roundtrip_is_lossless_and_valid(path: Path) -> None:
+    spec = CellSpecification.from_path(path)  # auto-detects canonical vs library
+    rec1 = spec.to_record()
+
+    # Every structure component the spec carries must survive serialization (not be dropped).
+    present = [k for k in _STRUCTURE if getattr(spec, k) is not None] + (
+        ["construction"] if spec.construction else []
+    )
+    for key in present:
+        assert key in rec1, f"{path.name}: to_record dropped {key!r}"
+
+    # The emitted canonical record validates.
+    report = validate_record(rec1)
+    assert report.ok, f"{path.name}: {[i.message for i in report.errors][:3]}"
+
+    # from_record → to_record is idempotent (no drift, no loss) at the record level.
+    rec2 = CellSpecification.from_record(rec1).to_record()
+    assert rec1 == rec2, f"{path.name}: canonical round-trip is not idempotent"
+
+
+def test_detailed_fixtures_actually_carry_structure() -> None:
+    # Guard against the round-trip test passing vacuously because no fixture has structure.
+    assert _DETAILED, "no detailed example fixtures found"
+    any_structure = any(
+        any(k in json.loads(p.read_text(encoding="utf-8")) for k in _STRUCTURE) for p in _DETAILED
+    )
+    assert any_structure, "no detailed fixture carries datasheet structure"
+
+
+def test_inline_component_schema_reconciled_with_model() -> None:
+    # The inline datasheet structure is strictly validated. Pins the component-schema reconciliation:
+    # a material component carrying molecular_formula, and a current_collector with no name, are both
+    # valid — the CellSpecification models allow them, and the schemas now match the models.
+    base = json.loads(
+        next(p for p in _DETAILED if "cell_spec" in json.loads(p.read_text(encoding="utf-8"))).read_text(
+            encoding="utf-8"
+        )
+    )
+    base["positive_electrode"] = {
+        "coating": {"component": {"active_material": [{"name": "LFP", "molecular_formula": "LiFePO4"}]}},
+        "current_collector": {"manufacturer": "Acme"},  # deliberately no 'name' (optional in the model)
+    }
+    report = validate_record(base)
+    assert report.ok, [i.message for i in report.errors][:5]
+
+
+def test_electrode_drop_regression() -> None:
+    # The specific bug: a spec with electrodes must not lose them through canonical serialization.
+    rich = next(
+        p for p in _DETAILED if "positive_electrode" in json.loads(p.read_text(encoding="utf-8"))
+    )
+    spec = CellSpecification.from_path(rich)
+    assert spec.positive_electrode is not None and spec.electrolyte is not None  # fixture sanity
+
+    rec = spec.to_record()
+    assert "positive_electrode" in rec and "electrolyte" in rec  # not dropped on save
+
+    reloaded = CellSpecification.from_record(rec)
+    assert reloaded.positive_electrode is not None  # not dropped on load
+    # byte-lossless on the electrode subtree
+    src = json.loads(rich.read_text(encoding="utf-8"))
+    assert json.dumps(rec["positive_electrode"], sort_keys=True) == json.dumps(
+        src["positive_electrode"], sort_keys=True
+    )


### PR DESCRIPTION
Saving a cell specification serialised it to the canonical record via to_record(), which dropped the entire datasheet structure — the electrodes, electrolyte, separator, housing, and construction. A richly described cell lost that information the moment it was written to disk, and from_record() could never read it back.

to_record() now emits the full structure at the top level of the record, where the schema already defines those fields, and from_record() reads it back, so the model-to-record round-trip is lossless. A specification_comment field is added to the record schema for the same reason.

Emitting the structure means it is now validated against the inline component schemas — which turned out to be stricter than the models that produce the data. Two are reconciled so the schema matches the model: a material component may carry a molecular formula, and a current collector's name is optional.

New tests cover the round-trip over the detailed example cells, an electrode-drop regression, and a check that the reconciled component fields validate. The full test suite passes.