### PR TITLE
Document the library/canonical unification plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed (breaking — authoring API)
+
+- The per-record-type input classes are retired: the pydantic models are now both the
+  canonical source of truth **and** the authoring input. Construct the model directly with the
+  same field names you passed before and hand it to the matching `save_*` function.
+  - `CellSpecificationInput` → `CellSpecification`
+  - `CellInstanceInput` → `CellInstance`
+  - `TestInput` → `Test`
+  - `DatasetInput` → `Dataset`
+  - `TestSpecInput` (and the `TestProtocolInput` alias) → `TestSpec`
+- Each model accepts the flat authoring shape directly (e.g. `model_name`, `notes`,
+  `source_type`, PyBaMM-style `experiment=[...]`) and normalizes it internally, so most call
+  sites change only the class name.
+
+### Added
+
+- A dataset can now relate to multiple cells and tests via `related_cell_ids` /
+  `related_test_ids` (previously a single cell/test reference silently dropped the extras).
+- Test-spec artifacts are validated as structured `Artifact` objects on save (previously passed
+  through unchecked), so a malformed artifact fails fast.
+
+### Fixed
+
+- Timezone-naive timestamps (a bare ISO date such as `"2022-01-15"`, or a time with no offset)
+  are now anchored to UTC before conversion. Saved record timestamps
+  (`manufactured_at` / `started_at` / `ended_at` / `created_at`) were previously interpreted in
+  the authoring machine's local timezone, making the same input non-reproducible across machines;
+  an explicit offset is still respected.
+- Datasets always emit the schema-required `access_url` (falling back to the provenance URL, then
+  a stable id-derived value), so a dataset built directly from the model can no longer serialize
+  into a schema-invalid record.
+
 ## [0.7.0] — 2026-06-19
 
 First publication of the `battinfo` **Python package** (library + CLI) to PyPI.

--- a/docs/cell-fleet.md
+++ b/docs/cell-fleet.md
@@ -25,7 +25,7 @@ when a basis/inline node is also present, the `@id` is merged onto it.
 ```python
 import battinfo as bi
 
-rec = bi.save_cell_spec(bi.CellSpecificationInput(
+rec = bi.save_cell_spec(bi.CellSpecification(
     model_name="COIN-NMC811-D", manufacturer="EMPA", format="coin", chemistry="Li-ion",
     positive_electrode_spec_id=NMC811_CATHODE_IRI,
     negative_electrode_spec_id=GRAPHITE_ANODE_IRI,

--- a/docs/internal/library-canonical-unification.md
+++ b/docs/internal/library-canonical-unification.md
@@ -1,0 +1,68 @@
+# Library/canonical cell-spec unification — status and post-beta plan
+
+Status: **deferred to a single post-beta effort** (decided 2026-07-05, during the beta-readiness
+sweep). This note records why, and the plan to finish it later.
+
+## Where things stand (already true)
+
+The "one model" goal is met. `CellSpecification` (`bundle.py`) is the single source of truth for a
+cell specification. It serializes into two envelopes:
+
+- **Canonical** (`cell_spec` key) — `to_record()` / `from_record()`. Schema-validated, IRI-minted,
+  provenance-complete. Consumed by the publish path, the registry, the JSON-Schema gate, and SHACL
+  input. This is the real record.
+- **Library** (`specification` key) — `to_library_record()` / `from_library_record()`. A flatter,
+  author-friendly *internal* serialization used only by the local reuse catalog
+  (`save_library_cell_spec`, `query_library_cell_specs`, `build_cell_spec_library_rdf`,
+  `Workspace.save_descriptions`).
+
+The library shape is **not a rival model** — it is a second serialization of the same model. So the
+original "competing models" concern is already resolved.
+
+## Why the collapse is deferred (de-risking findings, 2026-07-05)
+
+1. **The RDF is not shape-agnostic.** `run_mapping(canonical)` drops the `specification_comment`
+   (curation notes) from the domain-battery JSON-LD that `run_mapping(specification)` keeps — a quirk
+   of Builder A's (`transform/json_to_jsonld.py`) `cell_spec` normalization path. So the
+   `specification` envelope must survive internally until Builder A is fixed, and fixing Builder A is
+   JSON-LD-builder work (see 3B) that also changes converter/batterypass output.
+2. **The whole library CRUD surface keys off `specification`.** `save_library_cell_spec`,
+   `query_library_cell_specs`, `_find_library_descriptor_path_by_id`, `Workspace.save_descriptions`,
+   and the `library` CLI commands all read `specification.id` / `specification.manufacturer`
+   internally. Flipping the stored shape to canonical means reworking all of them + migrating files +
+   updating their tests — an invasive change to a working subsystem for a largely-internal benefit.
+
+Because (1) ties the envelope collapse to the JSON-LD builders, the envelope work and the shared
+JSON-LD core (3B) are one problem, best done together.
+
+## Beta: no code change (validation win attempted, backed out)
+
+Adding canonical-projection validation on `save_library_cell_spec` was attempted as a small win but
+backed out: it revealed that the library authoring path never applies the save-time provenance
+defaults (`source_type`, etc.) that `_record_from_cell_spec` applies on the canonical path, so many
+library docs' canonical projections fail schema on `provenance.source_type`. Making them valid means
+adding provenance-defaulting to the library path — which is part of the deferred collapse, not a
+one-liner. Folded into the post-beta plan below. For beta the library subsystem is unchanged and
+`CellSpecification` remains the documented single source of truth.
+
+## Post-beta plan (one unified effort: envelope collapse + shared JSON-LD core)
+
+The four JSON-LD builders serve four distinct output contracts and should not be merged into one;
+the goal is to remove the *duplicated cell-spec→node logic*, then collapse the envelope on top:
+
+1. Extract a shared cell-spec→JSON-LD core (vocab maps, quantity encoding, node assembly) that
+   builders A (`transform/json_to_jsonld.py`), B (`jsonld.py`), and D (`api.py::_resolver_jsonld`)
+   all call, so they stop drifting. Fold the Zenodo builder (C, `ws.py::_assemble_zenodo_jsonld`)
+   onto B's node functions. Keep the four output targets as thin adapters. Guard with golden JSON-LD
+   baselines per consumer (SHACL, publish, converter, batterypass, Zenodo).
+2. With the shared core mapping canonical directly (and preserving the curation-comment behavior),
+   flip the library's *stored* shape to canonical: rework `save_library_cell_spec` /
+   `query_library_cell_specs` / `_find_library_descriptor_path_by_id` / `Workspace.save_descriptions`
+   / the CLI to key off `cell_spec`; add save-time provenance defaulting to the library path (it
+   currently omits `provenance.source_type`, so canonical projections fail schema — see the backed-out
+   validation attempt above); migrate the packaged `data/library/cell-spec/*.json`; keep
+   `from_library_record` / `from_path` as a read adapter for legacy files. Guard with a
+   `build_cell_spec_library_rdf` golden baseline.
+
+Verification tooling already scoped: golden-baseline harnesses for the library RDF output and for
+per-consumer JSON-LD exist in the sweep's scratch work and should be lifted into `tests/`.

--- a/docs/test-specs.md
+++ b/docs/test-specs.md
@@ -20,7 +20,7 @@ kinds), enforced by `tests/test_test_contract.py::test_test_protocol_examples_co
 ```python
 import battinfo as bi
 
-bi.save_test_spec(bi.TestSpecInput(
+bi.save_test_spec(bi.TestSpec(
     name="Capacity Check — C/10 at 25 C",
     kind=bi.BatteryTestType.CAPACITY_CHECK,
     description="CC-CV charge then slow C/10 discharge.",


### PR DESCRIPTION
Records the decision to defer the library-envelope collapse and bundle it with the shared JSON-LD-core work as one post-beta effort, with the de-risking findings that motivated it: the CellSpecification model is already the single source of truth (the library "specification" shape is a second serialization of it, not a rival model); the domain-battery RDF is not shape-agnostic (Builder A drops specification_comment on the canonical path), which ties the envelope to the JSON-LD builders; and the whole library CRUD surface keys off the specification envelope, making a flip invasive for an internal-only benefit.

Lives under docs/internal/ (excluded from the docs build)
