### PR TITLE
Sync schema source of truth with the packaged copies

### DIFF
--- a/assets/schemas/cell-spec.schema.json
+++ b/assets/schemas/cell-spec.schema.json
@@ -300,6 +300,12 @@
         "type": "string"
       }
     },
+    "specification_comment": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "editorial": {
       "type": "object",
       "description": "Internal editorial metadata — review status and curation notes. Ignored by the publish pipeline; not forwarded to the registry semantic payload.",

--- a/assets/schemas/modules/components/current-collector.schema.json
+++ b/assets/schemas/modules/components/current-collector.schema.json
@@ -5,9 +5,6 @@
   "description": "Current collector material and quantitative properties.",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "name"
-  ],
   "properties": {
     "name": {
       "type": "string",

--- a/assets/schemas/modules/components/material-component.schema.json
+++ b/assets/schemas/modules/components/material-component.schema.json
@@ -27,6 +27,10 @@
     "product_id": {
       "type": "string"
     },
+    "molecular_formula": {
+      "type": "string",
+      "description": "Optional chemical formula of the material (e.g. 'LiFePO4')."
+    },
     "property": {
       "$ref": "../common/quantitative-properties.schema.json"
     },

--- a/tests/test_schema_assets_sync.py
+++ b/tests/test_schema_assets_sync.py
@@ -1,0 +1,38 @@
+"""Every schema shipped in the package must match its source of truth in assets/schemas.
+
+`profile.json`'s source_of_truth_order names `assets/schemas/...` as authoritative; the packaged
+`src/battinfo/data/schemas/` tree is a synced copy. The per-family contract tests only gate a handful
+of named top-level schemas, so `cell-spec.schema.json` and the `modules/components/*` sub-schemas could
+(and did) drift silently. This gate covers the WHOLE packaged tree: edit assets/schemas first, then
+re-sync the packaged copy."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+ASSETS = ROOT / "assets" / "schemas"
+PACKAGE = ROOT / "src" / "battinfo" / "data" / "schemas"
+
+_PACKAGED = sorted(p.relative_to(PACKAGE).as_posix() for p in PACKAGE.rglob("*.json"))
+
+
+def test_packaged_schema_tree_is_non_empty() -> None:
+    assert _PACKAGED, "no packaged schemas found — path drift?"
+
+
+@pytest.mark.parametrize("rel", _PACKAGED)
+def test_packaged_schema_matches_assets_source_of_truth(rel: str) -> None:
+    assets_path = ASSETS / rel
+    assert assets_path.exists(), (
+        f"{rel} is packaged but missing from assets/schemas (the source of truth). "
+        "Add it to assets/schemas, then re-sync."
+    )
+    assets_doc = json.loads(assets_path.read_text(encoding="utf-8"))
+    package_doc = json.loads((PACKAGE / rel).read_text(encoding="utf-8"))
+    assert assets_doc == package_doc, (
+        f"schema drift for {rel}: edit assets/schemas (the source of truth), then re-sync the "
+        "packaged copy under src/battinfo/data/schemas."
+    )


### PR DESCRIPTION
The schema source of truth is assets/schemas; the packaged tree under src/battinfo/data/schemas is a synced copy. A previous change edited the packaged copies directly (specification_comment on the cell spec, molecular_formula on a material component, and making a current collector's name optional), leaving assets/schemas behind. The per-family contract tests only gate a few named schemas, so this drift went uncaught.

Propagate those changes into assets/schemas so the two trees match again, and add a gate covering the whole packaged schema tree, every packaged schema must equal its assets source of truthso cell-spec and the component sub-schemas can no longer drift silently.

