### PR TITLE
Build the cell-spec save record through the model, not a parallel dict

### DIFF
--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -2463,77 +2463,70 @@ def _assert_id_matches_uid(entity_id: str, uid: str) -> None:
         raise ValueError("Provided id and uid do not match.")
 
 
+_COMPONENT_SPEC_REF_NAMESPACES = {
+    "positive_electrode_spec_id": "electrode-spec",
+    "negative_electrode_spec_id": "electrode-spec",
+    "electrolyte_spec_id": "electrolyte-spec",
+    "separator_spec_id": "separator-spec",
+    "housing_spec_id": "housing-spec",
+}
+
+
 def _record_from_cell_spec(draft: CellSpecificationInput) -> dict[str, Any]:
+    from battinfo.bundle import CellSpecification, ProvenanceInfo  # noqa: PLC0415
+
+    # Mint / validate the canonical IRI — the one piece of canonicalization the model does not do.
     if draft.id is not None:
         if not CELL_SPEC_IRI_RE.fullmatch(draft.id):
             raise ValueError("cell spec id must match https://w3id.org/battinfo/spec/{uid}.")
         if draft.uid is not None:
-            dashed = _normalized_dashed_uid(draft.uid)
-            _assert_id_matches_uid(draft.id, dashed)
+            _assert_id_matches_uid(draft.id, _normalized_dashed_uid(draft.uid))
         entity_id = draft.id
-        _, dashed_uid = _iri_tail(entity_id)
     else:
-        dashed_uid = _normalized_dashed_uid(draft.uid)
-        entity_id = f"https://w3id.org/battinfo/spec/{dashed_uid}"
-
-    manufacturer_org = _org_value(draft.manufacturer)
-    manufacturer_name = manufacturer_org["name"] if manufacturer_org else str(draft.manufacturer)
-    record: dict[str, Any] = {
-        "schema_version": draft.schema_version,
-        "cell_spec": {
-            "id": entity_id,
-            "short_id": dashed_uid.replace("-", "")[:6],
-            "identifier": f"cell-spec:{dashed_uid}",
-            "name": f"{manufacturer_name} {draft.model_name}",
-            "model": draft.model_name,
-            "manufacturer": manufacturer_org or {"type": "Organization", "name": str(draft.manufacturer)},
-            "cell_format": draft.format,
-            "chemistry": draft.chemistry,
-        },
-        "properties": draft.specs,
-        "provenance": {
-            "source_type": draft.source_type,
-            "source_file": draft.source_file,
-            "source_url": draft.source_url,
-            "retrieved_at": draft.retrieved_at or _now_unix(),
-        },
-    }
-    citation = _citation_url_value(draft.citation)
-    if citation is not None:
-        record["provenance"]["citation"] = citation
-    if draft.positive_electrode_basis is not None:
-        record["cell_spec"]["positive_electrode_basis"] = draft.positive_electrode_basis
-    if draft.negative_electrode_basis is not None:
-        record["cell_spec"]["negative_electrode_basis"] = draft.negative_electrode_basis
-    if draft.size_code is not None:
-        record["cell_spec"]["size_code"] = draft.size_code
-    if draft.iec_code is not None:
-        record["cell_spec"]["iec_code"] = draft.iec_code
-    if draft.country_of_origin is not None:
-        record["cell_spec"]["country_of_origin"] = draft.country_of_origin
-    if draft.year is not None:
-        record["cell_spec"]["year"] = draft.year
-    if draft.datasheet_revision is not None:
-        record["cell_spec"]["datasheet_revision"] = draft.datasheet_revision
-    if draft.file_hash is not None:
-        record["provenance"]["file_hash"] = draft.file_hash
-    # Component-spec references (top-level siblings of the inline holders).
-    _COMPONENT_SPEC_REF_PATTERNS = {
-        "positive_electrode_spec_id": "electrode-spec",
-        "negative_electrode_spec_id": "electrode-spec",
-        "electrolyte_spec_id": "electrolyte-spec",
-        "separator_spec_id": "separator-spec",
-        "housing_spec_id": "housing-spec",
-    }
-    for field_name, namespace in _COMPONENT_SPEC_REF_PATTERNS.items():
+        entity_id = f"https://w3id.org/battinfo/spec/{_normalized_dashed_uid(draft.uid)}"
+    # Validate component-spec reference IRIs at the input boundary.
+    for field_name, namespace in _COMPONENT_SPEC_REF_NAMESPACES.items():
         value = getattr(draft, field_name)
-        if value is not None:
-            if not _component_iri_re(namespace).fullmatch(value):
-                raise ValueError(f"{field_name} must match https://w3id.org/battinfo/{namespace}/{{uid}}.")
-            record[field_name] = value
-    if draft.notes:
-        record["notes"] = list(draft.notes)
-    return record_to_snake_aliases(record)
+        if value is not None and not _component_iri_re(namespace).fullmatch(value):
+            raise ValueError(f"{field_name} must match https://w3id.org/battinfo/{namespace}/{{uid}}.")
+
+    org = _org_value(draft.manufacturer)
+    manufacturer_name = org["name"] if org else str(draft.manufacturer)
+    # Build the record through the one model (the source of truth) rather than hand-assembling a
+    # parallel canonical dict — to_record() is now the single serializer.
+    return CellSpecification(
+        schema_version=draft.schema_version,
+        id=entity_id,
+        name=f"{manufacturer_name} {draft.model_name}",
+        manufacturer=manufacturer_name,
+        manufacturer_id=(org or {}).get("id"),
+        model=draft.model_name,
+        format=draft.format,
+        chemistry=draft.chemistry,
+        product_type=draft.product_type,
+        positive_electrode_basis=draft.positive_electrode_basis,
+        negative_electrode_basis=draft.negative_electrode_basis,
+        positive_electrode_spec_id=draft.positive_electrode_spec_id,
+        negative_electrode_spec_id=draft.negative_electrode_spec_id,
+        electrolyte_spec_id=draft.electrolyte_spec_id,
+        separator_spec_id=draft.separator_spec_id,
+        housing_spec_id=draft.housing_spec_id,
+        size_code=draft.size_code,
+        iec_code=draft.iec_code,
+        country_of_origin=draft.country_of_origin,
+        year=draft.year,
+        datasheet_revision=draft.datasheet_revision,
+        properties=draft.specs,
+        source=ProvenanceInfo(
+            type=draft.source_type,
+            file=draft.source_file,
+            url=draft.source_url,
+            citation=_citation_url_value(draft.citation),
+            file_hash=draft.file_hash,
+            retrieved_at=draft.retrieved_at or _now_unix(),
+        ),
+        comment=list(draft.notes),
+    ).to_record()
 
 
 def _record_from_cell_instance(draft: CellInstanceInput) -> dict[str, Any]:

--- a/tests/test_cell_spec_input_routing.py
+++ b/tests/test_cell_spec_input_routing.py
@@ -1,0 +1,41 @@
+"""PR B (step A): the CellSpecificationInput save path builds its canonical record THROUGH the one
+model (CellSpecification.to_record), not a parallel hand-assembled dict. These pin that the routed
+builder preserves everything the input carries — including product_type, which the old hand-builder
+silently dropped — and still derives the id/short_id/identifier the same way."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import validate_record
+from battinfo.api import CellSpecificationInput, _record_from_cell_spec
+
+
+def test_routed_builder_preserves_all_fields_and_validates() -> None:
+    rec = _record_from_cell_spec(CellSpecificationInput(
+        uid="1c4m-7p9q-2k6t-8v3r", model_name="CR2032",
+        manufacturer={"name": "Energizer", "id": "https://w3id.org/battinfo/organization/1111-2222-3333-4444"},
+        format="coin", chemistry="Li-primary", product_type="commercial", size_code="R2032",
+        positive_electrode_spec_id="https://w3id.org/battinfo/electrode-spec/5555-6666-7777-8888",
+        specs={"nominal_capacity": {"value": 0.24, "unit": "Ah"}}, notes=["note"],
+    ))
+    assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
+    cs = rec["cell_spec"]
+    assert cs["manufacturer"]["id"] == "https://w3id.org/battinfo/organization/1111-2222-3333-4444"
+    assert cs["product_type"] == "commercial"  # regression: the hand-builder dropped product_type
+    assert rec["positive_electrode_spec_id"] == "https://w3id.org/battinfo/electrode-spec/5555-6666-7777-8888"
+    assert rec["notes"] == ["note"]
+
+
+def test_routed_builder_mints_id_short_id_and_identifier_from_uid() -> None:
+    rec = _record_from_cell_spec(CellSpecificationInput(
+        uid="1c4m-7p9q-2k6t-8v3r", model_name="X", manufacturer="Acme", format="coin", chemistry="Li-ion",
+    ))
+    cs = rec["cell_spec"]
+    assert cs["id"] == "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
+    assert cs["short_id"] == "1c4m7p"
+    assert cs["identifier"] == "cell-spec:1c4m-7p9q-2k6t-8v3r"
+    assert cs["name"] == "Acme X"


### PR DESCRIPTION
The cell-spec input builder hand-assembled its own canonical record dict — a second serializer alongside the model's to_record() that had drifted: it dropped product_type and emitted a null source_url the model omits. It now mints/validates the IRI and component-spec references at the input boundary (the one bit the model doesn't do), then builds a CellSpecification and returns to_record(). One serializer now; product_type is preserved. Tests pin field preservation and the id/short_id/identifier derivation.