### PR TITLE
Retire the TestSpecInput DTO the TestSpec model is both the input and the serializer

### DIFF
--- a/src/battinfo/__init__.py
+++ b/src/battinfo/__init__.py
@@ -2,8 +2,6 @@ from battinfo._workspace import Workspace, q, quantity
 from battinfo.api import (
     MaterialInput,
     MaterialSpecInput,
-    TestProtocolInput,  # backward compat alias
-    TestSpecInput,
     build_cell_spec_library_rdf,
     build_curated_cell_spec_submission,
     build_index,
@@ -279,8 +277,6 @@ __all__ = [
     "TableSchema",
     "MaterialSpecInput",
     "MaterialInput",
-    "TestSpecInput",
-    "TestProtocolInput",
     "build_cell_spec_library_rdf",
     "build_index",
     "build_curated_cell_spec_submission",

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import difflib
 import functools
 import html
@@ -19,7 +18,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from battinfo._jsonio import read_record_json as _load_json
 from battinfo._jsonio import write_json as _write_json
-from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
+from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test, TestSpec
 from battinfo.canonical_aliases import record_to_snake_aliases
 from battinfo.entities import (
     COMPONENT_FAMILIES,
@@ -138,36 +137,6 @@ def _citation_url_value(citation: object = None, citation_doi: object = None) ->
 # dict manufacturer, flat provenance kwargs, a transient uid), so one model is both the source of
 # truth and the thing callers construct. ``_record_from_cell_spec`` mints the IRI + applies save-time
 # provenance defaults. (The former ``CellDatasheetInput`` was likewise retired earlier.)
-
-
-class TestSpecInput(BaseModel):
-    """Typed input for saving a reusable canonical test-protocol resource."""
-
-    model_config = ConfigDict(extra="forbid")
-    __test__ = False
-
-    schema_version: str = "0.1.0"
-    id: str | None = None
-    uid: str | None = None
-    name: str
-    kind: TestKind
-    description: str | None = None
-    version: str | None = None
-    protocol_url: str | None = None
-    conditions: dict[str, Any] = Field(default_factory=dict)
-    experiment: list[str] = Field(default_factory=list)   # PyBaMM-style strings (authoring)
-    cycles: int | None = None
-    method: list[dict[str, Any]] = Field(default_factory=list)  # pre-built structured method
-    record: dict[str, Any] = Field(default_factory=dict)
-    safety: dict[str, Any] = Field(default_factory=dict)
-    artifacts: list[dict[str, Any]] = Field(default_factory=list)
-    source_type: Literal["manual", "lab", "simulation", "import", "other"] = "manual"
-    source_url: str | None = None
-    citation: str | None = Field(default=None, validation_alias=AliasChoices("citation", "citation_doi"))
-    source_file: str | None = None
-    retrieved_at: int | str | None = None
-    workflow_version: str | None = None
-    notes: list[str] = Field(default_factory=list)
 
 
 def template_cell_spec(
@@ -340,7 +309,7 @@ def template_test_spec(
     uid: str | None = TEMPLATE_UID,
 ) -> dict[str, Any]:
     """Build a starter canonical test-protocol document for save workflows."""
-    draft = TestSpecInput(
+    draft = TestSpec(
         uid=uid,
         name=name,
         kind=kind,
@@ -2465,78 +2434,23 @@ def _record_from_test(test: Test) -> dict[str, Any]:
     return finalized.to_record()
 
 
-def _record_from_test_protocol(draft: TestSpecInput) -> dict[str, Any]:
-    if draft.id is not None:
-        if not TEST_PROTOCOL_IRI_RE.fullmatch(draft.id):
+def _record_from_test_protocol(spec: TestSpec) -> dict[str, Any]:
+    if spec.id is not None:
+        if not TEST_PROTOCOL_IRI_RE.fullmatch(spec.id):
             raise ValueError("test protocol id must match https://w3id.org/battinfo/spec/{uid}.")
-        if draft.uid is not None:
-            dashed = _normalized_dashed_uid(draft.uid)
-            _assert_id_matches_uid(draft.id, dashed)
-        entity_id = draft.id
-        _, dashed_uid = _iri_tail(entity_id)
+        entity_id = spec.id
     else:
-        dashed_uid = _normalized_dashed_uid(draft.uid)
-        entity_id = f"https://w3id.org/battinfo/spec/{dashed_uid}"
+        entity_id = f"https://w3id.org/battinfo/spec/{_normalized_dashed_uid(spec.uid)}"
 
-    record: dict[str, Any] = {
-        "schema_version": draft.schema_version,
-        "test_spec": {
-            "id": entity_id,
-            "short_id": dashed_uid.replace("-", "")[:6],
-            "identifier": f"test-protocol:{dashed_uid}",
-            "name": draft.name,
-            "kind": draft.kind,
-        },
-        "provenance": {
-            "source_type": draft.source_type,
-            "retrieved_at": _to_unix_time(draft.retrieved_at) or _now_unix(),
-        },
-    }
-    if draft.description is not None:
-        record["test_spec"]["description"] = draft.description
-    if draft.version is not None:
-        record["test_spec"]["version"] = draft.version
-    if draft.protocol_url is not None:
-        record["test_spec"]["protocol_url"] = draft.protocol_url
-    if draft.conditions:
-        record["conditions"] = copy.deepcopy(draft.conditions)
-    if draft.record:
-        record["record"] = copy.deepcopy(draft.record)
-    if draft.safety:
-        record["safety"] = copy.deepcopy(draft.safety)
-    # Descriptive method: a pre-built structured `method` wins, else parse the
-    # PyBaMM-style `experiment` strings (the default human authoring interface).
-    from battinfo.bundle import _prune_empty  # noqa: PLC0415
-    from battinfo.testmethod import Quantity, Step, compute_facets, parse_experiment  # noqa: PLC0415
-    method_objs: list[Step] = []
-    if draft.method:
-        method_objs = [Step.model_validate(s) for s in draft.method]
-    elif draft.experiment:
-        method_objs = parse_experiment(list(draft.experiment), draft.cycles)
-    if method_objs:
-        record["method"] = [_prune_empty(s.model_dump(mode="json")) for s in method_objs]
-        # Carry authored conditions (e.g. temperature) into the facet rollup so the
-        # API save path matches TestSpec.facets() — otherwise facets.temperatures is dropped.
-        facet_conditions = {
-            key: Quantity(value=value["value"], unit=value["unit"])
-            for key, value in (draft.conditions or {}).items()
-            if isinstance(value, Mapping) and "value" in value and "unit" in value
-        }
-        record["facets"] = compute_facets(method_objs, facet_conditions)
-    if draft.artifacts:
-        record["artifacts"] = [copy.deepcopy(a) for a in draft.artifacts]
-    if draft.source_url is not None:
-        record["provenance"]["source_url"] = draft.source_url
-    citation = _citation_url_value(draft.citation)
-    if citation is not None:
-        record["provenance"]["citation"] = citation
-    if draft.source_file is not None:
-        record["provenance"]["source_file"] = draft.source_file
-    if draft.workflow_version is not None:
-        record["provenance"]["workflow_version"] = draft.workflow_version
-    if draft.notes:
-        record["notes"] = list(draft.notes)
-    return record_to_snake_aliases(record)
+    # The model already parses the PyBaMM-style experiment/steps authoring input into the
+    # canonical `method` and computes `facets` in to_record(); the builder only mints the id
+    # and applies save-time provenance defaults.
+    finalized = spec.model_copy(deep=True)
+    finalized.id = entity_id
+    if finalized.source.type is None:
+        finalized.source.type = "manual"
+    finalized.source.retrieved_at = _to_unix_time(finalized.source.retrieved_at) or _now_unix()
+    return finalized.to_record()
 
 
 def _resolve_references_for_save(doc: dict[str, Any], source_root: Path) -> None:
@@ -2915,7 +2829,7 @@ def save_test(
 
 
 def save_test_spec(
-    draft: TestSpecInput | dict[str, Any] | PathLike,
+    draft: TestSpec | dict[str, Any] | PathLike,
     *,
     source_root: PathLike = DEFAULT_REGISTRATION_SOURCE_ROOT,
     mode: str = REGISTER_MODE_CREATE_ONLY,
@@ -2948,21 +2862,6 @@ def save_test_spec(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    if isinstance(draft, TestSpec):
-        return save_record(
-            draft.to_record(),
-            source_root=source_root,
-            mode=mode,
-            duplicate_policy=duplicate_policy,
-            resolve_references=resolve_references,
-            publish=publish,
-            publish_root=publish_root,
-            build_jsonld=build_jsonld,
-            build_html=build_html,
-            validate=validate,
-            validation_policy=validation_policy,
-            dry_run=dry_run,
-        )
     if isinstance(draft, Mapping) and isinstance(draft.get("test_spec"), Mapping):
         return save_record(
             dict(draft),
@@ -2978,8 +2877,8 @@ def save_test_spec(
             validation_policy=validation_policy,
             dry_run=dry_run,
         )
-    draft_model = draft if isinstance(draft, TestSpecInput) else TestSpecInput.model_validate(draft)
-    record = _record_from_test_protocol(draft_model)
+    spec = draft if isinstance(draft, TestSpec) else TestSpec(**dict(draft))
+    record = _record_from_test_protocol(spec)
     return save_record(
         record,
         source_root=source_root,
@@ -5208,7 +5107,6 @@ __all__ = [
     "query_component_instances",
     "template_component_spec",
     "template_component_instance",
-    "TestSpecInput",
     "build_cell_spec_library_rdf",
     "build_index",
     "build_curated_cell_spec_submission",
@@ -5250,7 +5148,6 @@ __all__ = [
     "validate_staging_cell_specs",
     "validate_staging_dataset",
     "validate_staging_datasets",
-    "TestProtocolInput",
     "save_test_protocol",
     "template_test_protocol",
     "template_test_protocol_draft",
@@ -5260,7 +5157,6 @@ __all__ = [
 # Per-family component wrappers (create_electrode_spec, query_electrode_specs, …).
 __all__ += _COMPONENT_WRAPPER_NAMES
 
-TestProtocolInput = TestSpecInput  # backward compat alias
 save_test_protocol = save_test_spec  # backward compat alias
 template_test_protocol = template_test_spec  # backward compat alias
 template_test_protocol_draft = template_test_spec_draft  # backward compat alias

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -1986,6 +1986,8 @@ class TestSpec(BundleJsonModel):
     kind: str = "TestSpec"
     __test__ = False
     id: str | None = None
+    # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
+    uid: str | None = Field(default=None, exclude=True, repr=False)
     name: str | None = None
     test_type: BatteryTestType = Field(
         default=BatteryTestType.OTHER,
@@ -2003,6 +2005,26 @@ class TestSpec(BundleJsonModel):
     artifacts: list[Artifact] = Field(default_factory=list)
     source: ProvenanceInfo = Field(default_factory=ProvenanceInfo)
     comment: list[str] = Field(default_factory=list)
+
+    def __init__(self, /, **data: Any) -> None:
+        # Absorb the flat authoring/input shape (formerly TestSpecInput). The discriminator
+        # field `kind` and test_type both alias "kind"; route it to test_type explicitly so
+        # the discriminator keeps its default. protocol_url/experiment/steps/cycles are
+        # authoring conveniences (experiment/steps/cycles are handled by _coerce_authoring).
+        if "kind" in data and "test_type" not in data:
+            data["test_type"] = data.pop("kind")
+        if "protocol_url" in data and "protocol" not in data:
+            data["protocol"] = {"url": data.pop("protocol_url")}
+        if "notes" in data and "comment" not in data:
+            data["comment"] = data.pop("notes")
+        _flat_provenance = {
+            "source_type": "type", "source_name": "name", "source_file": "file",
+            "source_url": "url", "citation": "citation", "file_hash": "file_hash",
+            "retrieved_at": "retrieved_at", "workflow_version": "workflow_version",
+        }
+        if any(key in data for key in _flat_provenance) and "source" not in data:
+            data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
+        super().__init__(**data)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/battinfo/cli.py
+++ b/src/battinfo/cli.py
@@ -8,9 +8,6 @@ import typer
 
 from battinfo._jsonio import write_json as _write_json_file
 from battinfo.api import (
-    TestSpecInput,
-)
-from battinfo.api import (
     build_cell_spec_library_rdf as api_build_cell_spec_library_rdf,
 )
 from battinfo.api import (
@@ -121,7 +118,7 @@ from battinfo.api import (
 from battinfo.api import (
     validate_staging_datasets as api_validate_staging_datasets,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test
+from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test, TestSpec
 from battinfo.demo import run_demo_pipeline, setup_demo_environment
 from battinfo.entities import ENTITY_KINDS
 from battinfo.ingest import build_ingest_workspace, inspect_ingest_root, publish_ingest_workspace, write_ingest_manifest
@@ -2094,11 +2091,11 @@ def save_test_spec(
     policy_name = _check_validation_policy(validation_policy)
     try:
         if input_path is not None:
-            draft_obj: TestSpecInput | dict[str, Any] | Path = input_path
+            draft_obj: TestSpec | dict[str, Any] | Path = input_path
         else:
             if not name:
                 raise ValueError("--name is required when --input is not provided.")
-            draft_obj = TestSpecInput(
+            draft_obj = TestSpec(
                 uid=uid,
                 name=name,
                 kind=kind,  # type: ignore[arg-type]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,6 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.api import (
-    TestProtocolInput,
     build_cell_spec_library_rdf,
     build_curated_cell_spec_submission,
     build_index,
@@ -45,7 +44,7 @@ from battinfo.api import (
     template_test_spec_draft,
     validate_staging_cell_spec,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test
+from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test, TestSpec
 from battinfo.validate import validate_references_report
 
 
@@ -613,7 +612,7 @@ def test_save_test_protocol_and_test_with_protocol_reference(tmp_path: Path) -> 
         mode="upsert",
     )
     protocol = save_test_spec(
-        TestProtocolInput(
+        TestSpec(
             uid="8r2m4v6k9p3t7n5x",
             name="1C Cycle Life at 25 C",
             kind="cycling",

--- a/tests/test_record_builder_routing.py
+++ b/tests/test_record_builder_routing.py
@@ -15,9 +15,10 @@ from battinfo.api import (
     _record_from_cell_instance,
     _record_from_dataset,
     _record_from_test,
+    _record_from_test_protocol,
     _to_unix_time,
 )
-from battinfo.bundle import CellInstance, Dataset, Test
+from battinfo.bundle import CellInstance, Dataset, Test, TestSpec
 
 _SPEC = "https://w3id.org/battinfo/spec/1c4m-7p9q-2k6t-8v3r"
 _DS = "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x"
@@ -124,3 +125,31 @@ def test_dataset_mints_id_from_uid() -> None:
     rec = _record_from_dataset(Dataset(uid="8c1h-8pk6-8034-vav6", title="X", source_type="other"))
     assert rec["dataset"]["id"] == _DS_IRI
     assert rec["dataset"]["short_id"] == "8c1h8p"
+
+
+_SPEC_IRI = "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5"
+
+
+def test_test_spec_parses_experiment_into_method_and_facets() -> None:
+    # The PyBaMM-style experiment[] authoring input is parsed by the model into the canonical
+    # method[] and rolled up into facets — via the model, not a parallel hand-builder.
+    rec = _record_from_test_protocol(TestSpec(
+        id=_SPEC_IRI, name="CC cycling", kind="cycling",
+        experiment=["Discharge at C/10 until 2.5 V", "Charge at C/10 until 4.2 V"], cycles=3,
+        conditions={"temperature": {"value": 25, "unit": "degC"}},
+        source_type="manual",
+    ))
+    assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
+    assert rec["test_spec"]["kind"] == "cycling"
+    assert rec["method"], "experiment[] should parse into a non-empty method[]"
+    assert 0.1 in rec["facets"]["c_rates"]
+    assert rec["facets"]["voltage_window_V"] == [2.5, 4.2]
+    assert rec["provenance"]["source_type"] == "manual"
+
+
+def test_test_spec_defaults_provenance_and_mints_id() -> None:
+    rec = _record_from_test_protocol(TestSpec(uid="7d9k-2m4p-8t3x-6nq5", name="X", kind="other"))
+    assert rec["test_spec"]["id"] == _SPEC_IRI
+    assert rec["test_spec"]["short_id"] == "7d9k2m"
+    assert rec["provenance"]["source_type"] == "manual"  # dataset/test-spec default
+    assert isinstance(rec["provenance"]["retrieved_at"], int)  # defaulted to now


### PR DESCRIPTION
Routes test-protocol saving through TestSpec.to_record() and removes the parallel hand-assembled record builder. The model already parsed the PyBaMM-style experiment/steps authoring strings into the canonical method[] and computed the facets rollup, so the builder was duplicating logic the model owns.

##What changed

- The model absorbs the remaining flat input. TestSpec(...) now accepts kind (routed to test_type so the discriminator keeps its default), protocol_url, notes, and the flat provenance fields (into the nested source). The experiment/steps/cycles authoring input continues to be parsed by the existing validator. A transient uid mints the IRI and is never serialized.
- One serialization path. _record_from_test_protocol is now a thin canonicalizer (mint id, default provenance) that delegates to to_record(); save_test_spec routes model and mapping inputs through it uniformly.
- Artifacts are validated. They're now parsed as Artifact objects on the save path instead of passed through raw, so a malformed artifact fails fast.
- Repoints the template builder, CLI, and tests; the interop protocol importers already constructed TestSpec directly. Deletes TestSpecInput, its TestProtocolInput backward-compat alias, and their exports.

##Compatibility
Removes TestSpecInput and TestProtocolInput from the public API; construct TestSpec(...) with the same field names. Emitted records are byte-equivalent to the prior output across representative inputs.

##Testing
Full suite 1173 passed, 3 skipped; ruff clean. Adds routing tests for experiment[]→method[]+facets, id minting, and provenance defaults.