### PR TITLE
Retire the DatasetInput DTO the Dataset model is both the input and the serializer

### DIFF
--- a/src/battinfo/__init__.py
+++ b/src/battinfo/__init__.py
@@ -1,6 +1,5 @@
 from battinfo._workspace import Workspace, q, quantity
 from battinfo.api import (
-    DatasetInput,
     MaterialInput,
     MaterialSpecInput,
     TestProtocolInput,  # backward compat alias
@@ -278,7 +277,6 @@ __all__ = [
     "CurrentCollectorTab",
     "TableColumn",
     "TableSchema",
-    "DatasetInput",
     "MaterialSpecInput",
     "MaterialInput",
     "TestSpecInput",

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -19,7 +19,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from battinfo._jsonio import read_record_json as _load_json
 from battinfo._jsonio import write_json as _write_json
-from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
 from battinfo.canonical_aliases import record_to_snake_aliases
 from battinfo.entities import (
     COMPONENT_FAMILIES,
@@ -138,56 +138,6 @@ def _citation_url_value(citation: object = None, citation_doi: object = None) ->
 # dict manufacturer, flat provenance kwargs, a transient uid), so one model is both the source of
 # truth and the thing callers construct. ``_record_from_cell_spec`` mints the IRI + applies save-time
 # provenance defaults. (The former ``CellDatasheetInput`` was likewise retired earlier.)
-
-
-class DatasetInput(BaseModel):
-    """Typed input for saving a new canonical dataset resource."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: str = "0.1.0"
-    id: str | None = None
-    uid: str | None = None
-    title: str
-    description: str | None = None
-    license: str | None = None
-    identifier: Any | None = None
-    same_as: list[str] = Field(default_factory=list)
-    additional_type: list[str] = Field(default_factory=list)
-    version: str | None = None
-    keywords: list[str] = Field(default_factory=list)
-    creator: list[dict[str, Any]] = Field(default_factory=list)
-    publisher: dict[str, Any] | None = None
-    funder: list[dict[str, Any]] = Field(default_factory=list)
-    citation_list: list[dict[str, Any]] = Field(default_factory=list)
-    measurement_techniques: list[str] = Field(default_factory=list)
-    measurement_methods: list[str] = Field(default_factory=list)
-    variable_measured: list[dict[str, Any]] = Field(default_factory=list)
-    is_accessible_for_free: bool | None = None
-    conditions_of_access: str | None = None
-    in_language: str | None = None
-    format: str | None = None
-    access_url: str | None = None
-    download_url: str | None = None
-    created_at: str | None = None
-    modified_at: str | None = None
-    published_at: str | None = None
-    temporal_coverage: str | None = None
-    spatial_coverage: str | None = None
-    is_based_on: list[str] = Field(default_factory=list)
-    included_in_data_catalog: Any | None = None
-    main_entity: list[dict[str, Any]] = Field(default_factory=list)
-    distribution: list[dict[str, Any]] = Field(default_factory=list)
-    checksum_algorithm: Literal["sha256", "sha512", "md5", "other"] | None = None
-    checksum_value: str | None = None
-    related_cell_ids: list[str] = Field(default_factory=list)
-    related_test_ids: list[str] = Field(default_factory=list)
-    source_type: Literal["catalog", "measurement", "lab", "simulation", "external", "manual", "other"] = "other"
-    source_url: str | None = None
-    citation: str | None = Field(default=None, validation_alias=AliasChoices("citation", "citation_doi"))
-    retrieved_at: int | None = None
-    curated_by: str | None = None
-    notes: list[str] = Field(default_factory=list)
 
 
 class TestSpecInput(BaseModel):
@@ -349,7 +299,7 @@ def template_dataset(
     related_test_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build a starter canonical dataset document for save workflows."""
-    draft = DatasetInput(
+    draft = Dataset(
         uid=uid,
         title=title,
         source_type=source_type,
@@ -2449,128 +2399,37 @@ def _record_from_cell_instance(instance: CellInstance) -> dict[str, Any]:
     return finalized.to_record()
 
 
-def _record_from_dataset(draft: DatasetInput) -> dict[str, Any]:
-    if draft.id is not None:
-        if not DATASET_IRI_RE.fullmatch(draft.id):
+def _record_from_dataset(dataset: Dataset) -> dict[str, Any]:
+    if dataset.id is not None:
+        if not DATASET_IRI_RE.fullmatch(dataset.id):
             raise ValueError("dataset id must match https://w3id.org/battinfo/dataset/{uid}.")
-        if draft.uid is not None:
-            dashed = _normalized_dashed_uid(draft.uid)
-            _assert_id_matches_uid(draft.id, dashed)
-        entity_id = draft.id
-        _, dashed_uid = _iri_tail(entity_id)
+        entity_id = dataset.id
     else:
-        dashed_uid = _normalized_dashed_uid(draft.uid)
-        entity_id = f"https://w3id.org/battinfo/dataset/{dashed_uid}"
+        entity_id = f"https://w3id.org/battinfo/dataset/{_normalized_dashed_uid(dataset.uid)}"
 
-    for cell_id in draft.related_cell_ids:
+    related_cells = [*dataset.related_cell_ids, *([dataset.cell_instance_id] if dataset.cell_instance_id else [])]
+    for cell_id in related_cells:
         if not CELL_IRI_RE.fullmatch(cell_id):
             raise ValueError("related_cell_ids entries must match https://w3id.org/battinfo/cell/{uid}.")
-    for test_id in draft.related_test_ids:
+    related_tests = [*dataset.related_test_ids, *([dataset.test_id] if dataset.test_id else [])]
+    for test_id in related_tests:
         if not TEST_IRI_RE.fullmatch(test_id):
             raise ValueError("related_test_ids entries must match https://w3id.org/battinfo/test/{uid}.")
 
-    about_refs = list(dict.fromkeys([*draft.related_cell_ids, *draft.related_test_ids]))
-
-    dataset_obj: dict[str, Any] = {
-        "id": entity_id,
-        "short_id": dashed_uid.replace("-", "")[:6],
-        "identifier": draft.identifier if draft.identifier is not None else f"dataset:{dashed_uid}",
-        "name": draft.title,
-        "url": draft.access_url or draft.source_url or f"https://example.org/dataset/{dashed_uid}",
-    }
-    if draft.description is not None:
-        dataset_obj["description"] = draft.description
-    if draft.license is not None:
-        dataset_obj["license"] = draft.license
-    if draft.same_as:
-        dataset_obj["same_as"] = list(dict.fromkeys(draft.same_as))
-    if draft.additional_type:
-        dataset_obj["additional_type"] = list(dict.fromkeys(draft.additional_type))
-    if draft.version is not None:
-        dataset_obj["version"] = draft.version
-    if draft.keywords:
-        dataset_obj["keywords"] = list(dict.fromkeys(draft.keywords))
-    if draft.creator:
-        dataset_obj["creator"] = copy.deepcopy(draft.creator)
-    if draft.publisher is not None:
-        dataset_obj["publisher"] = copy.deepcopy(draft.publisher)
-    if draft.funder:
-        dataset_obj["funder"] = copy.deepcopy(draft.funder)
-    if draft.citation_list:
-        dataset_obj["citation"] = copy.deepcopy(draft.citation_list)
-    if draft.measurement_techniques:
-        dataset_obj["measurementTechnique"] = list(dict.fromkeys(draft.measurement_techniques))
-    if draft.measurement_methods:
-        dataset_obj["measurementMethod"] = list(dict.fromkeys(draft.measurement_methods))
-    if draft.variable_measured:
-        dataset_obj["variableMeasured"] = copy.deepcopy(draft.variable_measured)
-    if draft.is_accessible_for_free is not None:
-        dataset_obj["isAccessibleForFree"] = draft.is_accessible_for_free
-    if draft.conditions_of_access is not None:
-        dataset_obj["conditionsOfAccess"] = draft.conditions_of_access
-    if draft.in_language is not None:
-        dataset_obj["inLanguage"] = draft.in_language
-    if about_refs:
-        dataset_obj["about"] = about_refs
-    created_unix = _to_unix_time(draft.created_at) or _now_unix()
-    modified_unix = _to_unix_time(draft.modified_at) or created_unix
-    published_unix = _to_unix_time(draft.published_at) or created_unix
-    dataset_obj["dateCreated"] = created_unix
-    dataset_obj["dateModified"] = modified_unix
-    dataset_obj["datePublished"] = published_unix
-    if draft.temporal_coverage is not None:
-        dataset_obj["temporalCoverage"] = draft.temporal_coverage
-    if draft.spatial_coverage is not None:
-        dataset_obj["spatialCoverage"] = draft.spatial_coverage
-    if draft.is_based_on:
-        dataset_obj["isBasedOn"] = list(dict.fromkeys(draft.is_based_on))
-    if draft.included_in_data_catalog is not None:
-        dataset_obj["includedInDataCatalog"] = draft.included_in_data_catalog
-    if draft.main_entity:
-        dataset_obj["main_entity"] = copy.deepcopy(draft.main_entity)
-
-    if draft.distribution:
-        dataset_obj["distributions"] = copy.deepcopy(draft.distribution)
-    elif draft.download_url is not None or draft.format is not None or (draft.checksum_algorithm and draft.checksum_value):
-        distribution: dict[str, Any] = {
-            "type": "DataDownload",
-            "content_url": draft.download_url or draft.access_url or draft.source_url or f"https://example.org/dataset/{dashed_uid}/download",
-            "encoding_format": draft.format or "application/octet-stream",
-        }
-        if draft.checksum_algorithm and draft.checksum_value:
-            distribution["checksum"] = {"algorithm": draft.checksum_algorithm, "value": draft.checksum_value}
-        dataset_obj["distributions"] = [distribution]
-
-    if draft.checksum_algorithm and draft.checksum_value:
-        dataset_obj.setdefault("distributions", [
-            {
-                "type": "DataDownload",
-                "content_url": draft.access_url or draft.source_url or f"https://example.org/dataset/{dashed_uid}/download",
-                "encoding_format": draft.format or "application/octet-stream",
-            }
-        ])
-        first_dist = dataset_obj["distributions"][0]
-        if isinstance(first_dist, dict):
-            first_dist["checksum"] = {"algorithm": draft.checksum_algorithm, "value": draft.checksum_value}
-
-    record: dict[str, Any] = {
-        "schema_version": draft.schema_version,
-        "dataset": dataset_obj,
-        "provenance": {
-            "source_type": draft.source_type,
-            "retrieved_at": draft.retrieved_at or _now_unix(),
-        },
-    }
-    if draft.source_url is not None:
-        record["provenance"]["source_url"] = draft.source_url
-    citation = _citation_url_value(draft.citation)
-    if citation is not None:
-        record["provenance"]["citation"] = citation
-    if draft.curated_by is not None:
-        record["provenance"]["curated_by"] = draft.curated_by
-    if draft.notes:
-        record["notes"] = list(draft.notes)
-    return record_to_snake_aliases(record)
+    finalized = dataset.model_copy(deep=True)
+    finalized.id = entity_id
+    # Save-time canonicalization: dates default to now and convert to Unix; provenance
+    # gets the dataset default source type and a retrieval timestamp. The model's
+    # to_record() handles the schema.org field mapping and distribution assembly.
+    created = _to_unix_time(finalized.created_at) or _now_unix()
+    finalized.created_at = created
+    finalized.modified_at = _to_unix_time(finalized.modified_at) or created
+    finalized.published_at = _to_unix_time(finalized.published_at) or created
+    if finalized.source.type is None:
+        finalized.source.type = "other"
+    if finalized.source.retrieved_at is None:
+        finalized.source.retrieved_at = _now_unix()
+    return finalized.to_record()
 
 
 def _record_from_test(test: Test) -> dict[str, Any]:
@@ -2922,7 +2781,7 @@ def save_cell_instance(
 
 
 def save_dataset(
-    draft: DatasetInput | dict[str, Any] | PathLike,
+    draft: Dataset | dict[str, Any] | PathLike,
     *,
     source_root: PathLike = DEFAULT_REGISTRATION_SOURCE_ROOT,
     mode: str = REGISTER_MODE_CREATE_ONLY,
@@ -2955,21 +2814,6 @@ def save_dataset(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    if isinstance(draft, DatasetBundle):
-        return save_record(
-            draft.to_record(),
-            source_root=source_root,
-            mode=mode,
-            duplicate_policy=duplicate_policy,
-            resolve_references=resolve_references,
-            publish=publish,
-            publish_root=publish_root,
-            build_jsonld=build_jsonld,
-            build_html=build_html,
-            validate=validate,
-            validation_policy=validation_policy,
-            dry_run=dry_run,
-        )
     if isinstance(draft, Mapping) and isinstance(draft.get("dataset"), Mapping):
         return save_record(
             dict(draft),
@@ -2985,8 +2829,8 @@ def save_dataset(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    draft_model = draft if isinstance(draft, DatasetInput) else DatasetInput.model_validate(draft)
-    record = _record_from_dataset(draft_model)
+    dataset = draft if isinstance(draft, DatasetBundle) else DatasetBundle(**dict(draft))
+    record = _record_from_dataset(dataset)
     return save_record(
         record,
         source_root=source_root,
@@ -5364,7 +5208,6 @@ __all__ = [
     "query_component_instances",
     "template_component_spec",
     "template_component_instance",
-    "DatasetInput",
     "TestSpecInput",
     "build_cell_spec_library_rdf",
     "build_index",

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -2387,6 +2387,8 @@ class Dataset(BundleJsonModel):
 
     kind: str = "Dataset"
     id: str | None = None
+    # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
+    uid: str | None = Field(default=None, exclude=True, repr=False)
     identifier: Any = None
     name: str | None = None
     description: str | None = None
@@ -2421,6 +2423,8 @@ class Dataset(BundleJsonModel):
     checksum: ChecksumInfo = Field(default_factory=ChecksumInfo)
     cell_instance_id: str | None = None
     test_id: str | None = None
+    related_cell_ids: list[str] = Field(default_factory=list)
+    related_test_ids: list[str] = Field(default_factory=list)
     test: Test | None = Field(default=None, exclude=True, repr=False)
     cell: CellInstance | None = Field(default=None, exclude=True, repr=False)
     source: ProvenanceInfo = Field(default_factory=ProvenanceInfo)
@@ -2429,6 +2433,30 @@ class Dataset(BundleJsonModel):
     def __init__(self, path: str | Path | None = None, /, **data: Any) -> None:
         if path is not None and "dataset_path" not in data and "path" not in data:
             data["path"] = str(path)
+        # Absorb the flat authoring/input shape (formerly DatasetInput).
+        if "title" in data and "name" not in data:
+            data["name"] = data.pop("title")
+        if "format" in data and "data_format" not in data:
+            data["data_format"] = data.pop("format")
+        if "citation_list" in data and "citations" not in data:
+            data["citations"] = data.pop("citation_list")
+        _ck_alg = data.pop("checksum_algorithm", None)
+        _ck_val = data.pop("checksum_value", None)
+        if (_ck_alg is not None or _ck_val is not None) and "checksum" not in data:
+            data["checksum"] = {"algorithm": _ck_alg, "value": _ck_val}
+        if "notes" in data and "comment" not in data:
+            data["comment"] = data.pop("notes")
+        # The dataset citations list aliases "citation"; the provenance citation is a
+        # different concept, so route a flat ``citation`` into source before the alias
+        # can capture it for the citations list.
+        _flat_provenance = {
+            "source_type": "type", "source_name": "name", "source_file": "file",
+            "source_url": "url", "citation": "citation", "file_hash": "file_hash",
+            "retrieved_at": "retrieved_at", "workflow_version": "workflow_version",
+            "curated_by": "curated_by",
+        }
+        if any(key in data for key in _flat_provenance) and "source" not in data:
+            data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
         super().__init__(**data)
 
     @field_validator("identifier", mode="before")
@@ -2701,8 +2729,11 @@ class Dataset(BundleJsonModel):
             dataset_obj["conditions_of_access"] = self.conditions_of_access
         if self.in_language is not None:
             dataset_obj["in_language"] = self.in_language
-        if self.access_url is not None:
-            dataset_obj["access_url"] = self.access_url
+        # access_url is required by the dataset schema; always emit it, falling back to
+        # the provenance URL and finally a stable placeholder derived from the id.
+        dataset_obj["access_url"] = (
+            self.access_url or self.source.url or f"https://example.org/dataset/{_id_tail(self.id)}"
+        )
         if self.created_at is not None:
             dataset_obj["created_at"] = self.created_at
         if self.modified_at is not None:
@@ -2717,11 +2748,12 @@ class Dataset(BundleJsonModel):
             dataset_obj["temporal_coverage"] = self.temporal_coverage
         if self.spatial_coverage is not None:
             dataset_obj["spatial_coverage"] = self.spatial_coverage
-        about: list[str] = []
-        if self.cell_instance_id is not None:
-            about.append(self.cell_instance_id)
-        if self.test_id is not None:
-            about.append(self.test_id)
+        about = list(dict.fromkeys([
+            *self.related_cell_ids,
+            *([self.cell_instance_id] if self.cell_instance_id is not None else []),
+            *self.related_test_ids,
+            *([self.test_id] if self.test_id is not None else []),
+        ]))
         if about:
             dataset_obj["about"] = about
         if self.is_based_on:
@@ -2733,13 +2765,14 @@ class Dataset(BundleJsonModel):
         if self.distributions:
             dataset_obj["distributions"] = copy.deepcopy(self.distributions)
         elif self.download_url is not None or self.data_format is not None or self.checksum.value is not None:
-            dist: dict[str, Any] = {}
-            if self.download_url is not None:
-                dist["content_url"] = self.download_url
-            elif self.access_url is not None:
-                dist["content_url"] = self.access_url
-            if self.data_format is not None:
-                dist["encoding_format"] = self.data_format
+            dist: dict[str, Any] = {
+                "type": "DataDownload",
+                "content_url": (
+                    self.download_url or self.access_url or self.source.url
+                    or f"https://example.org/dataset/{_id_tail(self.id)}/download"
+                ),
+                "encoding_format": self.data_format or "application/octet-stream",
+            }
             if self.checksum.value is not None:
                 dist["checksum"] = {
                     "algorithm": self.checksum.algorithm,

--- a/src/battinfo/cli.py
+++ b/src/battinfo/cli.py
@@ -8,7 +8,6 @@ import typer
 
 from battinfo._jsonio import write_json as _write_json_file
 from battinfo.api import (
-    DatasetInput,
     TestSpecInput,
 )
 from battinfo.api import (
@@ -122,7 +121,7 @@ from battinfo.api import (
 from battinfo.api import (
     validate_staging_datasets as api_validate_staging_datasets,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Test
+from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test
 from battinfo.demo import run_demo_pipeline, setup_demo_environment
 from battinfo.entities import ENTITY_KINDS
 from battinfo.ingest import build_ingest_workspace, inspect_ingest_root, publish_ingest_workspace, write_ingest_manifest
@@ -2023,13 +2022,13 @@ def save_dataset(
     policy_name = _check_validation_policy(validation_policy)
     try:
         if input_path is not None:
-            draft_obj: DatasetInput | dict[str, Any] | Path = input_path
+            draft_obj: Dataset | dict[str, Any] | Path = input_path
         else:
             if not title:
                 raise ValueError("--title is required when --input is not provided.")
             if bool(checksum_algorithm) != bool(checksum_value):
                 raise ValueError("--checksum-algorithm and --checksum-value must be provided together.")
-            draft_obj = DatasetInput(
+            draft_obj = Dataset(
                 uid=uid,
                 title=title,
                 description=description,

--- a/src/battinfo/interop/battery_data_commons.py
+++ b/src/battinfo/interop/battery_data_commons.py
@@ -36,7 +36,6 @@ from typing import Any
 
 from battinfo.api import (
     UID_ALPHABET,
-    DatasetInput,
     _normalized_dashed_uid,
     _record_from_cell_instance,
     _record_from_cell_spec,
@@ -45,7 +44,7 @@ from battinfo.api import (
     _validate_canonical_record,
     create_material_spec,
 )
-from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
 
 PathLike = str | Path
 
@@ -286,7 +285,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     title = _clean(record.get("title")) or _clean(overview.get("feature")) \
         or _clean(record.get("comment")) or f"Battery dataset {bdc_id}"
     licence = record.get("license") or {}
-    dataset = _check(_record_from_dataset(DatasetInput(
+    dataset = _check(_record_from_dataset(Dataset(
         uid=_uid("bdc", "dataset", bdc_id),
         title=title,
         description=_clean(source_meta.get("purpose")),

--- a/src/battinfo/interop/discovery.py
+++ b/src/battinfo/interop/discovery.py
@@ -41,7 +41,6 @@ from typing import Any
 
 from battinfo.api import (
     UID_ALPHABET,
-    DatasetInput,
     _normalized_dashed_uid,
     _record_from_cell_instance,
     _record_from_cell_spec,
@@ -51,7 +50,7 @@ from battinfo.api import (
     create_component_spec,
     create_material_spec,
 )
-from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
 from battinfo.interop.protocols import _num
 
 PathLike = str | Path
@@ -332,7 +331,7 @@ class _Builder:
             )))
             test_id = test["test"]["id"]
             if dataset_file is not None:
-                dataset = self._check(_record_from_dataset(DatasetInput(
+                dataset = self._check(_record_from_dataset(Dataset(
                     uid=_uid("discovery", "dataset", seed),
                     title=f"{model_name} cycling data",
                     source_type="measurement",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,6 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.api import (
-    DatasetInput,
     TestProtocolInput,
     build_cell_spec_library_rdf,
     build_curated_cell_spec_submission,
@@ -46,7 +45,7 @@ from battinfo.api import (
     template_test_spec_draft,
     validate_staging_cell_spec,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Test
+from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test
 from battinfo.validate import validate_references_report
 
 
@@ -858,7 +857,7 @@ def test_save_resource_drafts_and_duplicate_policy(tmp_path: Path) -> None:
     assert test_payload["status"] == "created"
 
     dataset_payload = save_dataset(
-        DatasetInput(
+        Dataset(
             uid="8c1h8pk68034vav6",
             title="Duracell MN1500 cycling",
             source_type="measurement",
@@ -1004,7 +1003,7 @@ def test_save_record_strict_policy_rejects_semantic_issue(tmp_path: Path) -> Non
 def test_save_cell_instance_rejects_reference_with_wrong_record_type(tmp_path: Path) -> None:
     source_root = tmp_path / "examples"
     dataset_payload = save_dataset(
-        DatasetInput(
+        Dataset(
             uid="8c1h8pk68034vav6",
             title="Dataset only",
             source_type="measurement",

--- a/tests/test_core_workflow.py
+++ b/tests/test_core_workflow.py
@@ -8,7 +8,6 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.api import (
-    DatasetInput,
     build_index,
     publish_batch,
     save_cell_instance,
@@ -16,7 +15,7 @@ from battinfo.api import (
     save_dataset,
     save_test,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Test
+from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test
 
 
 def test_core_workflow_end_to_end(tmp_path: Path) -> None:
@@ -60,7 +59,7 @@ def test_core_workflow_end_to_end(tmp_path: Path) -> None:
         validation_policy="strict",
     )
     dataset = save_dataset(
-        DatasetInput(
+        Dataset(
             uid="8c1h8pk68034vav6",
             title="MN1500 dataset",
             source_type="measurement",

--- a/tests/test_record_builder_routing.py
+++ b/tests/test_record_builder_routing.py
@@ -13,10 +13,11 @@ sys.path.insert(0, str(ROOT / "src"))
 from battinfo import validate_record
 from battinfo.api import (
     _record_from_cell_instance,
+    _record_from_dataset,
     _record_from_test,
     _to_unix_time,
 )
-from battinfo.bundle import CellInstance, Test
+from battinfo.bundle import CellInstance, Dataset, Test
 
 _SPEC = "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
 _DS = "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x"
@@ -73,3 +74,53 @@ def test_test_routes_through_model_mapping_fields_and_validates() -> None:
     assert t["started_at"] == _to_unix_time("2022-02-01")  # ISO -> unix
     assert t["ended_at"] == _to_unix_time("2022-02-02")
     assert t["dataset_ids"] == [_DS]
+
+
+_CELL = "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
+_TEST = "https://w3id.org/battinfo/test/5p7v-2n8k-4m3t-6q9r"
+_TEST2 = "https://w3id.org/battinfo/test/7d9k-2m4p-8t3x-6nq5"
+_DS_IRI = "https://w3id.org/battinfo/dataset/8c1h-8pk6-8034-vav6"
+
+
+def test_dataset_routes_through_model_and_validates() -> None:
+    # The flat authoring shape (title/format/checksum_*/source_*) is absorbed by the model
+    # and serialized via to_record(); the record must be schema-valid and carry the fields.
+    rec = _record_from_dataset(Dataset(
+        id=_DS_IRI, title="MN1500 dataset", format="application/x-hdf5",
+        download_url="https://x/d.h5", checksum_algorithm="sha256", checksum_value="abc",
+        related_cell_ids=[_CELL], related_test_ids=[_TEST], created_at="2022-03-01",
+        source_type="measurement", source_url="https://x/src",
+    ))
+    assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
+    ds = rec["dataset"]
+    assert ds["name"] == "MN1500 dataset"
+    assert ds["about"] == [_CELL, _TEST]
+    assert ds["created_at"] == _to_unix_time("2022-03-01")  # ISO -> unix
+    assert ds["distributions"][0]["encoding_format"] == "application/x-hdf5"
+    assert ds["distributions"][0]["checksum"] == {"algorithm": "sha256", "value": "abc"}
+    assert rec["provenance"]["source_type"] == "measurement"
+
+
+def test_dataset_relates_to_multiple_tests_losslessly() -> None:
+    # One dataset can relate to several tests; the model must carry all of them in `about`
+    # (the single cell_instance_id/test_id shape would have dropped the extras).
+    rec = _record_from_dataset(Dataset(
+        id=_DS_IRI, title="Multi", related_cell_ids=[_CELL], related_test_ids=[_TEST, _TEST2],
+        source_type="lab",
+    ))
+    assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
+    assert rec["dataset"]["about"] == [_CELL, _TEST, _TEST2]
+
+
+def test_dataset_always_emits_required_access_url() -> None:
+    # access_url is schema-required; the model fills it even when unset so an object-first
+    # dataset is valid on its own (previously only the DTO save path guaranteed this).
+    rec = _record_from_dataset(Dataset(id=_DS_IRI, title="Bare", source_type="other"))
+    assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
+    assert rec["dataset"]["access_url"]  # present and non-empty
+
+
+def test_dataset_mints_id_from_uid() -> None:
+    rec = _record_from_dataset(Dataset(uid="8c1h-8pk6-8034-vav6", title="X", source_type="other"))
+    assert rec["dataset"]["id"] == _DS_IRI
+    assert rec["dataset"]["short_id"] == "8c1h8p"


### PR DESCRIPTION
Consolidates dataset authoring onto the Dataset model, removing a ~120-line hand-assembled record builder that was a second, divergent serialization path running in parallel to Dataset.to_record().

##What changed

- The model absorbs the flat authoring shape. Dataset(...) now accepts the convenient flat fields directly and normalizes them: title → name, format → data_format, citation_list → citations, checksum_algorithm/checksum_value → checksum, notes → comment, and the flat provenance fields (source_type/source_url, retrieved_at, curated_by) into the nested source. A transient uid mints the IRI and is never serialized.
- Datasets can relate to multiple cells/tests. The model now carries related_cell_ids / related_test_ids lists. The previous single cell_instance_id / test_id shape silently dropped extras — e.g. one dataset spanning several tests.
- Fixes a latent validity bug. access_url is schema-required, but to_record() previously emitted it only when explicitly set, so an object-first dataset could serialize invalid. The model now always fills it (provenance URL, then a stable id-derived fallback), so a Dataset is valid on its own.
- One serialization path. _record_from_dataset is now a thin canonicalizer (mint id, validate references, default/convert dates, default provenance) that delegates to to_record(); save_dataset routes model and mapping inputs through it uniformly.
- Repoints every caller (template builder, CLI, both interop importers, tests) and deletes DatasetInput and its exports.

##Compatibility
Removes DatasetInput from the public API; construct Dataset(...) with the same field names instead. Emitted records are equivalent to the prior output, except where the model applies its existing canonical agent/citation normalization (the object-first path already produced that form).

##Testing
Full suite 1169 passed, 3 skipped; ruff clean. Adds Dataset routing tests covering multi-test about, required-access_url, date conversion, and id minting.