### PR TITLE
Separate a draft cell spec from a publish-ready one

### DIFF
--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -1395,9 +1395,53 @@ class CellSpecification(BundleJsonModel):
             comment=["Generated from the linked CellSpecification."],
         )
 
+    # ── Draft vs. publish-ready ──────────────────────────────────────────────────
+    # The model is deliberately tolerant to construct — importers build it from arbitrary external
+    # data, and a GUI/notebook fills it in incrementally, so a half-filled spec is a valid *draft*.
+    # Publish-readiness — the strictness the former input DTOs enforced at construction time — is a
+    # policy applied here, at finalize(), NOT baked into the field types. One model therefore serves
+    # both interactive drafting and strict publishing.
+    _REQUIRED_FOR_PUBLISH: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("id", "id (mint one via publish() or build_publication_package())"),
+        ("name", "name"),
+        ("manufacturer", "manufacturer"),
+        ("model", "model"),
+        ("format", "format"),
+        ("chemistry", "chemistry"),
+    )
+
+    def publish_readiness_problems(self) -> list[str]:
+        """The reasons this spec is not yet publish-ready (empty list == ready).
+
+        A field counts as unset if it is None, blank, or the ``"unknown"`` placeholder that tolerant
+        construction leaves on ``format``/``chemistry``."""
+        problems: list[str] = []
+        for field, label in self._REQUIRED_FOR_PUBLISH:
+            value = getattr(self, field)
+            if value is None or (isinstance(value, str) and value.strip() in {"", "unknown"}):
+                problems.append(label)
+        return problems
+
+    def is_publishable(self) -> bool:
+        """True when every field required to publish is set (never raises — for a GUI/CLI check)."""
+        return not self.publish_readiness_problems()
+
+    def finalize(self) -> "CellSpecification":
+        """Assert publish-readiness and return self, so ``spec.finalize().to_record()`` reads cleanly.
+
+        Raises listing every still-missing field at once. A draft is valid to hold and to persist via
+        ``model_dump``; ``finalize()`` is the gate it must pass to become a published record."""
+        problems = self.publish_readiness_problems()
+        if problems:
+            raise ValueError("CellSpecification is not publish-ready; set: " + ", ".join(problems))
+        return self
+
     def to_record(self) -> dict[str, Any]:
         if self.id is None:
-            raise ValueError("CellSpecification.id is required before serialization. Use battinfo.build_publication_package(...) or battinfo.publish(...) to finalize IDs.")
+            raise ValueError(
+                "CellSpecification has no id yet (it is still a draft). Mint one via publish() or "
+                "build_publication_package(); call finalize() to check everything needed to publish."
+            )
         if self.name is None:
             raise ValueError("CellSpecification.name is required before serialization.")
         record: dict[str, Any] = {

--- a/tests/test_draft_finalize.py
+++ b/tests/test_draft_finalize.py
@@ -1,0 +1,63 @@
+"""PR D: draft vs. publish-ready.
+
+The CellSpecification model is tolerant to construct (a half-filled spec is a valid draft — this is
+what lets importers build it from arbitrary data and a GUI hold work-in-progress). Publish-readiness
+is a POLICY applied at finalize()/is_publishable(), not baked into the field types. These tests pin
+that separation, which is the foundation for folding the strict input DTOs onto the one model."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.bundle import CellSpecification
+
+
+def test_draft_constructs_and_is_not_publishable() -> None:
+    draft = CellSpecification(manufacturer="Acme")  # half-filled, no id
+    assert draft.is_publishable() is False
+    problems = draft.publish_readiness_problems()
+    # every unset required field is reported at once (manufacturer IS set, so it is not listed)
+    assert any(p.startswith("id") for p in problems)
+    assert "model" in problems and "format" in problems and "chemistry" in problems
+    assert "manufacturer" not in problems
+
+
+def test_finalize_raises_listing_all_missing_fields() -> None:
+    draft = CellSpecification(manufacturer="Acme")
+    with pytest.raises(ValueError, match="not publish-ready") as exc:
+        draft.finalize()
+    msg = str(exc.value)
+    assert "model" in msg and "chemistry" in msg  # aggregated, not one-at-a-time
+
+
+def test_complete_spec_is_publishable_and_finalize_returns_self() -> None:
+    spec = CellSpecification(
+        id="https://w3id.org/battinfo/spec/aaaa-bbbb-cccc-dddd", name="Acme X",
+        manufacturer="Acme", model="X", format="coin", chemistry="Li-ion",
+    )
+    assert spec.is_publishable() is True
+    assert spec.finalize() is spec  # chainable: spec.finalize().to_record()
+    assert "cell_spec" in spec.finalize().to_record()
+
+
+def test_tolerant_import_is_serializable_but_flagged_unpublishable() -> None:
+    # A record imported with an unknown chemistry (tolerant construction) must still serialize — so
+    # import->save round-trips — while is_publishable() flags it for the author to complete.
+    imported = CellSpecification(
+        id="https://w3id.org/battinfo/spec/bbbb-cccc-dddd-eeee", name="Imported",
+        manufacturer="X", model="Y", format="coin",  # chemistry defaults to "unknown"
+    )
+    assert "cell_spec" in imported.to_record()  # serialization does not require a known chemistry
+    assert imported.is_publishable() is False
+    assert imported.publish_readiness_problems() == ["chemistry"]
+
+
+def test_to_record_on_a_draft_raises_a_clear_draft_error() -> None:
+    draft = CellSpecification(manufacturer="Acme", model="X", format="coin", chemistry="Li-ion")
+    with pytest.raises(ValueError, match="draft"):
+        draft.to_record()  # no id yet


### PR DESCRIPTION
The model is deliberately tolerant to construct (importers build it from arbitrary data; a form fills it incrementally), so a half-filled spec is a valid draft. Publish-readiness — the strictness the input DTOs enforced at construction — is now a policy applied on demand via is_publishable(), publish_readiness_problems(), and finalize(), not baked into field types. Serialization still only requires id+name, so a tolerantly imported record still round-trips while being flagged not-yet-publishable. Lets one model serve both interactive drafting and strict publishing.