### PR TITLE
Retire the CellInstanceInput and TestInput input classes; the models are the input

### DIFF
--- a/src/battinfo/__init__.py
+++ b/src/battinfo/__init__.py
@@ -1,10 +1,8 @@
 from battinfo._workspace import Workspace, q, quantity
 from battinfo.api import (
-    CellInstanceInput,
     DatasetInput,
     MaterialInput,
     MaterialSpecInput,
-    TestInput,
     TestProtocolInput,  # backward compat alias
     TestSpecInput,
     build_cell_spec_library_rdf,
@@ -280,13 +278,11 @@ __all__ = [
     "CurrentCollectorTab",
     "TableColumn",
     "TableSchema",
-    "CellInstanceInput",
     "DatasetInput",
     "MaterialSpecInput",
     "MaterialInput",
     "TestSpecInput",
     "TestProtocolInput",
-    "TestInput",
     "build_cell_spec_library_rdf",
     "build_index",
     "build_curated_cell_spec_submission",

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -19,7 +19,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from battinfo._jsonio import read_record_json as _load_json
 from battinfo._jsonio import write_json as _write_json
-from battinfo.bundle import BatteryTestType, CellSpecification
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
 from battinfo.canonical_aliases import record_to_snake_aliases
 from battinfo.entities import (
     COMPONENT_FAMILIES,
@@ -140,28 +140,6 @@ def _citation_url_value(citation: object = None, citation_doi: object = None) ->
 # provenance defaults. (The former ``CellDatasheetInput`` was likewise retired earlier.)
 
 
-class CellInstanceInput(BaseModel):
-    """Typed input for saving a new canonical cell-instance resource."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: str = "0.1.0"
-    id: str | None = None
-    uid: str | None = None
-    cell_spec_id: str
-    serial_number: str | None = None
-    batch_id: str | None = None
-    manufactured_at: int | str | None = None
-    measured: dict[str, Any] | None = None
-    source_type: Literal["measurement", "lab", "bms", "other"] = "measurement"
-    dataset_id: str | None = None
-    dataset_ids: list[str] = Field(default_factory=list)
-    source_url: str | None = None
-    citation: str | None = Field(default=None, validation_alias=AliasChoices("citation", "citation_doi"))
-    retrieved_at: int | str | None = None
-    notes: list[str] = Field(default_factory=list)
-
-
 class DatasetInput(BaseModel):
     """Typed input for saving a new canonical dataset resource."""
 
@@ -209,36 +187,6 @@ class DatasetInput(BaseModel):
     citation: str | None = Field(default=None, validation_alias=AliasChoices("citation", "citation_doi"))
     retrieved_at: int | None = None
     curated_by: str | None = None
-    notes: list[str] = Field(default_factory=list)
-
-
-class TestInput(BaseModel):
-    """Typed input for saving a new canonical test resource."""
-
-    model_config = ConfigDict(extra="forbid")
-    __test__ = False
-
-    schema_version: str = "0.1.0"
-    id: str | None = None
-    uid: str | None = None
-    cell_id: str
-    name: str
-    kind: TestKind
-    protocol_id: str | None = None
-    description: str | None = None
-    status: Literal["planned", "running", "completed", "aborted", "other"] | None = None
-    protocol_name: str | None = None
-    protocol_url: str | None = None
-    instrument_name: str | None = None
-    started_at: int | str | None = None
-    ended_at: int | str | None = None
-    dataset_ids: list[str] = Field(default_factory=list)
-    source_type: Literal["measurement", "lab", "simulation", "manual", "other"] = "measurement"
-    source_url: str | None = None
-    citation: str | None = Field(default=None, validation_alias=AliasChoices("citation", "citation_doi"))
-    source_file: str | None = None
-    retrieved_at: int | str | None = None
-    workflow_version: str | None = None
     notes: list[str] = Field(default_factory=list)
 
 
@@ -383,7 +331,7 @@ def template_cell_instance(
     uid: str | None = TEMPLATE_UID,
 ) -> dict[str, Any]:
     """Build a starter canonical cell-instance document for save workflows."""
-    draft = CellInstanceInput(
+    draft = CellInstance(
         uid=uid,
         cell_spec_id=cell_spec_id,
         source_type=source_type,
@@ -422,7 +370,7 @@ def template_test(
     dataset_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build a starter canonical test document for save workflows."""
-    draft = TestInput(
+    draft = Test(
         uid=uid,
         cell_id=cell_id,
         name=name,
@@ -2465,50 +2413,33 @@ def _record_from_cell_spec(spec: CellSpecification) -> dict[str, Any]:
     return finalized.to_record()
 
 
-def _record_from_cell_instance(draft: CellInstanceInput) -> dict[str, Any]:
-    if not CELL_SPEC_IRI_RE.fullmatch(draft.cell_spec_id):
+def _record_from_cell_instance(instance: CellInstance) -> dict[str, Any]:
+    if instance.cell_spec_id is None or not CELL_SPEC_IRI_RE.fullmatch(instance.cell_spec_id):
         raise ValueError("cell_spec_id must match https://w3id.org/battinfo/spec/{uid}.")
-    if draft.dataset_id is not None and not DATASET_IRI_RE.fullmatch(draft.dataset_id):
-        raise ValueError("dataset_id must match https://w3id.org/battinfo/dataset/{uid}.")
-    for dataset_id in draft.dataset_ids:
+    for dataset_id in instance.dataset_ids:
         if not DATASET_IRI_RE.fullmatch(dataset_id):
             raise ValueError("dataset_ids entries must match https://w3id.org/battinfo/dataset/{uid}.")
-
-    if draft.id is not None:
-        if not CELL_IRI_RE.fullmatch(draft.id):
+    if instance.id is not None:
+        if not CELL_IRI_RE.fullmatch(instance.id):
             raise ValueError("cell-instance id must match https://w3id.org/battinfo/cell/{uid}.")
-        if draft.uid is not None:
-            _assert_id_matches_uid(draft.id, _normalized_dashed_uid(draft.uid))
-        entity_id = draft.id
+        if instance.uid is not None:
+            _assert_id_matches_uid(instance.id, _normalized_dashed_uid(instance.uid))
+        entity_id = instance.id
     else:
-        entity_id = f"https://w3id.org/battinfo/cell/{_normalized_dashed_uid(draft.uid)}"
-
-    manufactured_at: int | None = None
-    if draft.manufactured_at is not None:
-        manufactured_at = _to_unix_time(draft.manufactured_at)
-        if manufactured_at is None:
+        entity_id = f"https://w3id.org/battinfo/cell/{_normalized_dashed_uid(instance.uid)}"
+    # Finalize a copy (mint the id, convert manufactured_at, apply save-time provenance defaults).
+    finalized = instance.model_copy(deep=True)
+    finalized.id = entity_id
+    if finalized.manufactured_at is not None:
+        converted = _to_unix_time(finalized.manufactured_at)
+        if converted is None:
             raise ValueError("manufactured_at must be a Unix timestamp or ISO datetime string.")
-    dataset_ids = list(dict.fromkeys([*draft.dataset_ids, *([draft.dataset_id] if draft.dataset_id else [])]))
-    from battinfo.bundle import CellInstance, ProvenanceInfo  # noqa: PLC0415
-
-    # Build the record through the one model (its to_record is the single serializer).
-    return CellInstance(
-        schema_version=draft.schema_version,
-        id=entity_id,
-        cell_spec_id=draft.cell_spec_id,
-        serial_number=draft.serial_number,
-        batch_id=draft.batch_id,
-        manufactured_at=manufactured_at,
-        measured=draft.measured or {},
-        dataset_ids=dataset_ids,
-        source=ProvenanceInfo(
-            type=draft.source_type,
-            url=draft.source_url,
-            citation=_citation_url_value(draft.citation),
-            retrieved_at=_to_unix_time(draft.retrieved_at) or _now_unix(),
-        ),
-        comment=list(draft.notes),
-    ).to_record()
+        finalized.manufactured_at = converted
+    if finalized.source.type is None:
+        finalized.source.type = "measurement"
+    if finalized.source.retrieved_at is None:
+        finalized.source.retrieved_at = _now_unix()
+    return finalized.to_record()
 
 
 def _record_from_dataset(draft: DatasetInput) -> dict[str, Any]:
@@ -2635,58 +2566,37 @@ def _record_from_dataset(draft: DatasetInput) -> dict[str, Any]:
     return record_to_snake_aliases(record)
 
 
-def _record_from_test(draft: TestInput) -> dict[str, Any]:
-    if not CELL_IRI_RE.fullmatch(draft.cell_id):
+def _record_from_test(test: Test) -> dict[str, Any]:
+    if test.cell_instance_id is None or not CELL_IRI_RE.fullmatch(test.cell_instance_id):
         raise ValueError("cell_id must match https://w3id.org/battinfo/cell/{uid}.")
-    if draft.protocol_id is not None and not TEST_PROTOCOL_IRI_RE.fullmatch(draft.protocol_id):
+    if test.protocol_id is not None and not TEST_PROTOCOL_IRI_RE.fullmatch(test.protocol_id):
         raise ValueError("protocol_id must match https://w3id.org/battinfo/spec/{uid}.")
-    for dataset_id in draft.dataset_ids:
+    for dataset_id in test.dataset_ids:
         if not DATASET_IRI_RE.fullmatch(dataset_id):
             raise ValueError("dataset_ids entries must match https://w3id.org/battinfo/dataset/{uid}.")
-
-    if draft.id is not None:
-        if not TEST_IRI_RE.fullmatch(draft.id):
+    if test.id is not None:
+        if not TEST_IRI_RE.fullmatch(test.id):
             raise ValueError("test id must match https://w3id.org/battinfo/test/{uid}.")
-        if draft.uid is not None:
-            _assert_id_matches_uid(draft.id, _normalized_dashed_uid(draft.uid))
-        entity_id = draft.id
+        if test.uid is not None:
+            _assert_id_matches_uid(test.id, _normalized_dashed_uid(test.uid))
+        entity_id = test.id
     else:
-        entity_id = f"https://w3id.org/battinfo/test/{_normalized_dashed_uid(draft.uid)}"
-
-    started_at = _to_unix_time(draft.started_at) if draft.started_at is not None else None
-    if draft.started_at is not None and started_at is None:
-        raise ValueError("started_at must be a Unix timestamp or ISO datetime string.")
-    ended_at = _to_unix_time(draft.ended_at) if draft.ended_at is not None else None
-    if draft.ended_at is not None and ended_at is None:
-        raise ValueError("ended_at must be a Unix timestamp or ISO datetime string.")
-    from battinfo.bundle import ProtocolInfo, ProvenanceInfo, Test  # noqa: PLC0415
-
-    # Build the record through the one model (its to_record maps test_type/cell_instance_id/
-    # instrument/protocol back to the record's kind/cell_id/instrument_name/protocol_* fields).
-    return Test(
-        schema_version=draft.schema_version,
-        id=entity_id,
-        cell_instance_id=draft.cell_id,
-        name=draft.name,
-        test_type=draft.kind,
-        description=draft.description,
-        protocol_id=draft.protocol_id,
-        status=draft.status,
-        protocol=ProtocolInfo(name=draft.protocol_name, url=draft.protocol_url),
-        instrument=draft.instrument_name,
-        started_at=started_at,
-        ended_at=ended_at,
-        dataset_ids=list(dict.fromkeys(draft.dataset_ids)),
-        source=ProvenanceInfo(
-            type=draft.source_type,
-            url=draft.source_url,
-            citation=_citation_url_value(draft.citation),
-            file=draft.source_file,
-            workflow_version=draft.workflow_version,
-            retrieved_at=_to_unix_time(draft.retrieved_at) or _now_unix(),
-        ),
-        comment=list(draft.notes),
-    ).to_record()
+        entity_id = f"https://w3id.org/battinfo/test/{_normalized_dashed_uid(test.uid)}"
+    # Finalize a copy (mint the id, convert timestamps, apply save-time provenance defaults).
+    finalized = test.model_copy(deep=True)
+    finalized.id = entity_id
+    for _time_field in ("started_at", "ended_at"):
+        value = getattr(finalized, _time_field)
+        if value is not None:
+            converted = _to_unix_time(value)
+            if converted is None:
+                raise ValueError(f"{_time_field} must be a Unix timestamp or ISO datetime string.")
+            setattr(finalized, _time_field, converted)
+    if finalized.source.type is None:
+        finalized.source.type = "measurement"
+    if finalized.source.retrieved_at is None:
+        finalized.source.retrieved_at = _now_unix()
+    return finalized.to_record()
 
 
 def _record_from_test_protocol(draft: TestSpecInput) -> dict[str, Any]:
@@ -2938,7 +2848,7 @@ def save_cell_spec(
 
 
 def save_cell_instance(
-    draft: CellInstanceInput | dict[str, Any] | PathLike,
+    draft: CellInstance | dict[str, Any] | PathLike,
     *,
     source_root: PathLike = DEFAULT_REGISTRATION_SOURCE_ROOT,
     mode: str = REGISTER_MODE_CREATE_ONLY,
@@ -2971,21 +2881,6 @@ def save_cell_instance(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    if isinstance(draft, CellInstanceBundle):
-        return save_record(
-            draft.to_record(),
-            source_root=source_root,
-            mode=mode,
-            duplicate_policy=duplicate_policy,
-            resolve_references=resolve_references,
-            publish=publish,
-            publish_root=publish_root,
-            build_jsonld=build_jsonld,
-            build_html=build_html,
-            validate=validate,
-            validation_policy=validation_policy,
-            dry_run=dry_run,
-        )
     if isinstance(draft, Mapping) and isinstance(draft.get("cell_instance"), Mapping):
         return save_record(
             dict(draft),
@@ -3001,8 +2896,8 @@ def save_cell_instance(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    draft_model = draft if isinstance(draft, CellInstanceInput) else CellInstanceInput.model_validate(draft)
-    record = _record_from_cell_instance(draft_model)
+    instance = draft if isinstance(draft, CellInstanceBundle) else CellInstanceBundle(**dict(draft))
+    record = _record_from_cell_instance(instance)
     return save_record(
         record,
         source_root=source_root,
@@ -3102,7 +2997,7 @@ def save_dataset(
 
 
 def save_test(
-    draft: TestInput | dict[str, Any] | PathLike,
+    draft: Test | dict[str, Any] | PathLike,
     *,
     source_root: PathLike = DEFAULT_REGISTRATION_SOURCE_ROOT,
     mode: str = REGISTER_MODE_CREATE_ONLY,
@@ -3135,21 +3030,6 @@ def save_test(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    if isinstance(draft, TestBundle):
-        return save_record(
-            draft.to_record(),
-            source_root=source_root,
-            mode=mode,
-            duplicate_policy=duplicate_policy,
-            resolve_references=resolve_references,
-            publish=publish,
-            publish_root=publish_root,
-            build_jsonld=build_jsonld,
-            build_html=build_html,
-            validate=validate,
-            validation_policy=validation_policy,
-            dry_run=dry_run,
-        )
     if isinstance(draft, Mapping) and isinstance(draft.get("test"), Mapping):
         return save_record(
             dict(draft),
@@ -3165,8 +3045,8 @@ def save_test(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    draft_model = draft if isinstance(draft, TestInput) else TestInput.model_validate(draft)
-    record = _record_from_test(draft_model)
+    test = draft if isinstance(draft, TestBundle) else TestBundle(**dict(draft))
+    record = _record_from_test(test)
     return save_record(
         record,
         source_root=source_root,
@@ -5459,7 +5339,6 @@ __all__ = [
     "RegistryError",
     "RegistryClientError",
     "RegistryTransientError",
-    "CellInstanceInput",
     "MaterialSpecInput",
     "MaterialInput",
     "create_material_spec",
@@ -5480,7 +5359,6 @@ __all__ = [
     "template_component_instance",
     "DatasetInput",
     "TestSpecInput",
-    "TestInput",
     "build_cell_spec_library_rdf",
     "build_index",
     "build_curated_cell_spec_submission",

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -1684,6 +1684,8 @@ class CellInstance(BundleJsonModel):
 
     kind: str = "CellInstance"
     id: str | None = None
+    # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
+    uid: str | None = Field(default=None, exclude=True, repr=False)
     name: str | None = None
     cell_spec_id: str | None = None
     cell_spec: CellSpecification | None = Field(default=None, exclude=True, repr=False)
@@ -1699,6 +1701,19 @@ class CellInstance(BundleJsonModel):
     comment: list[str] = Field(default_factory=list)
 
     def __init__(self, cell_spec: CellSpecification | None = None, /, **data: Any) -> None:
+        # Absorb the flat authoring/input shape (formerly CellInstanceInput).
+        if "notes" in data and "comment" not in data:
+            data["comment"] = data.pop("notes")
+        _dataset_id = data.pop("dataset_id", None)
+        if _dataset_id is not None:
+            data["dataset_ids"] = list(dict.fromkeys([*(data.get("dataset_ids") or []), _dataset_id]))
+        _flat_provenance = {
+            "source_type": "type", "source_name": "name", "source_file": "file", "source_url": "url",
+            "citation": "citation", "file_hash": "file_hash", "retrieved_at": "retrieved_at",
+            "workflow_version": "workflow_version",
+        }
+        if any(key in data for key in _flat_provenance) and "source" not in data:
+            data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
         if cell_spec is not None and "cell_spec" not in data and "cell_spec_id" not in data:
             data["cell_spec"] = cell_spec
         super().__init__(**data)
@@ -2158,6 +2173,8 @@ class Test(BundleJsonModel):
     kind: str = "Test"
     __test__ = False
     id: str | None = None
+    # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
+    uid: str | None = Field(default=None, exclude=True, repr=False)
     name: str | None = None
     test_type: BatteryTestType = Field(
         default=BatteryTestType.OTHER,
@@ -2180,6 +2197,26 @@ class Test(BundleJsonModel):
     comment: list[str] = Field(default_factory=list)
 
     def __init__(self, cell: CellInstance | None = None, /, **data: Any) -> None:
+        # Absorb the flat authoring/input shape (formerly TestInput).
+        if "cell_id" in data and "cell_instance_id" not in data:
+            data["cell_instance_id"] = data.pop("cell_id")
+        if "kind" in data and "test_type" not in data:
+            data["test_type"] = data.pop("kind")
+        if "instrument_name" in data and "instrument" not in data:
+            data["instrument"] = data.pop("instrument_name")
+        _protocol_name = data.pop("protocol_name", None)
+        _protocol_url = data.pop("protocol_url", None)
+        if (_protocol_name is not None or _protocol_url is not None) and "protocol" not in data:
+            data["protocol"] = {"name": _protocol_name, "url": _protocol_url}
+        if "notes" in data and "comment" not in data:
+            data["comment"] = data.pop("notes")
+        _flat_provenance = {
+            "source_type": "type", "source_name": "name", "source_file": "file", "source_url": "url",
+            "citation": "citation", "file_hash": "file_hash", "retrieved_at": "retrieved_at",
+            "workflow_version": "workflow_version",
+        }
+        if any(key in data for key in _flat_provenance) and "source" not in data:
+            data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
         if cell is not None and "cell" not in data and "cell_instance_id" not in data:
             data["cell"] = cell
         super().__init__(**data)

--- a/src/battinfo/cli.py
+++ b/src/battinfo/cli.py
@@ -8,9 +8,7 @@ import typer
 
 from battinfo._jsonio import write_json as _write_json_file
 from battinfo.api import (
-    CellInstanceInput,
     DatasetInput,
-    TestInput,
     TestSpecInput,
 )
 from battinfo.api import (
@@ -124,7 +122,7 @@ from battinfo.api import (
 from battinfo.api import (
     validate_staging_datasets as api_validate_staging_datasets,
 )
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellInstance, CellSpecification, Test
 from battinfo.demo import run_demo_pipeline, setup_demo_environment
 from battinfo.entities import ENTITY_KINDS
 from battinfo.ingest import build_ingest_workspace, inspect_ingest_root, publish_ingest_workspace, write_ingest_manifest
@@ -1957,17 +1955,16 @@ def save_cell_instance(
     policy_name = _check_validation_policy(validation_policy)
     try:
         if input_path is not None:
-            draft_obj: CellInstanceInput | dict[str, Any] | Path = input_path
+            draft_obj: CellInstance | dict[str, Any] | Path = input_path
         else:
             if not cell_spec_id:
                 raise ValueError("--cell-spec-id is required when --input is not provided.")
-            draft_obj = CellInstanceInput(
+            draft_obj = CellInstance(
                 uid=uid,
                 cell_spec_id=cell_spec_id,
                 serial_number=serial_number,
                 source_type=source_type,  # type: ignore[arg-type]
-                dataset_id=(dataset_id[0] if dataset_id else None),
-                dataset_ids=(dataset_id[1:] if len(dataset_id) > 1 else []),
+                dataset_ids=list(dataset_id),
             )
         payload = api_save_cell_instance(
             draft_obj,
@@ -2168,11 +2165,11 @@ def save_test(
     policy_name = _check_validation_policy(validation_policy)
     try:
         if input_path is not None:
-            draft_obj: TestInput | dict[str, Any] | Path = input_path
+            draft_obj: Test | dict[str, Any] | Path = input_path
         else:
             if not cell_id or not name:
                 raise ValueError("--cell-id and --name are required when --input is not provided.")
-            draft_obj = TestInput(
+            draft_obj = Test(
                 uid=uid,
                 cell_id=cell_id,
                 name=name,

--- a/src/battinfo/interop/battery_data_commons.py
+++ b/src/battinfo/interop/battery_data_commons.py
@@ -36,9 +36,7 @@ from typing import Any
 
 from battinfo.api import (
     UID_ALPHABET,
-    CellInstanceInput,
     DatasetInput,
-    TestInput,
     _normalized_dashed_uid,
     _record_from_cell_instance,
     _record_from_cell_spec,
@@ -47,7 +45,7 @@ from battinfo.api import (
     _validate_canonical_record,
     create_material_spec,
 )
-from battinfo.bundle import BatteryTestType, CellSpecification
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
 
 PathLike = str | Path
 
@@ -260,7 +258,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     )))
     cell_spec_id = cell_spec["cell_spec"]["id"]
 
-    cell_instance = _check(_record_from_cell_instance(CellInstanceInput(
+    cell_instance = _check(_record_from_cell_instance(CellInstance(
         uid=_uid("bdc", "cell-instance", bdc_id),
         cell_spec_id=cell_spec_id,
         serial_number=bdc_id,
@@ -274,7 +272,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     for flag, (kind, label) in _MEASUREMENT_KIND.items():
         if (record.get("available_measurements") or {}).get(flag):
             techniques.append(label)
-            tests.append(_check(_record_from_test(TestInput(
+            tests.append(_check(_record_from_test(Test(
                 uid=_uid("bdc", "test", bdc_id, flag),
                 cell_id=cell_uid,
                 name=label,

--- a/src/battinfo/interop/discovery.py
+++ b/src/battinfo/interop/discovery.py
@@ -41,9 +41,7 @@ from typing import Any
 
 from battinfo.api import (
     UID_ALPHABET,
-    CellInstanceInput,
     DatasetInput,
-    TestInput,
     _normalized_dashed_uid,
     _record_from_cell_instance,
     _record_from_cell_spec,
@@ -53,7 +51,7 @@ from battinfo.api import (
     create_component_spec,
     create_material_spec,
 )
-from battinfo.bundle import BatteryTestType, CellSpecification
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
 from battinfo.interop.protocols import _num
 
 PathLike = str | Path
@@ -310,7 +308,7 @@ class _Builder:
         )))
         cell_spec_id = cell_spec["cell_spec"]["id"]
 
-        cell_instance = self._check(_record_from_cell_instance(CellInstanceInput(
+        cell_instance = self._check(_record_from_cell_instance(CellInstance(
             uid=_uid("discovery", "cell-instance", seed),
             cell_spec_id=cell_spec_id,
             serial_number=cell_id,
@@ -322,7 +320,7 @@ class _Builder:
         test: dict[str, Any] | None = None
         dataset: dict[str, Any] | None = None
         if test_name is not None:
-            test = self._check(_record_from_test(TestInput(
+            test = self._check(_record_from_test(Test(
                 uid=_uid("discovery", "test", seed),
                 cell_id=cell_uid,
                 name=test_name,

--- a/src/battinfo/interop/solid_state_db.py
+++ b/src/battinfo/interop/solid_state_db.py
@@ -41,9 +41,7 @@ from typing import Any
 
 from battinfo.api import (
     UID_ALPHABET,
-    CellInstanceInput,
     MaterialSpecInput,
-    TestInput,
     _normalized_dashed_uid,
     _record_from_cell_instance,
     _record_from_cell_spec,
@@ -51,7 +49,7 @@ from battinfo.api import (
     _record_from_test,
     _validate_canonical_record,
 )
-from battinfo.bundle import BatteryTestType, CellSpecification
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
 
 PathLike = str | Path
 
@@ -294,7 +292,7 @@ def from_solid_state_db_row(
     ))
     cell_spec_id = cell_spec["cell_spec"]["id"]
 
-    cell_instance = _record_from_cell_instance(CellInstanceInput(
+    cell_instance = _record_from_cell_instance(CellInstance(
         uid=_uid_from_seed(seed, "cell-instance"),
         cell_spec_id=cell_spec_id,
         source_type="lab",
@@ -320,7 +318,7 @@ def from_solid_state_db_row(
             desc_parts.append(f"areal capacity {areal_cap} mAh/cm2")
         if cycle_life is not None:
             desc_parts.append(f"{int(cycle_life)} cycles")
-        test = _record_from_test(TestInput(
+        test = _record_from_test(Test(
             uid=_uid_from_seed(seed, "test", "clc"),
             cell_id=cell_id,
             name="Constant-current cycle-life test",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,9 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.api import (
-    CellInstanceInput,
     DatasetInput,
-    TestInput,
     TestProtocolInput,
     build_cell_spec_library_rdf,
     build_curated_cell_spec_submission,
@@ -48,7 +46,7 @@ from battinfo.api import (
     template_test_spec_draft,
     validate_staging_cell_spec,
 )
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellInstance, CellSpecification, Test
 from battinfo.validate import validate_references_report
 
 
@@ -608,7 +606,7 @@ def test_save_test_protocol_and_test_with_protocol_reference(tmp_path: Path) -> 
         mode="upsert",
     )
     cell = save_cell_instance(
-        CellInstanceInput(
+        CellInstance(
             uid="3m6k9t2p7x4h9nq8",
             cell_spec_id=cell_spec["id"],
         ),
@@ -627,7 +625,7 @@ def test_save_test_protocol_and_test_with_protocol_reference(tmp_path: Path) -> 
         mode="upsert",
     )
     test = save_test(
-        TestInput(
+        Test(
             uid="5p7v2n8k4m3t6q9r",
             cell_id=cell["id"],
             name="A123 cycle life run",
@@ -835,7 +833,7 @@ def test_save_resource_drafts_and_duplicate_policy(tmp_path: Path) -> None:
     assert exists_payload["status"] == "exists"
 
     cell_instance_payload = save_cell_instance(
-        CellInstanceInput(
+        CellInstance(
             uid="1f8r6v2k9p4m3t7x",
             cell_spec_id=cell_spec_payload["id"],
             serial_number="LAB-001",
@@ -847,7 +845,7 @@ def test_save_resource_drafts_and_duplicate_policy(tmp_path: Path) -> None:
     assert cell_instance_payload["status"] == "created"
 
     test_payload = save_test(
-        TestInput(
+        Test(
             uid="5p7v2n8k4m3t6q9r",
             cell_id=cell_instance_payload["id"],
             name="Duracell MN1500 baseline cycling",
@@ -914,7 +912,7 @@ def test_save_record_accepts_canonical_records_and_paths(tmp_path: Path) -> None
 def test_save_cell_instance_missing_reference_is_deferred_until_set_validation(tmp_path: Path) -> None:
     source_root = tmp_path / "examples"
     payload = save_cell_instance(
-        CellInstanceInput(
+        CellInstance(
             uid="eysh4h5sk4bxzkgg",
             cell_spec_id="https://w3id.org/battinfo/spec/pvn1-43h7-rm3e-mjqq",
             dataset_id="https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x",

--- a/tests/test_core_workflow.py
+++ b/tests/test_core_workflow.py
@@ -8,9 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.api import (
-    CellInstanceInput,
     DatasetInput,
-    TestInput,
     build_index,
     publish_batch,
     save_cell_instance,
@@ -18,7 +16,7 @@ from battinfo.api import (
     save_dataset,
     save_test,
 )
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellInstance, CellSpecification, Test
 
 
 def test_core_workflow_end_to_end(tmp_path: Path) -> None:
@@ -39,7 +37,7 @@ def test_core_workflow_end_to_end(tmp_path: Path) -> None:
         validation_policy="strict",
     )
     cell_instance = save_cell_instance(
-        CellInstanceInput(
+        CellInstance(
             uid="1f8r6v2k9p4m3t7x",
             cell_spec_id=cell_spec["id"],
             serial_number="SN-001",
@@ -50,7 +48,7 @@ def test_core_workflow_end_to_end(tmp_path: Path) -> None:
         validation_policy="strict",
     )
     test = save_test(
-        TestInput(
+        Test(
             uid="5p7v2n8k4m3t6q9r",
             cell_id=cell_instance["id"],
             name="MN1500 baseline cycling",

--- a/tests/test_record_builder_routing.py
+++ b/tests/test_record_builder_routing.py
@@ -12,19 +12,18 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo import validate_record
 from battinfo.api import (
-    CellInstanceInput,
-    TestInput,
     _record_from_cell_instance,
     _record_from_test,
     _to_unix_time,
 )
+from battinfo.bundle import CellInstance, Test
 
 _SPEC = "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
 _DS = "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x"
 
 
 def test_cell_instance_routes_through_model_and_validates() -> None:
-    rec = _record_from_cell_instance(CellInstanceInput(
+    rec = _record_from_cell_instance(CellInstance(
         id="https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC,
         serial_number="FAC-002", batch_id="B1", manufactured_at="2022-01-15",
         measured={"mass": {"value": 45, "unit": "g"}}, dataset_ids=[_DS], notes=["n"],
@@ -40,9 +39,7 @@ def test_cell_instance_routes_through_model_and_validates() -> None:
 def test_cell_instance_save_path_now_matches_the_object_first_path() -> None:
     # Routing aligns the two save paths: the DTO builder now emits the derived name the model already
     # produces via Workspace.cell(), instead of silently omitting it.
-    from battinfo.bundle import CellInstance
-
-    rec = _record_from_cell_instance(CellInstanceInput(
+    rec = _record_from_cell_instance(CellInstance(
         uid="3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC, serial_number="FAC-001",
     ))
     model_direct = CellInstance(
@@ -53,7 +50,7 @@ def test_cell_instance_save_path_now_matches_the_object_first_path() -> None:
 
 
 def test_cell_instance_mints_id_from_uid() -> None:
-    rec = _record_from_cell_instance(CellInstanceInput(uid="3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC))
+    rec = _record_from_cell_instance(CellInstance(uid="3m6k-9t2p-7x4h-9nq8", cell_spec_id=_SPEC))
     assert rec["cell_instance"]["id"] == "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
     assert rec["cell_instance"]["short_id"] == "3m6k9t"
 
@@ -61,7 +58,7 @@ def test_cell_instance_mints_id_from_uid() -> None:
 def test_test_routes_through_model_mapping_fields_and_validates() -> None:
     # The Test model names fields differently from the record (test_type/cell_instance_id/instrument/
     # protocol); routing must map them back to kind/cell_id/instrument_name/protocol_* — byte-identically.
-    rec = _record_from_test(TestInput(
+    rec = _record_from_test(Test(
         uid="5p7v-2n8k-4m3t-6q9r", cell_id="https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8",
         name="Capacity check", kind="capacity_check",
         protocol_id="https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",


### PR DESCRIPTION
Each canonical record type now has a single class that is both the validated source of truth and the object callers construct. Previously, saving a cell instance or a test went through a separate typed input class (CellInstanceInput, TestInput) whose fields largely duplicated the CellInstance and Test models. This change folds that flat authoring shape into the models themselves and removes the duplicate classes, completing the consolidation already applied to cell specifications.