### PR TITLE
Anchor timezone-naive timestamps to UTC in _to_unix_time

### DIFF
--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -481,9 +481,16 @@ def _to_unix_time(value: object) -> int | None:
         if txt.isdigit():
             return int(txt)
         try:
-            return int(datetime.fromisoformat(txt.replace("Z", "+00:00")).timestamp())
+            parsed = datetime.fromisoformat(txt.replace("Z", "+00:00"))
         except ValueError:
             return None
+        # A bare date ("2022-01-15") or a time without an offset parses to a naive
+        # datetime; .timestamp() would then read it in the machine's local zone, making
+        # the resulting Unix time timezone-dependent (non-reproducible across machines).
+        # Anchor naive values to UTC so the same input always yields the same timestamp.
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp())
     return None
 
 

--- a/tests/test_to_unix_time.py
+++ b/tests/test_to_unix_time.py
@@ -1,0 +1,36 @@
+"""_to_unix_time must anchor timezone-naive inputs to UTC so a saved record's timestamps
+(manufactured_at / started_at / ended_at / created_at) are reproducible across machines,
+regardless of the authoring machine's local timezone."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api import _to_unix_time
+
+
+def test_bare_date_parses_as_utc_midnight() -> None:
+    # 2022-01-15 00:00:00 UTC. Pinned to an absolute value (not recomputed) so a
+    # local-time regression fails here instead of silently drifting per machine.
+    assert _to_unix_time("2022-01-15") == 1642204800
+    assert _to_unix_time("2022-02-01") == 1643673600
+
+
+def test_naive_datetime_parses_as_utc() -> None:
+    assert _to_unix_time("2022-01-15T00:00:00") == 1642204800
+
+
+def test_explicit_offset_is_respected() -> None:
+    # An explicit offset must not be overridden by the UTC anchor.
+    assert _to_unix_time("2022-01-15T00:00:00+01:00") == 1642204800 - 3600
+    assert _to_unix_time("2022-01-15T00:00:00Z") == 1642204800
+
+
+def test_passthrough_and_empty() -> None:
+    assert _to_unix_time(1642204800) == 1642204800
+    assert _to_unix_time("1642204800") == 1642204800
+    assert _to_unix_time("") is None
+    assert _to_unix_time("not-a-date") is None


### PR DESCRIPTION
A bare ISO date ("2022-01-15") or a time with no offset parses to a naive datetime, and datetime.timestamp() then interprets it in the machine's local timezone. As a result, a saved record's manufactured_at / started_at / ended_at / created_at depended on the authoring machine's zone — the same input produced different Unix timestamps on different machines, breaking reproducibility and cross-machine deduplication.

Naive values are now anchored to UTC before conversion; explicit offsets are respected unchanged. Adds a regression test that pins absolute UTC values so a local-time regression fails deterministically instead of drifting per machine.