### PR TITLE
Feat/route record builders through models

### DIFF
--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -2542,48 +2542,37 @@ def _record_from_cell_instance(draft: CellInstanceInput) -> dict[str, Any]:
         if not CELL_IRI_RE.fullmatch(draft.id):
             raise ValueError("cell-instance id must match https://w3id.org/battinfo/cell/{uid}.")
         if draft.uid is not None:
-            dashed = _normalized_dashed_uid(draft.uid)
-            _assert_id_matches_uid(draft.id, dashed)
+            _assert_id_matches_uid(draft.id, _normalized_dashed_uid(draft.uid))
         entity_id = draft.id
-        _, dashed_uid = _iri_tail(entity_id)
     else:
-        dashed_uid = _normalized_dashed_uid(draft.uid)
-        entity_id = f"https://w3id.org/battinfo/cell/{dashed_uid}"
+        entity_id = f"https://w3id.org/battinfo/cell/{_normalized_dashed_uid(draft.uid)}"
 
-    dataset_ids = list(dict.fromkeys([*draft.dataset_ids, *( [draft.dataset_id] if draft.dataset_id else [])]))
-    record: dict[str, Any] = {
-        "schema_version": draft.schema_version,
-        "cell_instance": {
-            "id": entity_id,
-            "cell_spec_id": draft.cell_spec_id,
-            "short_id": dashed_uid.replace("-", "")[:6],
-        },
-        "provenance": {
-            "source_type": draft.source_type,
-            "retrieved_at": _to_unix_time(draft.retrieved_at) or _now_unix(),
-        },
-    }
-    if draft.serial_number is not None:
-        record["cell_instance"]["serial_number"] = draft.serial_number
-    if draft.batch_id is not None:
-        record["cell_instance"]["batch_id"] = draft.batch_id
+    manufactured_at: int | None = None
     if draft.manufactured_at is not None:
         manufactured_at = _to_unix_time(draft.manufactured_at)
         if manufactured_at is None:
             raise ValueError("manufactured_at must be a Unix timestamp or ISO datetime string.")
-        record["cell_instance"]["manufactured_at"] = manufactured_at
-    if draft.measured:
-        record["measured"] = draft.measured
-    if draft.source_url is not None:
-        record["provenance"]["source_url"] = draft.source_url
-    citation = _citation_url_value(draft.citation)
-    if citation is not None:
-        record["provenance"]["citation"] = citation
-    if dataset_ids:
-        record["datasets"] = [{"id": dataset_id, "role": "raw"} for dataset_id in dataset_ids]
-    if draft.notes:
-        record["notes"] = list(draft.notes)
-    return record
+    dataset_ids = list(dict.fromkeys([*draft.dataset_ids, *([draft.dataset_id] if draft.dataset_id else [])]))
+    from battinfo.bundle import CellInstance, ProvenanceInfo  # noqa: PLC0415
+
+    # Build the record through the one model (its to_record is the single serializer).
+    return CellInstance(
+        schema_version=draft.schema_version,
+        id=entity_id,
+        cell_spec_id=draft.cell_spec_id,
+        serial_number=draft.serial_number,
+        batch_id=draft.batch_id,
+        manufactured_at=manufactured_at,
+        measured=draft.measured or {},
+        dataset_ids=dataset_ids,
+        source=ProvenanceInfo(
+            type=draft.source_type,
+            url=draft.source_url,
+            citation=_citation_url_value(draft.citation),
+            retrieved_at=_to_unix_time(draft.retrieved_at) or _now_unix(),
+        ),
+        comment=list(draft.notes),
+    ).to_record()
 
 
 def _record_from_dataset(draft: DatasetInput) -> dict[str, Any]:

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -2712,65 +2712,45 @@ def _record_from_test(draft: TestInput) -> dict[str, Any]:
         if not TEST_IRI_RE.fullmatch(draft.id):
             raise ValueError("test id must match https://w3id.org/battinfo/test/{uid}.")
         if draft.uid is not None:
-            dashed = _normalized_dashed_uid(draft.uid)
-            _assert_id_matches_uid(draft.id, dashed)
+            _assert_id_matches_uid(draft.id, _normalized_dashed_uid(draft.uid))
         entity_id = draft.id
-        _, dashed_uid = _iri_tail(entity_id)
     else:
-        dashed_uid = _normalized_dashed_uid(draft.uid)
-        entity_id = f"https://w3id.org/battinfo/test/{dashed_uid}"
+        entity_id = f"https://w3id.org/battinfo/test/{_normalized_dashed_uid(draft.uid)}"
 
-    record: dict[str, Any] = {
-        "schema_version": draft.schema_version,
-        "test": {
-            "id": entity_id,
-            "short_id": dashed_uid.replace("-", "")[:6],
-            "identifier": f"test:{dashed_uid}",
-            "cell_id": draft.cell_id,
-            "name": draft.name,
-            "kind": draft.kind,
-        },
-        "provenance": {
-            "source_type": draft.source_type,
-            "retrieved_at": _to_unix_time(draft.retrieved_at) or _now_unix(),
-        },
-    }
-    if draft.description is not None:
-        record["test"]["description"] = draft.description
-    if draft.protocol_id is not None:
-        record["test"]["protocol_id"] = draft.protocol_id
-    if draft.status is not None:
-        record["test"]["status"] = draft.status
-    if draft.protocol_name is not None:
-        record["test"]["protocol_name"] = draft.protocol_name
-    if draft.protocol_url is not None:
-        record["test"]["protocol_url"] = draft.protocol_url
-    if draft.instrument_name is not None:
-        record["test"]["instrument_name"] = draft.instrument_name
-    if draft.started_at is not None:
-        started_at = _to_unix_time(draft.started_at)
-        if started_at is None:
-            raise ValueError("started_at must be a Unix timestamp or ISO datetime string.")
-        record["test"]["started_at"] = started_at
-    if draft.ended_at is not None:
-        ended_at = _to_unix_time(draft.ended_at)
-        if ended_at is None:
-            raise ValueError("ended_at must be a Unix timestamp or ISO datetime string.")
-        record["test"]["ended_at"] = ended_at
-    if draft.dataset_ids:
-        record["test"]["dataset_ids"] = list(dict.fromkeys(draft.dataset_ids))
-    if draft.source_url is not None:
-        record["provenance"]["source_url"] = draft.source_url
-    citation = _citation_url_value(draft.citation)
-    if citation is not None:
-        record["provenance"]["citation"] = citation
-    if draft.source_file is not None:
-        record["provenance"]["source_file"] = draft.source_file
-    if draft.workflow_version is not None:
-        record["provenance"]["workflow_version"] = draft.workflow_version
-    if draft.notes:
-        record["notes"] = list(draft.notes)
-    return record_to_snake_aliases(record)
+    started_at = _to_unix_time(draft.started_at) if draft.started_at is not None else None
+    if draft.started_at is not None and started_at is None:
+        raise ValueError("started_at must be a Unix timestamp or ISO datetime string.")
+    ended_at = _to_unix_time(draft.ended_at) if draft.ended_at is not None else None
+    if draft.ended_at is not None and ended_at is None:
+        raise ValueError("ended_at must be a Unix timestamp or ISO datetime string.")
+    from battinfo.bundle import ProtocolInfo, ProvenanceInfo, Test  # noqa: PLC0415
+
+    # Build the record through the one model (its to_record maps test_type/cell_instance_id/
+    # instrument/protocol back to the record's kind/cell_id/instrument_name/protocol_* fields).
+    return Test(
+        schema_version=draft.schema_version,
+        id=entity_id,
+        cell_instance_id=draft.cell_id,
+        name=draft.name,
+        test_type=draft.kind,
+        description=draft.description,
+        protocol_id=draft.protocol_id,
+        status=draft.status,
+        protocol=ProtocolInfo(name=draft.protocol_name, url=draft.protocol_url),
+        instrument=draft.instrument_name,
+        started_at=started_at,
+        ended_at=ended_at,
+        dataset_ids=list(dict.fromkeys(draft.dataset_ids)),
+        source=ProvenanceInfo(
+            type=draft.source_type,
+            url=draft.source_url,
+            citation=_citation_url_value(draft.citation),
+            file=draft.source_file,
+            workflow_version=draft.workflow_version,
+            retrieved_at=_to_unix_time(draft.retrieved_at) or _now_unix(),
+        ),
+        comment=list(draft.notes),
+    ).to_record()
 
 
 def _record_from_test_protocol(draft: TestSpecInput) -> dict[str, Any]:

--- a/tests/test_record_builder_routing.py
+++ b/tests/test_record_builder_routing.py
@@ -16,6 +16,7 @@ from battinfo.api import (
     TestInput,
     _record_from_cell_instance,
     _record_from_test,
+    _to_unix_time,
 )
 
 _SPEC = "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
@@ -31,7 +32,7 @@ def test_cell_instance_routes_through_model_and_validates() -> None:
     assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
     ci = rec["cell_instance"]
     assert ci["cell_spec_id"] == _SPEC and ci["serial_number"] == "FAC-002" and ci["batch_id"] == "B1"
-    assert ci["manufactured_at"] == 1642201200  # ISO string converted to unix, as before
+    assert ci["manufactured_at"] == _to_unix_time("2022-01-15")  # ISO string converted to unix
     assert rec["datasets"] == [{"id": _DS, "role": "raw"}]
     assert rec["measured"] == {"mass": {"value": 45, "unit": "g"}}
 
@@ -72,5 +73,6 @@ def test_test_routes_through_model_mapping_fields_and_validates() -> None:
     assert t["cell_id"] == "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
     assert t["kind"] == "capacity_check" and t["instrument_name"] == "Maccor"
     assert t["protocol_name"] == "CC discharge C/5" and t["protocol_url"] == "https://x/proto"
-    assert t["started_at"] == 1643670000 and t["ended_at"] == 1643756400  # ISO -> unix
+    assert t["started_at"] == _to_unix_time("2022-02-01")  # ISO -> unix
+    assert t["ended_at"] == _to_unix_time("2022-02-02")
     assert t["dataset_ids"] == [_DS]

--- a/tests/test_record_builder_routing.py
+++ b/tests/test_record_builder_routing.py
@@ -11,7 +11,12 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo import validate_record
-from battinfo.api import CellInstanceInput, _record_from_cell_instance
+from battinfo.api import (
+    CellInstanceInput,
+    TestInput,
+    _record_from_cell_instance,
+    _record_from_test,
+)
 
 _SPEC = "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
 _DS = "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x"
@@ -50,3 +55,22 @@ def test_cell_instance_mints_id_from_uid() -> None:
     rec = _record_from_cell_instance(CellInstanceInput(uid="3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC))
     assert rec["cell_instance"]["id"] == "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
     assert rec["cell_instance"]["short_id"] == "3m6k9t"
+
+
+def test_test_routes_through_model_mapping_fields_and_validates() -> None:
+    # The Test model names fields differently from the record (test_type/cell_instance_id/instrument/
+    # protocol); routing must map them back to kind/cell_id/instrument_name/protocol_* — byte-identically.
+    rec = _record_from_test(TestInput(
+        uid="5p7v-2n8k-4m3t-6q9r", cell_id="https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8",
+        name="Capacity check", kind="capacity_check",
+        protocol_id="https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+        protocol_name="CC discharge C/5", protocol_url="https://x/proto", status="completed",
+        instrument_name="Maccor", started_at="2022-02-01", ended_at="2022-02-02", dataset_ids=[_DS],
+    ))
+    assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
+    t = rec["test"]
+    assert t["cell_id"] == "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
+    assert t["kind"] == "capacity_check" and t["instrument_name"] == "Maccor"
+    assert t["protocol_name"] == "CC discharge C/5" and t["protocol_url"] == "https://x/proto"
+    assert t["started_at"] == 1643670000 and t["ended_at"] == 1643756400  # ISO -> unix
+    assert t["dataset_ids"] == [_DS]

--- a/tests/test_record_builder_routing.py
+++ b/tests/test_record_builder_routing.py
@@ -1,0 +1,52 @@
+"""PR B (step A), remaining entities: each *Input save builder builds its canonical record THROUGH
+its model's to_record(), not a parallel hand-assembled dict. Pins that routing preserves the fields
+and (where the model does more) aligns the DTO save path with what the object-first path already
+produces."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import validate_record
+from battinfo.api import CellInstanceInput, _record_from_cell_instance
+
+_SPEC = "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
+_DS = "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x"
+
+
+def test_cell_instance_routes_through_model_and_validates() -> None:
+    rec = _record_from_cell_instance(CellInstanceInput(
+        id="https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC,
+        serial_number="FAC-002", batch_id="B1", manufactured_at="2022-01-15",
+        measured={"mass": {"value": 45, "unit": "g"}}, dataset_ids=[_DS], notes=["n"],
+    ))
+    assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
+    ci = rec["cell_instance"]
+    assert ci["cell_spec_id"] == _SPEC and ci["serial_number"] == "FAC-002" and ci["batch_id"] == "B1"
+    assert ci["manufactured_at"] == 1642201200  # ISO string converted to unix, as before
+    assert rec["datasets"] == [{"id": _DS, "role": "raw"}]
+    assert rec["measured"] == {"mass": {"value": 45, "unit": "g"}}
+
+
+def test_cell_instance_save_path_now_matches_the_object_first_path() -> None:
+    # Routing aligns the two save paths: the DTO builder now emits the derived name the model already
+    # produces via Workspace.cell(), instead of silently omitting it.
+    from battinfo.bundle import CellInstance
+
+    rec = _record_from_cell_instance(CellInstanceInput(
+        uid="3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC, serial_number="FAC-001",
+    ))
+    model_direct = CellInstance(
+        id="https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC,
+        serial_number="FAC-001",
+    ).to_record()
+    assert rec["cell_instance"]["name"] == model_direct["cell_instance"]["name"] == "FAC-001"
+
+
+def test_cell_instance_mints_id_from_uid() -> None:
+    rec = _record_from_cell_instance(CellInstanceInput(uid="3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC))
+    assert rec["cell_instance"]["id"] == "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
+    assert rec["cell_instance"]["short_id"] == "3m6k9t"


### PR DESCRIPTION
The cell-instance and test input builders each hand-assembled a canonical record dict in parallel with their model's to_record(). Route both through their models: each still validates reference IRIs, mints the id, and converts timestamps at the input boundary, then builds the model and returns to_record(). cell-instance now emits the derived name the object-first path already produced; test's model↔record field mapping is verified byte-identical. The dataset and test-spec builders are left as-is — they're dominated by pre-processing (distribution/experiment assembly) the models don't duplicate, so they're better handled when their DTOs are retired. Adds routing regression tests.