### PR TITLE
Authoring experience: teaching errors, no silent drops, one blessed surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   authoring aliases (e.g. `title=` for `Dataset.name`, `kind=` for `test_type`). A test
   gate keeps new fields from shipping undocumented.
 
+### Changed (interop sharp edges)
+
+- `import_discovery_eln` accepts real `.eln` exports (ZIP archives wrapping the crate),
+  not just an unpacked crate directory or a bare `ro-crate-metadata.json`.
+- Importer JSON parse/read errors now name the offending file (shared
+  `load_json_source` across the BDC, BPX, converter, discovery, and protocol importers).
+- The aurora-unicycler importer surfaces a present-but-unparseable numeric field as a
+  warning on the imported test spec instead of silently ignoring it.
+- Batch imports that produce zero records from a real source say so in the package
+  warnings instead of returning an empty result silently.
+
 ### Changed (validation errors aggregate and teach)
 
 - Save/publish validation failures now report **every** error in one message instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed (nothing accepted is silently dropped)
+
+- `specs=` must be a mapping of property name → value; a list or scalar now raises a
+  `TypeError` showing the expected shape (it used to be discarded without a word).
+- Provenance kwargs accepted at construction (`source_name=`, `file_hash=`, `curated_by=`,
+  `workflow_version=`, provenance `comment`) are now emitted by every record type's
+  serializer and read back by `from_record` — previously four of the five serializers
+  silently omitted them. All record schemas (assets + packaged copies) accept the full
+  provenance field set; each schema's `required` list is unchanged. **Registry note:** the
+  vendored schemas in battinfo-registry must be re-synced before records carrying the new
+  optional fields will pass its gate.
+- Passing a cell/cell-spec object positionally together with a conflicting `cell_id=`/
+  `cell_spec_id=` kwarg now raises naming both ids; with a matching id the object is kept
+  (it used to be silently discarded whenever the id kwarg was present).
+
 ### Changed (record format)
 
 - Every emitted record now carries `schema_version: "0.2.0"`, stamped from a single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Every field of the five authoring models (`CellSpecification`, `CellInstance`, `Test`,
+  `TestSpec`, `Dataset`) and `ProvenanceInfo` now carries a `Field(description=...)`,
+  surfacing in `help()`, IDE hover, and `.model_json_schema()`. Descriptions note the flat
+  authoring aliases (e.g. `title=` for `Dataset.name`, `kind=` for `test_type`). A test
+  gate keeps new fields from shipping undocumented.
+
 ### Changed (validation errors aggregate and teach)
 
 - Save/publish validation failures now report **every** error in one message instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `battinfo.AuthoringWorkspace` is exported by name (previously reachable only via the
+  `battinfo.workspace(...)` factory); its docstring now points at the correct engine class.
+  A new [Workspace authoring](docs/workspace-authoring.md) doc page mirrors
+  `ws.quickstart()`, and QUICKSTART/README carry a "Which surface do I use?" table mapping
+  the three entry points (authoring workspace, models + `publish`, `battinfo.Workspace`
+  object-graph engine). The internal `WorkspaceManifest` in `workspace_state.py` is renamed
+  `WorkspaceStateManifest`, ending the name clash with `local_workspace.WorkspaceManifest`.
 - Every field of the five authoring models (`CellSpecification`, `CellInstance`, `Test`,
   `TestSpec`, `Dataset`) and `ProvenanceInfo` now carries a `Field(description=...)`,
   surfacing in `help()`, IDE hover, and `.model_json_schema()`. Descriptions note the flat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed (validation errors aggregate and teach)
+
+- Save/publish validation failures now report **every** error in one message instead of
+  only the first, so a record with three problems is fixed in one pass, not three.
+- Canonical record paths in error messages translate back to the authoring vocabulary
+  (`cell_spec.cell_format` → `format=`, missing `provenance.source_type` → `source_type=`).
+- Quantity-shape errors include a copy-pasteable example
+  (`{"nominal_capacity": {"value": 0.0, "unit": "ah"}}`) and point at
+  `battinfo properties show <name>` for the accepted units.
+- A misspelled keyword argument on any of the five record models now raises a `TypeError`
+  with a did-you-mean (`manufacture=` → "did you mean `manufacturer=`?") covering fields,
+  aliases, and all spec property names, instead of a bare pydantic extra-field error.
+
 ### Changed (nothing accepted is silently dropped)
 
 - `specs=` must be a mapping of property name → value; a list or scalar now raises a

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,6 +2,17 @@
 
 BattINFO turns battery metadata into machine-readable Linked Data. In five minutes you will create a semantically typed battery cell record, validate it, and see the EMMO-aligned JSON-LD that BattINFO produces automatically.
 
+## Which surface do I use?
+
+| You want to… | Use | Entry point |
+|---|---|---|
+| Describe cells/tests/datasets interactively and publish them (the common case) | **Authoring workspace** | `ws = battinfo.workspace(".")` then `ws.quickstart()` |
+| Create a single record in code and save/publish it | **Models + functions** | `CellSpecification(...)` + `battinfo.publish(...)` (this page) |
+| Build or script the full object graph programmatically (ingest pipelines, batch tooling) | **Object-graph engine** | `battinfo.Workspace` — the lower-level engine the authoring workspace wraps |
+
+If in doubt, start with `battinfo.workspace(".")` — it wraps everything else. See
+[Workspace authoring](docs/workspace-authoring.md) for the guided tour.
+
 ---
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ Or from the command line:
 battinfo --help
 ```
 
+For interactive, multi-record work, the authoring workspace is the blessed surface —
+it wraps everything else:
+
+```python
+import battinfo
+ws = battinfo.workspace(".")
+ws.quickstart()   # prints a copy-pasteable end-to-end example
+```
+
+The [quickstart's "Which surface do I use?" table](QUICKSTART.md#which-surface-do-i-use)
+maps the three entry points (workspace, models + `publish`, `battinfo.Workspace` engine).
+
 **→ Read the [full quickstart](QUICKSTART.md) and the [documentation index](docs/index.md).**
 
 ## Guide notebooks

--- a/assets/schemas/cell-instance.schema.json
+++ b/assets/schemas/cell-instance.schema.json
@@ -209,6 +209,32 @@
         },
         "retrieved_at": {
           "$ref": "#/$defs/UnixTime"
+        },
+        "source_name": {
+          "type": "string"
+        },
+        "source_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "workflow_version": {
+          "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/assets/schemas/cell-spec.schema.json
+++ b/assets/schemas/cell-spec.schema.json
@@ -279,6 +279,9 @@
         },
         "comment": {
           "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
         }
       }
     },

--- a/assets/schemas/dataset.schema.json
+++ b/assets/schemas/dataset.schema.json
@@ -313,6 +313,13 @@
         },
         "workflow_version": {
           "type": "string"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/assets/schemas/material-spec.schema.json
+++ b/assets/schemas/material-spec.schema.json
@@ -146,6 +146,19 @@
         },
         "retrieved_at": {
           "$ref": "#/$defs/UnixTime"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "workflow_version": {
+          "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/assets/schemas/material.schema.json
+++ b/assets/schemas/material.schema.json
@@ -114,6 +114,19 @@
         },
         "retrieved_at": {
           "$ref": "#/$defs/UnixTime"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "workflow_version": {
+          "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/assets/schemas/test-protocol.schema.json
+++ b/assets/schemas/test-protocol.schema.json
@@ -212,6 +212,19 @@
         },
         "workflow_version": {
           "type": "string"
+        },
+        "source_name": {
+          "type": "string"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/assets/schemas/test.schema.json
+++ b/assets/schemas/test.schema.json
@@ -243,6 +243,19 @@
         },
         "workflow_version": {
           "type": "string"
+        },
+        "source_name": {
+          "type": "string"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Open notebooks from the repo root with the `.venv` kernel selected.
 
 | | |
 |---|---|
+| **[Workspace authoring](workspace-authoring.md)** | The blessed authoring surface: `battinfo.workspace(".")` end-to-end, and which surface to use when |
 | **[Python API](python-api.md)** | Full Python surface: Workspace, authoring helpers, query/save/publish functions |
 | **[CLI spec](cli-spec.md)** | All CLI commands, options, and output formats |
 | **[Validation contract](validation-contract.md)** | Validation policies, machine-readable issue output |

--- a/docs/internal/beta-hardening-plan.md
+++ b/docs/internal/beta-hardening-plan.md
@@ -89,10 +89,17 @@ WIP is parked on `wip/docs-web` and needs reconciliation against these changes b
 
 ---
 
-## Phase 2 — Authoring experience (the non-coder succeeds unassisted)
+## Phase 2 — Authoring experience (the non-coder succeeds unassisted) — ✅ DONE (branch feat/phase2-authoring-ux, 2026-07-06)
 
 **Goal:** errors teach; nothing accepted is silently dropped; one obvious surface.
 **Size:** ~1 week. **Depends on:** P0 (error behavior changes build on the new call-site rules).
+
+Outcome notes: all five acceptance scenarios produce actionable messages. 2.1 extended the
+record schemas with the full optional provenance set — **battinfo-registry's vendored
+schemas need a re-sync** before records carrying source_name/file_hash/curated_by pass its
+gate (fold into 3.1). source_type turned out to be schema-required, so accepted-then-dropped
+was fixed by emitting everywhere (one shared serializer/reader pair). 2.4 renamed
+workspace_state.WorkspaceManifest → WorkspaceStateManifest.
 
 - **2.1 No silent drops** — raise (or warn + preserve) on: non-mapping `specs=`
   (bundle.py:1246); `source_name`/`file_hash` accepted then omitted from records (either emit

--- a/docs/pages/reference.rst
+++ b/docs/pages/reference.rst
@@ -6,6 +6,7 @@ Full reference documentation for the BattINFO Python API, CLI, and validation co
 .. toctree::
    :maxdepth: 1
 
+   ../workspace-authoring
    ../python-api
    ../cli-spec
    ../validation-contract

--- a/docs/workspace-authoring.md
+++ b/docs/workspace-authoring.md
@@ -1,0 +1,71 @@
+# Workspace authoring
+
+`battinfo.workspace(".")` is the blessed authoring surface — the one entry point that
+covers the common case end-to-end: describe the cells you tested, attach tests and data,
+and publish, without touching the lower layers.
+
+```python
+import battinfo
+
+ws = battinfo.workspace(".")
+ws.quickstart()   # prints the copy-pasteable version of everything below
+```
+
+## The end-to-end flow
+
+```python
+import battinfo
+ws = battinfo.workspace(".")
+
+# 1. One-time: log in (get a key at the registry settings page)
+ws.login(api_key="YOUR_KEY")        # or ws.setup() to see options
+
+# 2. Tag this work with the project that funded it (optional, once per
+#    workspace). The grant is stamped onto every record you save.
+ws.project("101103997")              # e.g. an EU grant agreement number
+
+# 3. Convert raw cycler files (NEWARE/Biologic/Excel/... auto-detected)
+ws.convert()                         # -> bdf/*.bdf.csv
+
+# 4. Find your cell in the registry (fuzzy search)
+spec = ws.search("samsung inr21700 50e")[0]
+
+# 5. Register the physical cells you tested
+ws.add("cell", spec=spec, serial_numbers=["S1", "S2", "S3"])
+
+# 6. Attach a test + data to a cell (explicit)
+ws.add("test", type="cycling", cell="S1", data="bdf/S1.bdf.csv")
+
+# 7. Publish (add zenodo=True for a citable DOI)
+ws.save()
+ws.publish(note="My cycling campaign, 2026")
+
+ws.status()                          # see it live
+```
+
+Every verb is a method on the returned `AuthoringWorkspace` (also importable as
+`battinfo.AuthoringWorkspace`): `login`, `project`, `convert`, `search`, `add`, `load`,
+`save`, `publish`, `submit`, `status`, `zenodo`. Each has a docstring with examples —
+`help(ws.add)` is the fastest reference.
+
+## Which surface do I use?
+
+| You want to… | Use | Entry point |
+|---|---|---|
+| Describe cells/tests/datasets interactively and publish them (the common case) | **Authoring workspace** | `ws = battinfo.workspace(".")` — this page |
+| Create a single record in code and save/publish it | **Models + functions** | `CellSpecification(...)` + `battinfo.publish(...)` — see the [Python API](python-api.md) |
+| Build or script the full object graph programmatically (ingest pipelines, batch tooling) | **Object-graph engine** | `battinfo.Workspace` |
+
+## The layers underneath
+
+- **`battinfo.Workspace`** (in `battinfo._workspace`) is the object-graph engine: it
+  holds linked `CellSpecification` / `CellInstance` / `Test` / `Dataset` objects,
+  finalizes ids and provenance, and writes the canonical records. The authoring
+  workspace delegates to it; script against it directly when you are building
+  pipelines rather than working interactively.
+- **The record models** (`CellSpecification`, `CellInstance`, `Test`, `TestSpec`,
+  `Dataset`) are both the canonical source of truth and the authoring input — every
+  field carries a description (`help(battinfo.CellSpecification)`), and misspelled
+  arguments get a did-you-mean.
+- **`battinfo.publish(...)`** takes a single model (or a linked graph of them) and
+  writes/publishes the canonical records without a workspace.

--- a/src/battinfo/__init__.py
+++ b/src/battinfo/__init__.py
@@ -201,7 +201,7 @@ from battinfo.validate import (
     validate_shacl,
     validate_shacl_report,
 )
-from battinfo.ws import validate_jsonld, workspace
+from battinfo.ws import AuthoringWorkspace, validate_jsonld, workspace
 from battinfo.zenodo import ZenodoClient, ZenodoError, patch_zenodo_urls, upload_zenodo_package
 
 BatteryCellSpecification = CellSpecification
@@ -361,6 +361,7 @@ __all__ = [
     "upload_zenodo_package",
     "LocalWorkspace",
     "Workspace",
+    "AuthoringWorkspace",
     "workspace",
     "validate_jsonld",
     "record_to_jsonld",

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -40,6 +40,7 @@ from battinfo.entities import (
 )
 from battinfo.transform.json_to_jsonld import _descriptor_quantity_node as _jsonld_quantity_node
 from battinfo.validate.core import DEFAULT_POLICY, ValidationPolicy
+from battinfo.validate.friendly import format_report_errors
 from battinfo.validate.publication import validate_publication_report
 from battinfo.validate.pydantic import validate_json
 from battinfo.validate.record import validate_record, validate_record_report
@@ -2182,11 +2183,7 @@ def _validate_schema(doc: dict[str, Any], schema_rel_path: str) -> None:
     report = validate_schema_data(doc, schema)
     if report.ok:
         return
-    first = report.errors[0]
-    location = first.path
-    if location:
-        raise ValueError(f"Schema validation failed at '{location}': {first.message}")
-    raise ValueError(f"Schema validation failed: {first.message}")
+    raise ValueError(format_report_errors(report, prefix="Schema validation failed"))
 
 
 def _validate_canonical_record(
@@ -2205,9 +2202,7 @@ def _validate_canonical_record(
         prefix = "Publication validation failed"
     else:
         prefix = "Validation failed"
-    if first.path:
-        raise ValueError(f"{prefix} at '{first.path}': {first.message}")
-    raise ValueError(f"{prefix}: {first.message}")
+    raise ValueError(format_report_errors(report, prefix=prefix))
 
 
 def _validate_publication_artifact(
@@ -2218,10 +2213,7 @@ def _validate_publication_artifact(
     report = validate_publication_report(doc, policy=policy)
     if report.ok:
         return
-    first = report.errors[0]
-    if first.path:
-        raise ValueError(f"Publication validation failed at '{first.path}': {first.message}")
-    raise ValueError(f"Publication validation failed: {first.message}")
+    raise ValueError(format_report_errors(report, prefix="Publication validation failed"))
 
 
 def create_cell_instance(
@@ -2516,7 +2508,7 @@ def _resolve_references_for_save(doc: dict[str, Any], source_root: Path) -> None
     report = validate_references_report(doc, source_root, allow_missing=True)
     if report.ok:
         return
-    raise ValueError(report.errors[0].message)
+    raise ValueError(format_report_errors(report, prefix="Reference validation failed"))
 
 
 def _record_content_differs(existing_path: PathLike, new_doc: Mapping[str, Any]) -> bool:

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import difflib
 import re
 from enum import StrEnum
 from pathlib import Path
@@ -318,6 +319,41 @@ class ProtocolInfo(BaseModel):
 
     name: str | None = None
     url: str | None = None
+
+
+# Flat provenance kwargs every record model absorbs into `source` (see the per-model
+# _flat_provenance maps); listed here so the unknown-kwarg check knows them as vocabulary.
+_FLAT_PROVENANCE_KEYS = (
+    "source_type", "source_name", "source_file", "source_url", "citation",
+    "file_hash", "retrieved_at", "workflow_version", "curated_by",
+)
+
+
+def _reject_unknown_kwargs(cls: type[BaseModel], data: Mapping[str, Any], *, extra_allowed: tuple[str, ...] = ()) -> None:
+    """Raise a teaching TypeError for kwargs that match no field or alias.
+
+    ``extra="forbid"`` would reject them anyway, but as a pydantic ValidationError that
+    names only the stray key. A typo like ``manufacture=`` deserves a did-you-mean.
+    Call AFTER the __init__ alias absorption, so only genuine strays remain in *data*."""
+    allowed: set[str] = set(extra_allowed)
+    for field_name, field_info in cls.model_fields.items():
+        allowed.add(field_name)
+        alias = field_info.validation_alias
+        if isinstance(alias, AliasChoices):
+            allowed.update(str(choice) for choice in alias.choices)
+        elif isinstance(alias, str):
+            allowed.add(alias)
+    unknown = [key for key in data if key not in allowed]
+    if not unknown:
+        return
+    parts = []
+    for key in unknown:
+        close = difflib.get_close_matches(key, sorted(allowed), n=1)
+        parts.append(f"{key}=" + (f" (did you mean {close[0]}=?)" if close else ""))
+    raise TypeError(
+        f"Unknown field(s) for {cls.__name__}: " + ", ".join(parts)
+        + f". Run help(battinfo.{cls.__name__}) for the accepted fields."
+    )
 
 
 def _provenance_from_record(provenance: Mapping[str, Any]) -> ProvenanceInfo:
@@ -1336,6 +1372,11 @@ class CellSpecification(BundleJsonModel):
                 data["housing"] = migrated
 
         data["properties"] = explicit_properties
+        _reject_unknown_kwargs(
+            type(self), data,
+            extra_allowed=("specs", "notes", "coin_hardware",
+                           *CELL_TYPE_AUTHORING_PROPERTY_FIELDS, *_FLAT_PROVENANCE_KEYS),
+        )
         super().__init__(**data)
 
     @model_validator(mode="after")
@@ -1748,6 +1789,9 @@ class CellInstance(BundleJsonModel):
                     "Pass one or the other."
                 )
             data["cell_spec"] = cell_spec
+        _reject_unknown_kwargs(
+            type(self), data, extra_allowed=("notes", "dataset_id", *_FLAT_PROVENANCE_KEYS)
+        )
         super().__init__(**data)
 
     @model_validator(mode="after")
@@ -2043,6 +2087,11 @@ class TestSpec(BundleJsonModel):
         }
         if any(key in data for key in _flat_provenance) and "source" not in data:
             data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
+        _reject_unknown_kwargs(
+            type(self), data,
+            extra_allowed=("kind", "protocol_url", "notes", "experiment", "steps", "cycles",
+                           *_FLAT_PROVENANCE_KEYS),
+        )
         super().__init__(**data)
 
     @model_validator(mode="before")
@@ -2252,6 +2301,11 @@ class Test(BundleJsonModel):
                     f"but cell_id={_kwarg_id!r} was also given. Pass one or the other."
                 )
             data["cell"] = cell
+        _reject_unknown_kwargs(
+            type(self), data,
+            extra_allowed=("cell_id", "kind", "instrument_name", "protocol_name",
+                           "protocol_url", "notes", *_FLAT_PROVENANCE_KEYS),
+        )
         super().__init__(**data)
 
     @field_validator("protocol", mode="before")
@@ -2484,6 +2538,11 @@ class Dataset(BundleJsonModel):
                 data["source"] = merged
             elif isinstance(source, ProvenanceInfo) and source.citation is None:
                 data["source"] = source.model_copy(update={"citation": _prov_citation})
+        _reject_unknown_kwargs(
+            type(self), data,
+            extra_allowed=("title", "format", "citation_list", "checksum_algorithm",
+                           "checksum_value", "notes", "citation", "path", *_FLAT_PROVENANCE_KEYS),
+        )
         super().__init__(**data)
 
     @field_validator("identifier", mode="before")

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -320,6 +320,56 @@ class ProtocolInfo(BaseModel):
     url: str | None = None
 
 
+def _provenance_from_record(provenance: Mapping[str, Any]) -> ProvenanceInfo:
+    """Read a record's provenance block back into ProvenanceInfo.
+
+    The inverse of ``_provenance_record`` — reads every field so
+    to_record→from_record round-trips are lossless for provenance."""
+    return ProvenanceInfo(
+        type=provenance.get("source_type"),
+        name=provenance.get("source_name"),
+        file=provenance.get("source_file"),
+        url=provenance.get("source_url"),
+        citation=_citation_url_value(provenance.get("citation"), provenance.get("citation_doi")),
+        retrieved_at=provenance.get("retrieved_at"),
+        workflow_version=provenance.get("workflow_version"),
+        file_hash=provenance.get("file_hash"),
+        curated_by=provenance.get("curated_by"),
+        comment=provenance.get("comment"),
+    )
+
+
+def _provenance_record(source: ProvenanceInfo) -> dict[str, Any]:
+    """Serialize a ProvenanceInfo into a record's provenance block.
+
+    Emits EVERY field the model accepts (None omitted) — the single serializer shared by
+    all record types, so a provenance value accepted at construction (source_name=,
+    file_hash=, ...) can never be silently dropped from the emitted record again."""
+    out: dict[str, Any] = {}
+    if source.type is not None:
+        out["source_type"] = source.type
+    if source.name is not None:
+        out["source_name"] = source.name
+    if source.file is not None:
+        out["source_file"] = source.file
+    if source.url is not None:
+        out["source_url"] = source.url
+    citation = _citation_url_value(source.citation)
+    if citation is not None:
+        out["citation"] = citation
+    if source.retrieved_at is not None:
+        out["retrieved_at"] = source.retrieved_at
+    if source.workflow_version is not None:
+        out["workflow_version"] = source.workflow_version
+    if source.file_hash is not None:
+        out["file_hash"] = source.file_hash
+    if source.curated_by is not None:
+        out["curated_by"] = source.curated_by
+    if source.comment is not None:
+        out["comment"] = source.comment
+    return out
+
+
 class ChecksumInfo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1247,7 +1297,7 @@ class CellSpecification(BundleJsonModel):
         _flat_provenance = {
             "source_type": "type", "source_name": "name", "source_file": "file", "source_url": "url",
             "citation": "citation", "file_hash": "file_hash", "retrieved_at": "retrieved_at",
-            "workflow_version": "workflow_version",
+            "workflow_version": "workflow_version", "curated_by": "curated_by",
         }
         if any(key in data for key in _flat_provenance) and "source" not in data:
             data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
@@ -1261,6 +1311,12 @@ class CellSpecification(BundleJsonModel):
             explicit_properties = dict(explicit_properties)
         # `specs` is an input alias for `properties`.
         _specs = data.pop("specs", None)
+        if _specs is not None and not isinstance(_specs, Mapping):
+            raise TypeError(
+                "specs= must be a mapping of property name to value, e.g. "
+                "specs={'nominal_capacity': {'value': 2.5, 'unit': 'Ah'}}; "
+                f"got {type(_specs).__name__}."
+            )
         if isinstance(_specs, Mapping):
             for _key, _value in _specs.items():
                 explicit_properties.setdefault(_key, _value)
@@ -1394,17 +1450,7 @@ class CellSpecification(BundleJsonModel):
             bibliography=dict(record.get("bibliography", {}))
             if isinstance(record.get("bibliography"), Mapping)
             else {},
-            source=ProvenanceInfo(
-                type=provenance.get("source_type"),
-                name=provenance.get("source_name"),
-                file=provenance.get("source_file"),
-                url=provenance.get("source_url"),
-                citation=_citation_url_value(provenance.get("citation"), provenance.get("citation_doi")),
-                retrieved_at=provenance.get("retrieved_at"),
-                workflow_version=provenance.get("workflow_version"),
-                file_hash=provenance.get("file_hash"),
-                comment=provenance.get("comment"),
-            ),
+            source=_provenance_from_record(provenance),
             comment=[str(item) for item in notes],
         )
 
@@ -1528,25 +1574,7 @@ class CellSpecification(BundleJsonModel):
             _ref_value = getattr(self, _ref)
             if _ref_value is not None:
                 record[_ref] = _ref_value  # top-level sibling of cell_spec, per the schema
-        if self.source.type is not None:
-            record["provenance"]["source_type"] = self.source.type
-        if self.source.name is not None:
-            record["provenance"]["source_name"] = self.source.name
-        if self.source.workflow_version is not None:
-            record["provenance"]["workflow_version"] = self.source.workflow_version
-        if self.source.comment is not None:
-            record["provenance"]["comment"] = self.source.comment
-        if self.source.file is not None:
-            record["provenance"]["source_file"] = self.source.file
-        if self.source.url is not None:
-            record["provenance"]["source_url"] = self.source.url
-        citation = _citation_url_value(self.source.citation)
-        if citation is not None:
-            record["provenance"]["citation"] = citation
-        if self.source.retrieved_at is not None:
-            record["provenance"]["retrieved_at"] = self.source.retrieved_at
-        if self.source.file_hash is not None:
-            record["provenance"]["file_hash"] = self.source.file_hash
+        record["provenance"] = _provenance_record(self.source)
         if self.bibliography:
             record["bibliography"] = dict(self.bibliography)
         if self.comment:
@@ -1620,16 +1648,7 @@ class CellSpecification(BundleJsonModel):
             if specification.get("housing") is not None
             else _housing_from_coin_hardware(specification.get("coin_hardware")),
             specification_comment=[str(item) for item in specification_comment],
-            source=ProvenanceInfo(
-                type=provenance.get("source_type"),
-                name=provenance.get("source_name"),
-                file=provenance.get("source_file"),
-                url=provenance.get("source_url"),
-                citation=_citation_url_value(provenance.get("citation"), provenance.get("citation_doi")),
-                retrieved_at=provenance.get("retrieved_at"),
-                workflow_version=provenance.get("workflow_version"),
-                comment=provenance.get("comment"),
-            ),
+            source=_provenance_from_record(provenance),
             comment=[str(item) for item in comment],
         )
 
@@ -1666,24 +1685,7 @@ class CellSpecification(BundleJsonModel):
         if self.specification_comment:
             specification["comment"] = list(self.specification_comment)
 
-        provenance: dict[str, Any] = {}
-        if self.source.type is not None:
-            provenance["source_type"] = self.source.type
-        if self.source.name is not None:
-            provenance["source_name"] = self.source.name
-        if self.source.file is not None:
-            provenance["source_file"] = self.source.file
-        if self.source.url is not None:
-            provenance["source_url"] = self.source.url
-        citation = _citation_url_value(self.source.citation)
-        if citation is not None:
-            provenance["citation"] = citation
-        if self.source.retrieved_at is not None:
-            provenance["retrieved_at"] = self.source.retrieved_at
-        if self.source.workflow_version is not None:
-            provenance["workflow_version"] = self.source.workflow_version
-        if self.source.comment is not None:
-            provenance["comment"] = self.source.comment
+        provenance = _provenance_record(self.source)
 
         out = {
             "schema_version": self.schema_version,
@@ -1727,11 +1729,24 @@ class CellInstance(BundleJsonModel):
         _flat_provenance = {
             "source_type": "type", "source_name": "name", "source_file": "file", "source_url": "url",
             "citation": "citation", "file_hash": "file_hash", "retrieved_at": "retrieved_at",
-            "workflow_version": "workflow_version",
+            "workflow_version": "workflow_version", "curated_by": "curated_by",
         }
         if any(key in data for key in _flat_provenance) and "source" not in data:
             data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
-        if cell_spec is not None and "cell_spec" not in data and "cell_spec_id" not in data:
+        if cell_spec is not None:
+            if "cell_spec" in data and data["cell_spec"] is not cell_spec:
+                raise ValueError(
+                    "Pass the cell spec either positionally or as cell_spec=, not both."
+                )
+            # A positional object used to be silently DISCARDED when cell_spec_id= was
+            # also given. Keep the object, but refuse a demonstrable identity conflict.
+            _kwarg_id = data.get("cell_spec_id")
+            if _kwarg_id is not None and cell_spec.id is not None and _kwarg_id != cell_spec.id:
+                raise ValueError(
+                    f"Conflicting cell spec references: the positional object has "
+                    f"id {cell_spec.id!r} but cell_spec_id={_kwarg_id!r} was also given. "
+                    "Pass one or the other."
+                )
             data["cell_spec"] = cell_spec
         super().__init__(**data)
 
@@ -1791,12 +1806,7 @@ class CellInstance(BundleJsonModel):
                 else None
             ),
             dataset_ids=[str(item) for item in dataset_ids],
-            source=ProvenanceInfo(
-                type=provenance.get("source_type"),
-                url=provenance.get("source_url"),
-                citation=_citation_url_value(provenance.get("citation"), provenance.get("citation_doi")),
-                retrieved_at=provenance.get("retrieved_at"),
-            ),
+            source=_provenance_from_record(provenance),
             comment=[str(item) for item in notes],
         )
 
@@ -1824,15 +1834,7 @@ class CellInstance(BundleJsonModel):
             record["measured"] = self.measured
         if self.dataset_ids:
             record["datasets"] = [{"id": dataset_id, "role": "raw"} for dataset_id in self.dataset_ids]
-        if self.source.type is not None:
-            record["provenance"]["source_type"] = self.source.type
-        if self.source.url is not None:
-            record["provenance"]["source_url"] = self.source.url
-        citation = _citation_url_value(self.source.citation)
-        if citation is not None:
-            record["provenance"]["citation"] = citation
-        if self.source.retrieved_at is not None:
-            record["provenance"]["retrieved_at"] = self.source.retrieved_at
+        record["provenance"] = _provenance_record(self.source)
         record["cell_instance"] = {key: value for key, value in record["cell_instance"].items() if value is not None}
         if self.conformance is not None:
             record["cell_instance"]["conformance"] = self.conformance.to_record()
@@ -2035,9 +2037,9 @@ class TestSpec(BundleJsonModel):
         if "notes" in data and "comment" not in data:
             data["comment"] = data.pop("notes")
         _flat_provenance = {
-            "source_type": "type", "source_name": "name", "source_file": "file",
-            "source_url": "url", "citation": "citation", "file_hash": "file_hash",
-            "retrieved_at": "retrieved_at", "workflow_version": "workflow_version",
+            "source_type": "type", "source_name": "name", "source_file": "file", "source_url": "url",
+            "citation": "citation", "file_hash": "file_hash", "retrieved_at": "retrieved_at",
+            "workflow_version": "workflow_version", "curated_by": "curated_by",
         }
         if any(key in data for key in _flat_provenance) and "source" not in data:
             data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
@@ -2142,14 +2144,7 @@ class TestSpec(BundleJsonModel):
             safety=dict(safety) if isinstance(safety, Mapping) else {},
             conditions=dict(conditions),
             artifacts=[Artifact.from_record(a) for a in artifacts if isinstance(a, Mapping)],
-            source=ProvenanceInfo(
-                type=provenance.get("source_type"),
-                file=provenance.get("source_file"),
-                url=provenance.get("source_url"),
-                citation=_citation_url_value(provenance.get("citation"), provenance.get("citation_doi")),
-                retrieved_at=provenance.get("retrieved_at"),
-                workflow_version=provenance.get("workflow_version"),
-            ),
+            source=_provenance_from_record(provenance),
             comment=[str(item) for item in notes],
         )
 
@@ -2188,19 +2183,7 @@ class TestSpec(BundleJsonModel):
             }
         if self.artifacts:
             record["artifacts"] = [a.to_record() for a in self.artifacts]
-        if self.source.type is not None:
-            record["provenance"]["source_type"] = self.source.type
-        if self.source.file is not None:
-            record["provenance"]["source_file"] = self.source.file
-        if self.source.url is not None:
-            record["provenance"]["source_url"] = self.source.url
-        citation = _citation_url_value(self.source.citation)
-        if citation is not None:
-            record["provenance"]["citation"] = citation
-        if self.source.retrieved_at is not None:
-            record["provenance"]["retrieved_at"] = self.source.retrieved_at
-        if self.source.workflow_version is not None:
-            record["provenance"]["workflow_version"] = self.source.workflow_version
+        record["provenance"] = _provenance_record(self.source)
         if self.comment:
             record["notes"] = list(self.comment)
         return record
@@ -2252,11 +2235,22 @@ class Test(BundleJsonModel):
         _flat_provenance = {
             "source_type": "type", "source_name": "name", "source_file": "file", "source_url": "url",
             "citation": "citation", "file_hash": "file_hash", "retrieved_at": "retrieved_at",
-            "workflow_version": "workflow_version",
+            "workflow_version": "workflow_version", "curated_by": "curated_by",
         }
         if any(key in data for key in _flat_provenance) and "source" not in data:
             data["source"] = {nested: data.pop(flat) for flat, nested in _flat_provenance.items() if flat in data}
-        if cell is not None and "cell" not in data and "cell_instance_id" not in data:
+        if cell is not None:
+            if "cell" in data and data["cell"] is not cell:
+                raise ValueError("Pass the cell either positionally or as cell=, not both.")
+            # A positional object used to be silently DISCARDED when cell_id=/
+            # cell_instance_id= was also given. Keep the object, but refuse a
+            # demonstrable identity conflict.
+            _kwarg_id = data.get("cell_instance_id")
+            if _kwarg_id is not None and cell.id is not None and _kwarg_id != cell.id:
+                raise ValueError(
+                    f"Conflicting cell references: the positional object has id {cell.id!r} "
+                    f"but cell_id={_kwarg_id!r} was also given. Pass one or the other."
+                )
             data["cell"] = cell
         super().__init__(**data)
 
@@ -2351,14 +2345,7 @@ class Test(BundleJsonModel):
             dataset_ids=[str(item) for item in dataset_ids],
             conformance=conformance,
             artifacts=[Artifact.from_record(a) for a in artifacts if isinstance(a, Mapping)],
-            source=ProvenanceInfo(
-                type=provenance.get("source_type"),
-                file=provenance.get("source_file"),
-                url=provenance.get("source_url"),
-                citation=_citation_url_value(provenance.get("citation"), provenance.get("citation_doi")),
-                retrieved_at=provenance.get("retrieved_at"),
-                workflow_version=provenance.get("workflow_version"),
-            ),
+            source=_provenance_from_record(provenance),
             comment=[str(item) for item in notes],
         )
 
@@ -2403,19 +2390,7 @@ class Test(BundleJsonModel):
             record["test"]["conformance"] = self.conformance.to_record()
         if self.artifacts:
             record["artifacts"] = [a.to_record() for a in self.artifacts]
-        if self.source.type is not None:
-            record["provenance"]["source_type"] = self.source.type
-        if self.source.file is not None:
-            record["provenance"]["source_file"] = self.source.file
-        if self.source.url is not None:
-            record["provenance"]["source_url"] = self.source.url
-        citation = _citation_url_value(self.source.citation)
-        if citation is not None:
-            record["provenance"]["citation"] = citation
-        if self.source.retrieved_at is not None:
-            record["provenance"]["retrieved_at"] = self.source.retrieved_at
-        if self.source.workflow_version is not None:
-            record["provenance"]["workflow_version"] = self.source.workflow_version
+        record["provenance"] = _provenance_record(self.source)
         if self.comment:
             record["notes"] = list(self.comment)
         return record
@@ -2744,13 +2719,7 @@ class Dataset(BundleJsonModel):
             test_id=related_test_id,
             related_cell_ids=related_cell_ids,
             related_test_ids=related_test_ids,
-            source=ProvenanceInfo(
-                type=provenance.get("source_type"),
-                url=provenance.get("source_url"),
-                citation=_citation_url_value(provenance.get("citation"), provenance.get("citation_doi")),
-                retrieved_at=provenance.get("retrieved_at"),
-                curated_by=provenance.get("curated_by"),
-            ),
+            source=_provenance_from_record(provenance),
             comment=[str(item) for item in notes],
         )
 
@@ -2859,17 +2828,7 @@ class Dataset(BundleJsonModel):
             "dataset": dataset_obj,
             "provenance": {},
         }
-        if self.source.type is not None:
-            record["provenance"]["source_type"] = self.source.type
-        if self.source.url is not None:
-            record["provenance"]["source_url"] = self.source.url
-        citation = _citation_url_value(self.source.citation)
-        if citation is not None:
-            record["provenance"]["citation"] = citation
-        if self.source.retrieved_at is not None:
-            record["provenance"]["retrieved_at"] = self.source.retrieved_at
-        if self.source.curated_by is not None:
-            record["provenance"]["curated_by"] = self.source.curated_by
+        record["provenance"] = _provenance_record(self.source)
         if self.comment:
             record["notes"] = list(self.comment)
         return record_to_snake_aliases(record)

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -302,16 +302,16 @@ def _year_value(value: Any) -> int | None:
 class ProvenanceInfo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    type: str | None = None
-    name: str | None = None
-    file: str | None = None
-    url: str | None = None
-    citation: str | None = Field(default=None, validation_alias=AliasChoices("citation", "citation_doi"))
-    retrieved_at: int | str | None = None
-    workflow_version: str | None = None
-    file_hash: str | None = None
-    curated_by: str | None = None
-    comment: str | None = None
+    type: str | None = Field(default=None, description="Origin category of the record (e.g. 'datasheet', 'measurement', 'catalog', 'manual'); schema-required, so save paths apply a documented category default when unset.")
+    name: str | None = Field(default=None, description="Human-readable label of the source (e.g. 'Acme datasheet portal').")
+    file: str | None = Field(default=None, description="Filename of the source document; absent unless a real source file exists.")
+    url: str | None = Field(default=None, description="URL of the original source document.")
+    citation: str | None = Field(default=None, validation_alias=AliasChoices("citation", "citation_doi"), description="Citable reference URL (a DOI URL preferred).")
+    retrieved_at: int | str | None = Field(default=None, description="When the record was retrieved/ingested: Unix seconds, ISO 8601 string, or datetime/date (defaults to now at save).")
+    workflow_version: str | None = Field(default=None, description="Version of the ingestion workflow that created this record.")
+    file_hash: str | None = Field(default=None, description="SHA-256 hex digest (64 chars) of the source file.")
+    curated_by: str | None = Field(default=None, description="ORCID or name of the person who curated this record.")
+    comment: str | None = Field(default=None, description="Free-text provenance note.")
 
 
 class ProtocolInfo(BaseModel):
@@ -1255,48 +1255,46 @@ class CellSpecification(BundleJsonModel):
     default_filename: ClassVar[str] = CELL_SPEC_FILENAME
 
     kind: str = "CellSpecification"
-    id: str | None = None
+    id: str | None = Field(default=None, description="Canonical IRI for this cell-spec record (https://w3id.org/battinfo/spec/{uid}); minted at save time when omitted.")
     # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
-    uid: str | None = Field(default=None, exclude=True, repr=False)
-    name: str | None = None
-    manufacturer: str = ""
-    # Canonical IRI of the manufacturer's organization record. The schema types manufacturer as an
-    # Organization object; keeping the name a plain string preserves the fluent authoring API while
-    # this optional id carries the org link (previously dropped on save).
-    manufacturer_id: str | None = None
-    model: str = ""
-    format: str = "unknown"
-    chemistry: str = "unknown"
-    product_type: CellProductType | None = None
-    positive_electrode_basis: str | None = None
-    negative_electrode_basis: str | None = None
-    size_code: str | None = None
-    iec_code: str | None = None
-    country_of_origin: str | None = None
-    rechargeable: bool | None = None
-    year: int | None = None
-    datasheet_revision: str | None = None
-    cell_specification_id: str | None = None
-    properties: dict[str, Any] = Field(default_factory=dict)
+    uid: str | None = Field(default=None, exclude=True, repr=False, description="Transient 16-char Crockford Base32 uid used to mint the canonical IRI when no id is given; never serialized.")
+    name: str | None = Field(default=None, description="Full display name of the product; defaults to 'manufacturer model'.")
+    manufacturer: str = Field(default="", description="The company that manufactured this cell (plain name; use manufacturer_id for the org record link).")
+    # The schema types manufacturer as an Organization object; keeping the name a plain string
+    # preserves the fluent authoring API while this optional id carries the org link.
+    manufacturer_id: str | None = Field(default=None, description="Canonical IRI of the manufacturer's organization record.")
+    model: str = Field(default="", description="Manufacturer's product model number or name (authoring alias: model_name=).")
+    format: str = Field(default="unknown", description="Physical format (geometry) of the cell housing: cylindrical, prismatic, pouch, coin, other, or unknown.")
+    chemistry: str = Field(default="unknown", description="Cell chemistry label (e.g. 'LFP', 'NMC', 'Li-primary').")
+    product_type: CellProductType | None = Field(default=None, description="Product maturity level (e.g. commercial, prototype, research).")
+    positive_electrode_basis: str | None = Field(default=None, description="Primary active material basis of the positive electrode (e.g. 'NMC811').")
+    negative_electrode_basis: str | None = Field(default=None, description="Primary active material basis of the negative electrode (e.g. 'graphite').")
+    size_code: str | None = Field(default=None, description="Standardised size code (e.g. '18650', '21700', 'AA').")
+    iec_code: str | None = Field(default=None, description="IEC 60086 or IEC 61960 code string (e.g. 'LR6', 'ICR18650').")
+    country_of_origin: str | None = Field(default=None, description="Country where the cell is manufactured.")
+    rechargeable: bool | None = Field(default=None, description="True for secondary (rechargeable) cells; false for primary.")
+    year: int | None = Field(default=None, description="Year the product or its datasheet was released.")
+    datasheet_revision: str | None = Field(default=None, description="Revision label of the source datasheet this spec was taken from.")
+    cell_specification_id: str | None = Field(default=None, description="IRI of a linked library specification record carrying the detailed datasheet structure.")
+    properties: dict[str, Any] = Field(default_factory=dict, description="Quantitative spec properties as name -> {value, unit} quantity objects (authoring alias: specs=; run 'battinfo properties list' for valid names).")
     # Datasheet structure (merged from the former CellSpecification).
-    construction: dict[str, Any] = Field(default_factory=dict)
-    positive_electrode: Electrode | None = None
-    negative_electrode: Electrode | None = None
-    electrolyte: Electrolyte | None = None
-    separator: Separator | None = None
-    housing: Housing | None = None
+    construction: dict[str, Any] = Field(default_factory=dict, description="As-designed construction details (assembly type, layering, stack geometry).")
+    positive_electrode: Electrode | None = Field(default=None, description="Inline positive-electrode datasheet structure (coating, current collector, composition).")
+    negative_electrode: Electrode | None = Field(default=None, description="Inline negative-electrode datasheet structure (coating, current collector, composition).")
+    electrolyte: Electrolyte | None = Field(default=None, description="Inline electrolyte description (solvents, salts, additives).")
+    separator: Separator | None = Field(default=None, description="Inline separator description (material, thickness, coating).")
+    housing: Housing | None = Field(default=None, description="Format-neutral housing description (case, seal, tabs; replaces the retired coin_hardware dict).")
     # Optional canonical IRIs of standalone component-spec records this cell-spec references (used
-    # instead of, or alongside, the inline holders above). The schema permits these; the model
-    # previously dropped them, so only the JSON-LD inline re-map preserved them.
-    positive_electrode_spec_id: str | None = None
-    negative_electrode_spec_id: str | None = None
-    electrolyte_spec_id: str | None = None
-    separator_spec_id: str | None = None
-    housing_spec_id: str | None = None
-    specification_comment: list[str] = Field(default_factory=list)
-    bibliography: dict[str, Any] = Field(default_factory=dict)
-    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo)
-    comment: list[str] = Field(default_factory=list)
+    # instead of, or alongside, the inline holders above).
+    positive_electrode_spec_id: str | None = Field(default=None, description="IRI of a standalone positive-electrode-spec record referenced instead of (or alongside) the inline structure.")
+    negative_electrode_spec_id: str | None = Field(default=None, description="IRI of a standalone negative-electrode-spec record.")
+    electrolyte_spec_id: str | None = Field(default=None, description="IRI of a standalone electrolyte-spec record.")
+    separator_spec_id: str | None = Field(default=None, description="IRI of a standalone separator-spec record.")
+    housing_spec_id: str | None = Field(default=None, description="IRI of a standalone housing-spec record.")
+    specification_comment: list[str] = Field(default_factory=list, description="Free-text notes attached to the library specification block (distinct from record-level comment).")
+    bibliography: dict[str, Any] = Field(default_factory=dict, description="Bibliographic links for this product (e.g. subject_of article references).")
+    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, source_file=, citation=, retrieved_at=, ...).")
+    comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
     # Audit note (model-as-source-of-truth): the cell-spec schema also permits `brand`,
     # `battery_category`, `category`, `url`, `additional_type`, `manufacturing_place`, `editorial`,
     # `hazardous_substances`, `critical_raw_materials`, `extinguishing_agent`, `funding`, and
@@ -1743,22 +1741,22 @@ class CellInstance(BundleJsonModel):
     default_filename: ClassVar[str] = CELL_INSTANCE_FILENAME
 
     kind: str = "CellInstance"
-    id: str | None = None
+    id: str | None = Field(default=None, description="Canonical IRI for this physical cell (https://w3id.org/battinfo/cell/{uid}); minted at save time when omitted.")
     # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
-    uid: str | None = Field(default=None, exclude=True, repr=False)
-    name: str | None = None
-    cell_spec_id: str | None = None
-    cell_spec: CellSpecification | None = Field(default=None, exclude=True, repr=False)
-    serial_number: str | None = None
-    batch_id: str | None = None
-    grade: str | None = None
-    manufactured_at: int | str | None = None
-    expires_at: int | str | None = None
-    measured: dict[str, Any] = Field(default_factory=dict)
-    conformance: Conformance | None = None
-    dataset_ids: list[str] = Field(default_factory=list)
-    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo)
-    comment: list[str] = Field(default_factory=list)
+    uid: str | None = Field(default=None, exclude=True, repr=False, description="Transient 16-char Crockford Base32 uid used to mint the canonical IRI when no id is given; never serialized.")
+    name: str | None = Field(default=None, description="Display name; defaults to the serial number or batch id.")
+    cell_spec_id: str | None = Field(default=None, description="IRI of the cell spec this physical cell instantiates (required at save).")
+    cell_spec: CellSpecification | None = Field(default=None, exclude=True, repr=False, description="Linked cell-spec object (alternative to cell_spec_id; may also be passed positionally).")
+    serial_number: str | None = Field(default=None, description="Manufacturer or lab serial number of this individual cell.")
+    batch_id: str | None = Field(default=None, description="Production or delivery batch identifier.")
+    grade: str | None = Field(default=None, description="Sorting/binning grade assigned to this cell (e.g. 'A', 'B').")
+    manufactured_at: int | str | None = Field(default=None, description="When the cell was manufactured: Unix seconds, ISO 8601 string, or datetime/date.")
+    expires_at: int | str | None = Field(default=None, description="Use-by / expiry time: Unix seconds, ISO 8601 string, or datetime/date.")
+    measured: dict[str, Any] = Field(default_factory=dict, description="Per-cell measured values as name -> {value, unit} quantity objects (e.g. mass, initial capacity).")
+    conformance: Conformance | None = Field(default=None, description="Conformance verdict of this cell against its spec (EARL-mapped status plus deviations).")
+    dataset_ids: list[str] = Field(default_factory=list, description="IRIs of datasets recorded on this cell (authoring alias: dataset_id= for a single one).")
+    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, retrieved_at=, ...).")
+    comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
 
     def __init__(self, cell_spec: CellSpecification | None = None, /, **data: Any) -> None:
         # Absorb the flat authoring/input shape (formerly CellInstanceInput).
@@ -2048,26 +2046,27 @@ class TestSpec(BundleJsonModel):
 
     kind: str = "TestSpec"
     __test__ = False
-    id: str | None = None
+    id: str | None = Field(default=None, description="Canonical IRI for this test spec (https://w3id.org/battinfo/spec/{uid}); minted at save time when omitted.")
     # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
-    uid: str | None = Field(default=None, exclude=True, repr=False)
-    name: str | None = None
+    uid: str | None = Field(default=None, exclude=True, repr=False, description="Transient 16-char Crockford Base32 uid used to mint the canonical IRI when no id is given; never serialized.")
+    name: str | None = Field(default=None, description="Human-readable name of the test procedure (e.g. 'CC cycling 25degC').")
     test_type: BatteryTestType = Field(
         default=BatteryTestType.OTHER,
         validation_alias=AliasChoices("test_type", "test_kind", "kind"),
+        description="Category of test (authoring alias: kind=; e.g. 'cycling', 'capacity_check', 'eis').",
     )
-    description: str | None = None
-    version: str | None = None
-    protocol: ProtocolInfo = Field(default_factory=ProtocolInfo)
+    description: str | None = Field(default=None, description="Free-text description of the procedure's intent.")
+    version: str | None = Field(default=None, description="Version label of this procedure definition.")
+    protocol: ProtocolInfo = Field(default_factory=ProtocolInfo, description="Name and optional URL of the protocol standard followed (authoring alias: protocol_url=).")
     # Descriptive layer (canonical structured form of the procedure).
-    method: list[Step] = Field(default_factory=list)
-    record: dict[str, Any] = Field(default_factory=dict)
-    safety: dict[str, Any] = Field(default_factory=dict)
-    conditions: dict[str, Quantity] = Field(default_factory=dict)
+    method: list[Step] = Field(default_factory=list, description="Canonical structured steps of the procedure (authoring aliases: experiment=/steps= PyBaMM-style strings plus cycles=).")
+    record: dict[str, Any] = Field(default_factory=dict, description="What is recorded during execution (signals, sampling).")
+    safety: dict[str, Any] = Field(default_factory=dict, description="Safety limits and abort criteria for execution.")
+    conditions: dict[str, Quantity] = Field(default_factory=dict, description="Ambient/boundary conditions as name -> quantity (e.g. temperature).")
     # Actionable layer.
-    artifacts: list[Artifact] = Field(default_factory=list)
-    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo)
-    comment: list[str] = Field(default_factory=list)
+    artifacts: list[Artifact] = Field(default_factory=list, description="Machine-actionable protocol artifacts (e.g. cycler programs, PyBaMM experiments) attached to this spec.")
+    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, retrieved_at=, ...).")
+    comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
 
     def __init__(self, /, **data: Any) -> None:
         # Absorb the flat authoring/input shape (formerly TestSpecInput). The discriminator
@@ -2243,29 +2242,30 @@ class Test(BundleJsonModel):
 
     kind: str = "Test"
     __test__ = False
-    id: str | None = None
+    id: str | None = Field(default=None, description="Canonical IRI for this test execution (https://w3id.org/battinfo/test/{uid}); minted at save time when omitted.")
     # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
-    uid: str | None = Field(default=None, exclude=True, repr=False)
-    name: str | None = None
+    uid: str | None = Field(default=None, exclude=True, repr=False, description="Transient 16-char Crockford Base32 uid used to mint the canonical IRI when no id is given; never serialized.")
+    name: str | None = Field(default=None, description="Display name; defaults to '<cell name> <protocol or kind>'.")
     test_type: BatteryTestType = Field(
         default=BatteryTestType.OTHER,
         validation_alias=AliasChoices("test_type", "test_kind", "kind"),
+        description="Category of test (authoring alias: kind=; e.g. 'cycling', 'capacity_check', 'eis').",
     )
-    protocol_id: str | None = None
-    protocol_entity: TestSpec | None = Field(default=None, exclude=True, repr=False)
-    cell_instance_id: str | None = None
-    cell: CellInstance | None = Field(default=None, exclude=True, repr=False)
-    description: str | None = None
-    status: str | None = None
-    protocol: ProtocolInfo = Field(default_factory=ProtocolInfo)
-    instrument: str | None = None
-    started_at: int | str | None = None
-    ended_at: int | str | None = None
-    dataset_ids: list[str] = Field(default_factory=list)
-    conformance: TestConformance | None = None
-    artifacts: list[Artifact] = Field(default_factory=list)
-    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo)
-    comment: list[str] = Field(default_factory=list)
+    protocol_id: str | None = Field(default=None, description="IRI of the test spec this execution followed.")
+    protocol_entity: TestSpec | None = Field(default=None, exclude=True, repr=False, description="Linked test-spec object (alternative to protocol_id).")
+    cell_instance_id: str | None = Field(default=None, description="IRI of the physical cell under test (authoring alias: cell_id=; required at save).")
+    cell: CellInstance | None = Field(default=None, exclude=True, repr=False, description="Linked cell-instance object (alternative to cell_instance_id; may also be passed positionally).")
+    description: str | None = Field(default=None, description="Free-text description of this execution.")
+    status: str | None = Field(default=None, description="Execution status (e.g. 'running', 'completed', 'aborted').")
+    protocol: ProtocolInfo = Field(default_factory=ProtocolInfo, description="Name and optional URL of the protocol followed (authoring aliases: protocol_name=, protocol_url=).")
+    instrument: str | None = Field(default=None, description="Instrument/cycler the test ran on (authoring alias: instrument_name=).")
+    started_at: int | str | None = Field(default=None, description="When the test started: Unix seconds, ISO 8601 string, or datetime/date.")
+    ended_at: int | str | None = Field(default=None, description="When the test ended: Unix seconds, ISO 8601 string, or datetime/date.")
+    dataset_ids: list[str] = Field(default_factory=list, description="IRIs of datasets produced by this test.")
+    conformance: TestConformance | None = Field(default=None, description="Conformance of the execution against its test spec (status plus deviations).")
+    artifacts: list[Artifact] = Field(default_factory=list, description="Machine-actionable artifacts used in this execution (e.g. the cycler program as run).")
+    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, retrieved_at=, ...).")
+    comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
 
     def __init__(self, cell: CellInstance | None = None, /, **data: Any) -> None:
         # Absorb the flat authoring/input shape (formerly TestInput).
@@ -2454,49 +2454,49 @@ class Dataset(BundleJsonModel):
     default_filename: ClassVar[str] = DATASET_FILENAME
 
     kind: str = "Dataset"
-    id: str | None = None
+    id: str | None = Field(default=None, description="Canonical IRI for this dataset (https://w3id.org/battinfo/dataset/{uid}); minted at save time when omitted.")
     # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
-    uid: str | None = Field(default=None, exclude=True, repr=False)
-    identifier: Any = None
-    name: str | None = None
-    description: str | None = None
-    license: str | None = None
-    same_as: list[str] = Field(default_factory=list, validation_alias=AliasChoices("same_as", "sameAs"))
-    additional_type: list[str] = Field(default_factory=list, validation_alias=AliasChoices("additional_type", "additionalType"))
-    version: str | None = None
-    keywords: list[str] = Field(default_factory=list)
-    creators: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("creators", "creator"))
-    publisher: dict[str, Any] | None = None
-    funders: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("funders", "funder"))
-    citations: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("citations", "citation"))
-    measurement_techniques: list[str] = Field(default_factory=list, validation_alias=AliasChoices("measurement_techniques", "measurementTechnique"))
-    measurement_methods: list[str] = Field(default_factory=list, validation_alias=AliasChoices("measurement_methods", "measurementMethod"))
-    variable_measured: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("variable_measured", "variableMeasured"))
-    is_accessible_for_free: bool | None = Field(default=None, validation_alias=AliasChoices("is_accessible_for_free", "isAccessibleForFree"))
-    conditions_of_access: str | None = Field(default=None, validation_alias=AliasChoices("conditions_of_access", "conditionsOfAccess"))
-    in_language: str | None = Field(default=None, validation_alias=AliasChoices("in_language", "inLanguage"))
-    data_format: str | None = None
-    dataset_path: str | None = Field(default=None, validation_alias=AliasChoices("dataset_path", "path"))
-    access_url: str | None = None
-    download_url: str | None = None
-    created_at: int | str | None = Field(default=None, validation_alias=AliasChoices("created_at", "dateCreated"))
-    modified_at: int | str | None = Field(default=None, validation_alias=AliasChoices("modified_at", "dateModified"))
-    published_at: int | str | None = Field(default=None, validation_alias=AliasChoices("published_at", "datePublished"))
-    temporal_coverage: str | None = Field(default=None, validation_alias=AliasChoices("temporal_coverage", "temporalCoverage"))
-    spatial_coverage: str | None = Field(default=None, validation_alias=AliasChoices("spatial_coverage", "spatialCoverage"))
-    is_based_on: list[str] = Field(default_factory=list, validation_alias=AliasChoices("is_based_on", "isBasedOn"))
-    included_in_data_catalog: str | dict[str, Any] | None = Field(default=None, validation_alias=AliasChoices("included_in_data_catalog", "includedInDataCatalog"))
-    main_entity: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("main_entity", "mainEntity"))
-    distributions: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("distributions", "distribution"))
-    checksum: ChecksumInfo = Field(default_factory=ChecksumInfo)
-    cell_instance_id: str | None = None
-    test_id: str | None = None
-    related_cell_ids: list[str] = Field(default_factory=list)
-    related_test_ids: list[str] = Field(default_factory=list)
-    test: Test | None = Field(default=None, exclude=True, repr=False)
-    cell: CellInstance | None = Field(default=None, exclude=True, repr=False)
-    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo)
-    comment: list[str] = Field(default_factory=list)
+    uid: str | None = Field(default=None, exclude=True, repr=False, description="Transient 16-char Crockford Base32 uid used to mint the canonical IRI when no id is given; never serialized.")
+    identifier: Any = Field(default=None, description="External identifier (e.g. {'property_id': 'doi', 'value': '10.5281/...'}); defaults to one derived from the IRI.")
+    name: str | None = Field(default=None, description="Dataset title (authoring alias: title=).")
+    description: str | None = Field(default=None, description="Free-text description of the dataset contents.")
+    license: str | None = Field(default=None, description="License URL (e.g. a creativecommons.org license).")
+    same_as: list[str] = Field(default_factory=list, validation_alias=AliasChoices("same_as", "sameAs"), description="URLs of other representations of this same dataset.")
+    additional_type: list[str] = Field(default_factory=list, validation_alias=AliasChoices("additional_type", "additionalType"), description="Additional schema.org/ontology type IRIs for discovery.")
+    version: str | None = Field(default=None, description="Dataset version label.")
+    keywords: list[str] = Field(default_factory=list, description="Free-text discovery keywords.")
+    creators: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("creators", "creator"), description="Creator agents; dicts with name and optionally orcid, given_name/family_name, affiliation.")
+    publisher: dict[str, Any] | None = Field(default=None, description="Publishing agent (name plus optional url/ROR sameAs).")
+    funders: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("funders", "funder"), description="Funding agents (name plus optional ROR sameAs).")
+    citations: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("citations", "citation"), description="Bibliographic references describing this dataset (list; a flat string citation= is routed to provenance instead).")
+    measurement_techniques: list[str] = Field(default_factory=list, validation_alias=AliasChoices("measurement_techniques", "measurementTechnique"), description="Measurement techniques used (e.g. 'electrochemical cycling').")
+    measurement_methods: list[str] = Field(default_factory=list, validation_alias=AliasChoices("measurement_methods", "measurementMethod"), description="Measurement methods used (e.g. 'constant current').")
+    variable_measured: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("variable_measured", "variableMeasured"), description="Measured variables; dicts with name, unit_text, and optional QUDT sameAs.")
+    is_accessible_for_free: bool | None = Field(default=None, validation_alias=AliasChoices("is_accessible_for_free", "isAccessibleForFree"), description="Whether the data is accessible without payment.")
+    conditions_of_access: str | None = Field(default=None, validation_alias=AliasChoices("conditions_of_access", "conditionsOfAccess"), description="Access conditions statement (e.g. 'open', 'on request').")
+    in_language: str | None = Field(default=None, validation_alias=AliasChoices("in_language", "inLanguage"), description="Language tag of textual content (e.g. 'en').")
+    data_format: str | None = Field(default=None, description="Media type of the data (authoring alias: format=; e.g. 'application/x-hdf5').")
+    dataset_path: str | None = Field(default=None, validation_alias=AliasChoices("dataset_path", "path"), description="Local path to the data (may also be passed positionally); workspace/publication flows derive access_url from it.")
+    access_url: str | None = Field(default=None, description="Landing page or direct download URL where the data lives (schema-required at serialization; a dataset path or provenance source_url also satisfies it).")
+    download_url: str | None = Field(default=None, description="Direct download URL when it differs from the landing page.")
+    created_at: int | str | None = Field(default=None, validation_alias=AliasChoices("created_at", "dateCreated"), description="When the dataset was created: Unix seconds, ISO 8601 string, or datetime/date (defaults to now at save).")
+    modified_at: int | str | None = Field(default=None, validation_alias=AliasChoices("modified_at", "dateModified"), description="Last modification time; defaults to created_at.")
+    published_at: int | str | None = Field(default=None, validation_alias=AliasChoices("published_at", "datePublished"), description="Publication time; defaults to created_at.")
+    temporal_coverage: str | None = Field(default=None, validation_alias=AliasChoices("temporal_coverage", "temporalCoverage"), description="Time interval the data covers (ISO 8601 interval, e.g. '2026-01-01/2026-01-31').")
+    spatial_coverage: str | None = Field(default=None, validation_alias=AliasChoices("spatial_coverage", "spatialCoverage"), description="Place the data was collected (free text).")
+    is_based_on: list[str] = Field(default_factory=list, validation_alias=AliasChoices("is_based_on", "isBasedOn"), description="URLs of resources this dataset derives from (e.g. a protocol).")
+    included_in_data_catalog: str | dict[str, Any] | None = Field(default=None, validation_alias=AliasChoices("included_in_data_catalog", "includedInDataCatalog"), description="Catalog this dataset is listed in (URL or DataCatalog object).")
+    main_entity: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("main_entity", "mainEntity"), description="Primary content entities (e.g. a CSVW Table with its tableSchema).")
+    distributions: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("distributions", "distribution"), description="DataDownload entries (content_url, encoding_format, checksum); synthesized from download_url/data_format/checksum when omitted.")
+    checksum: ChecksumInfo = Field(default_factory=ChecksumInfo, description="Checksum of the primary distribution (authoring aliases: checksum_algorithm=, checksum_value=).")
+    cell_instance_id: str | None = Field(default=None, description="IRI of the primary cell this data was measured on (emitted first in the record's about list).")
+    test_id: str | None = Field(default=None, description="IRI of the primary test that produced this data (emitted first in the record's about list).")
+    related_cell_ids: list[str] = Field(default_factory=list, description="IRIs of additional related cells beyond the primary one.")
+    related_test_ids: list[str] = Field(default_factory=list, description="IRIs of additional related tests beyond the primary one.")
+    test: Test | None = Field(default=None, exclude=True, repr=False, description="Linked test object (alternative to test_id).")
+    cell: CellInstance | None = Field(default=None, exclude=True, repr=False, description="Linked cell-instance object (alternative to cell_instance_id).")
+    source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, retrieved_at=, curated_by=, ...).")
+    comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
 
     def __init__(self, path: str | Path | None = None, /, **data: Any) -> None:
         if path is not None and "dataset_path" not in data and "path" not in data:

--- a/src/battinfo/data/schemas/cell-instance.schema.json
+++ b/src/battinfo/data/schemas/cell-instance.schema.json
@@ -209,6 +209,32 @@
         },
         "retrieved_at": {
           "$ref": "#/$defs/UnixTime"
+        },
+        "source_name": {
+          "type": "string"
+        },
+        "source_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "workflow_version": {
+          "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/src/battinfo/data/schemas/cell-spec.schema.json
+++ b/src/battinfo/data/schemas/cell-spec.schema.json
@@ -279,6 +279,9 @@
         },
         "comment": {
           "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
         }
       }
     },

--- a/src/battinfo/data/schemas/dataset.schema.json
+++ b/src/battinfo/data/schemas/dataset.schema.json
@@ -313,6 +313,13 @@
         },
         "workflow_version": {
           "type": "string"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/src/battinfo/data/schemas/material-spec.schema.json
+++ b/src/battinfo/data/schemas/material-spec.schema.json
@@ -146,6 +146,19 @@
         },
         "retrieved_at": {
           "$ref": "#/$defs/UnixTime"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "workflow_version": {
+          "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/src/battinfo/data/schemas/material.schema.json
+++ b/src/battinfo/data/schemas/material.schema.json
@@ -114,6 +114,19 @@
         },
         "retrieved_at": {
           "$ref": "#/$defs/UnixTime"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "workflow_version": {
+          "type": "string"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/src/battinfo/data/schemas/test-protocol.schema.json
+++ b/src/battinfo/data/schemas/test-protocol.schema.json
@@ -212,6 +212,19 @@
         },
         "workflow_version": {
           "type": "string"
+        },
+        "source_name": {
+          "type": "string"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/src/battinfo/data/schemas/test.schema.json
+++ b/src/battinfo/data/schemas/test.schema.json
@@ -243,6 +243,19 @@
         },
         "workflow_version": {
           "type": "string"
+        },
+        "source_name": {
+          "type": "string"
+        },
+        "file_hash": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "curated_by": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
         }
       }
     },

--- a/src/battinfo/interop/_common.py
+++ b/src/battinfo/interop/_common.py
@@ -1,0 +1,25 @@
+"""Shared helpers for the interop importers."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json_source(path: str | Path) -> Any:
+    """Read and parse a JSON source file for an importer.
+
+    Every failure carries the file path, so a batch import over many files reports
+    WHICH file was unreadable or malformed instead of a bare JSONDecodeError.
+    """
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"Cannot read {p}: {exc}") from exc
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{p} is not valid JSON (line {exc.lineno}, column {exc.colno}): {exc.msg}"
+        ) from exc

--- a/src/battinfo/interop/battery_data_commons.py
+++ b/src/battinfo/interop/battery_data_commons.py
@@ -27,7 +27,6 @@ identifiers, not published registry entries.
 from __future__ import annotations
 
 import hashlib
-import json
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -45,6 +44,7 @@ from battinfo.api import (
     create_material_spec,
 )
 from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
+from battinfo.interop._common import load_json_source
 
 PathLike = str | Path
 
@@ -336,17 +336,21 @@ def batch_import_bdc(source: PathLike, *, limit: int | None = None,
     for file in files:
         if limit is not None and len(imports) >= limit:
             break
-        record = json.loads(file.read_text(encoding="utf-8"))
+        record = load_json_source(file)
         if str(record.get("record_status", "active")) != "active":
             continue
         imp = import_bdc_record(record, validate=validate, _materials=materials)
         if imp is not None:
             imports.append(imp)
 
+    batch_warnings = [w for imp in imports for w in imp.warnings]
+    if not imports:
+        detail = f"{len(files)} file(s) matched" if files else "no bdc_*.json files found"
+        batch_warnings.append(f"{path}: 0 records imported ({detail}).")
     return BdcImportPackage(
         material_specs=list(materials.values()),
         imports=imports,
-        warnings=[w for imp in imports for w in imp.warnings],
+        warnings=batch_warnings,
     )
 
 

--- a/src/battinfo/interop/bpx.py
+++ b/src/battinfo/interop/bpx.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
 
+from battinfo.interop._common import load_json_source
+
 PathLike = str | Path
 
 # BPX "Parameterisation.Cell" key → (battinfo_spec_key, unit, scale_to_unit)
@@ -110,7 +112,7 @@ def _load_bpx(source: Mapping[str, Any] | str | Path) -> tuple[dict[str, Any], s
     if isinstance(source, Mapping):
         return dict(source), "bpx-parameter.json"
     path = Path(source)
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = load_json_source(path)
     return data, path.name
 
 

--- a/src/battinfo/interop/converter.py
+++ b/src/battinfo/interop/converter.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
 from battinfo.bundle import SCHEMA_VERSION, CellInstance, CellSpecification, ProvenanceInfo, Test, TestSpec
+from battinfo.interop._common import load_json_source
 from battinfo.interop.protocols import _num
 
 if TYPE_CHECKING:
@@ -504,7 +505,7 @@ def _load_source(source: Mapping[str, Any] | str | Path) -> tuple[dict[str, Any]
     if isinstance(source, Mapping):
         return copy.deepcopy(dict(source)), "converter-export.jsonld"
     path = Path(source)
-    return json.loads(path.read_text(encoding="utf-8")), path.name
+    return load_json_source(path), path.name
 
 
 def _workflow_version(converter_version: str | None, schema_version: str | None) -> str | None:

--- a/src/battinfo/interop/discovery.py
+++ b/src/battinfo/interop/discovery.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import zipfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -51,6 +52,7 @@ from battinfo.api import (
     create_material_spec,
 )
 from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
+from battinfo.interop._common import load_json_source
 from battinfo.interop.protocols import _num
 
 PathLike = str | Path
@@ -353,6 +355,12 @@ class _Builder:
         return cell
 
     def package(self) -> DiscoveryImportPackage:
+        if not self.cells:
+            # An empty result from a real source is worth a word: silence reads as
+            # "imported everything" when nothing matched.
+            self.warnings.append(
+                f"{self.source_file}: no cells found — 0 records imported."
+            )
         return DiscoveryImportPackage(
             source=self.source,
             material_specs=list(self._materials.values()),
@@ -419,12 +427,32 @@ def import_discovery_eln(
         Validate each produced record against its schema.
     """
     path = Path(source)
-    crate = path / "ro-crate-metadata.json" if path.is_dir() else path
-    graph = json.loads(crate.read_text(encoding="utf-8")).get("@graph", [])
+    if path.is_file() and zipfile.is_zipfile(path):
+        # A real `.eln` export is a ZIP archive wrapping the crate directory.
+        with zipfile.ZipFile(path) as archive:
+            candidates = [n for n in archive.namelist() if n.endswith("ro-crate-metadata.json")]
+            if not candidates:
+                raise ValueError(
+                    f"{path} contains no ro-crate-metadata.json — not an RO-Crate .eln archive."
+                )
+            candidates.sort(key=lambda n: n.count("/"))  # shallowest crate wins
+            try:
+                graph = json.loads(archive.read(candidates[0]).decode("utf-8")).get("@graph", [])
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{path} ({candidates[0]}) is not valid JSON "
+                    f"(line {exc.lineno}, column {exc.colno}): {exc.msg}"
+                ) from exc
+        source_name = path.name
+    else:
+        crate = path / "ro-crate-metadata.json" if path.is_dir() else path
+        loaded = load_json_source(crate)
+        graph = loaded.get("@graph", []) if isinstance(loaded, Mapping) else []
+        source_name = crate.name
     index: dict[str, Mapping[str, Any]] = {
         n["@id"]: n for n in graph if isinstance(n, Mapping) and "@id" in n
     }
-    builder = _Builder("eln", crate.name, validate)
+    builder = _Builder("eln", source_name, validate)
 
     cells = [n for n in graph if isinstance(n, Mapping) and "CoinCell" in _node_types(n)]
     cells.sort(key=lambda n: n.get("@id", ""))

--- a/src/battinfo/interop/protocols.py
+++ b/src/battinfo/interop/protocols.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from battinfo.bundle import Artifact, ProvenanceInfo, TestSpec
+from battinfo.interop._common import load_json_source
 from battinfo.testmethod import (
     ExperimentSyntaxError,
     Quantity,
@@ -41,8 +42,9 @@ def _load(source: Any) -> Any:
     """Accept a parsed object, a JSON string, or a path to a JSON file."""
     if isinstance(source, (dict, list)):
         return source
-    text = Path(source).read_text(encoding="utf-8") if _looks_like_path(source) else str(source)
-    return json.loads(text)
+    if _looks_like_path(source):
+        return load_json_source(source)
+    return json.loads(str(source))
 
 
 def _looks_like_path(source: Any) -> bool:
@@ -91,16 +93,33 @@ def _provenance(source_file: str | None) -> ProvenanceInfo:
 _AURORA_CONFORMS = "https://github.com/EmpaEconversion/aurora-unicycler"
 
 
-def _aurora_leaf(s: dict) -> Step | None:
+def _num_field(s: dict, key: str, warnings: list[str]) -> float | None:
+    """Parse a numeric field of an aurora block; a PRESENT but unparseable value is
+    surfaced as a warning instead of being silently ignored."""
+    raw = s.get(key)
+    if raw is None:
+        return None
+    value = _num(raw)
+    if value is None:
+        context = f"step '{s['step']}': " if s.get("step") else ""
+        warnings.append(
+            f"aurora-unicycler: {context}{key}={raw!r} is not a finite number; ignored."
+        )
+    return value
+
+
+def _aurora_leaf(s: dict, warnings: list[str]) -> Step | None:
     kind = s.get("step")
     if kind == "open_circuit_voltage":
         st = Step(mode="rest", direction="rest")
-        if _num(s.get("until_time_s")) is not None:
-            st.duration = _q(_num(s["until_time_s"]), "s")
+        duration = _num_field(s, "until_time_s", warnings)
+        if duration is not None:
+            st.duration = _q(duration, "s")
         return st
 
     if kind == "constant_current":
-        rate, cur = _num(s.get("rate_C")), _num(s.get("current_mA"))
+        rate = _num_field(s, "rate_C", warnings)
+        cur = _num_field(s, "current_mA", warnings)
         signed = rate if rate is not None else cur
         direction = "discharge" if (signed is not None and signed < 0) else "charge"
         setpoints: dict[str, Quantity] = {}
@@ -110,28 +129,34 @@ def _aurora_leaf(s: dict) -> Step | None:
             setpoints["current"] = _q(abs(cur) / 1000.0, "A")
         st = Step(mode="cc", direction=direction, setpoints=setpoints)
         terms: list[Termination] = []
-        if _num(s.get("until_voltage_V")) is not None:
-            terms.append(Termination(quantity="voltage", value=_num(s["until_voltage_V"]), unit="V",
+        until_v = _num_field(s, "until_voltage_V", warnings)
+        if until_v is not None:
+            terms.append(Termination(quantity="voltage", value=until_v, unit="V",
                                      direction="above" if direction == "charge" else "below"))
-        if _num(s.get("until_time_s")) is not None:
-            st.duration = _q(_num(s["until_time_s"]), "s")
+        duration = _num_field(s, "until_time_s", warnings)
+        if duration is not None:
+            st.duration = _q(duration, "s")
         st.termination = terms
         return st
 
     if kind == "constant_voltage":
         setpoints = {}
-        if _num(s.get("voltage_V")) is not None:
-            setpoints["voltage"] = _q(_num(s["voltage_V"]), "V")
+        voltage = _num_field(s, "voltage_V", warnings)
+        if voltage is not None:
+            setpoints["voltage"] = _q(voltage, "V")
         st = Step(mode="cv", direction="hold", setpoints=setpoints)
         terms = []
-        if _num(s.get("until_rate_C")) is not None:
-            terms.append(Termination(quantity="c_rate", value=abs(_num(s["until_rate_C"])),
+        until_rate = _num_field(s, "until_rate_C", warnings)
+        if until_rate is not None:
+            terms.append(Termination(quantity="c_rate", value=abs(until_rate),
                                      unit="A/Ah", direction="below"))
-        if _num(s.get("until_current_mA")) is not None:
-            terms.append(Termination(quantity="current", value=abs(_num(s["until_current_mA"])) / 1000.0,
+        until_cur = _num_field(s, "until_current_mA", warnings)
+        if until_cur is not None:
+            terms.append(Termination(quantity="current", value=abs(until_cur) / 1000.0,
                                      unit="A", direction="below"))
-        if _num(s.get("until_time_s")) is not None:
-            st.duration = _q(_num(s["until_time_s"]), "s")
+        duration = _num_field(s, "until_time_s", warnings)
+        if duration is not None:
+            st.duration = _q(duration, "s")
         st.termination = terms
         return st
 
@@ -139,16 +164,18 @@ def _aurora_leaf(s: dict) -> Step | None:
         setpoints = {}
         for key, unit in (("start_frequency_Hz", "Hz"), ("end_frequency_Hz", "Hz"),
                           ("amplitude_V", "V"), ("amplitude_mA", "mA")):
-            if _num(s.get(key)) is not None:
-                setpoints[key.rsplit("_", 1)[0]] = _q(_num(s[key]), unit)
+            value = _num_field(s, key, warnings)
+            if value is not None:
+                setpoints[key.rsplit("_", 1)[0]] = _q(value, unit)
         return Step(mode="eis", direction="hold", setpoints=setpoints)
 
     if kind == "voltage_scan":
         setpoints = {}
         for key, unit in (("start_voltage_V", "V"), ("end_voltage_V", "V"),
                           ("scan_rate_mV_per_s", "mV/s")):
-            if _num(s.get(key)) is not None:
-                setpoints[key.rsplit("_", 1)[0] if key.endswith("_V") else key] = _q(_num(s[key]), unit)
+            value = _num_field(s, key, warnings)
+            if value is not None:
+                setpoints[key.rsplit("_", 1)[0] if key.endswith("_V") else key] = _q(value, unit)
         return Step(mode="scan", direction="charge", setpoints=setpoints)
 
     return None  # tag / loop / unknown handled by the caller
@@ -175,7 +202,7 @@ def _fold_aurora_method(method: list[dict]) -> tuple[list[Step], list[str]]:
             if body:
                 flat.append({"orig": i, "step": Step(mode="group", count=count, steps=body)})
             continue
-        st = _aurora_leaf(s)
+        st = _aurora_leaf(s, warnings)
         if st is not None:
             flat.append({"orig": i, "step": st})
         else:
@@ -191,14 +218,16 @@ def import_aurora_unicycler(source: Any, *, name: str | None = None, kind: str |
     steps, warnings = _fold_aurora_method(method)
 
     record: dict[str, Any] = {}
+    _record_block = doc.get("record") or {}
     for key in ("time_s", "voltage_V", "current_mA"):
-        v = _num((doc.get("record") or {}).get(key))
+        v = _num_field(_record_block, key, warnings)
         if v is not None:
             record[key] = v
     safety: dict[str, Any] = {}
+    _safety_block = doc.get("safety") or {}
     for key in ("max_voltage_V", "min_voltage_V", "max_current_mA", "min_current_mA",
                 "max_capacity_mAh", "delay_s"):
-        v = _num((doc.get("safety") or {}).get(key))
+        v = _num_field(_safety_block, key, warnings)
         if v is not None:
             safety[key] = v
 

--- a/src/battinfo/validate/friendly.py
+++ b/src/battinfo/validate/friendly.py
@@ -1,0 +1,109 @@
+"""Render validation reports in the authoring vocabulary, aggregated.
+
+Validation collects every issue, but the save/publish raise sites used to surface only
+the FIRST error, phrased in canonical record paths (``cell_spec.cell_format``) that don't
+match what the author actually typed (``format=``). This module turns a report into one
+actionable message: all errors at once, canonical paths translated back to authoring
+kwargs, and quantity-shape errors carrying a copy-pasteable example.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+from battinfo.validate.core import ValidationIssue, ValidationReport
+
+# Canonical record path → the authoring kwarg the user actually typed. Longest-prefix
+# match, so "cell_spec.manufacturer.name" wins over "cell_spec.manufacturer".
+_AUTHORING_KWARGS: dict[str, str] = {
+    "cell_spec.cell_format": "format=",
+    "cell_spec.manufacturer.name": "manufacturer=",
+    "cell_spec.manufacturer": "manufacturer=",
+    "cell_spec.model": "model_name=",
+    "cell_spec.positive_electrode_basis": "positive_electrode_basis=",
+    "cell_spec.negative_electrode_basis": "negative_electrode_basis=",
+    "cell_instance.cell_spec_id": "cell_spec_id=",
+    "cell_instance.serial_number": "serial_number=",
+    "test.cell_id": "cell_id=",
+    "test.kind": "kind=",
+    "test_spec.kind": "kind=",
+    "dataset.name": "title=",
+    "dataset.access_url": "access_url=",
+    "provenance.source_type": "source_type=",
+    "provenance.source_url": "source_url=",
+    "provenance.source_file": "source_file=",
+    "provenance.source_name": "source_name=",
+    "provenance.retrieved_at": "retrieved_at=",
+    "provenance.citation": "citation=",
+    "provenance.file_hash": "file_hash=",
+    "provenance.curated_by": "curated_by=",
+}
+
+_REQUIRED_KEY_RE = re.compile(r"'([^']+)' is a required property")
+
+
+def _full_path(issue: ValidationIssue) -> str:
+    """Required-property errors anchor at the PARENT object; extend the path with the
+    missing key from the message so translation and reading both point at the field."""
+    path = issue.path or ""
+    match = _REQUIRED_KEY_RE.match(issue.message)
+    if match:
+        key = match.group(1)
+        return f"{path}.{key}" if path else key
+    return path
+
+
+def _authoring_kwarg(path: str) -> str | None:
+    while path:
+        if path in _AUTHORING_KWARGS:
+            return _AUTHORING_KWARGS[path]
+        if "." not in path:
+            return None
+        path = path.rsplit(".", 1)[0]
+    return None
+
+
+def _quantity_hint(path: str) -> str | None:
+    """For errors under properties.<name>, show the accepted quantity shape."""
+    parts = path.split(".")
+    if len(parts) < 2 or parts[0] != "properties":
+        return None
+    prop = parts[1]
+    from battinfo.validate.semantic import SPEC_UNIT_COMPATIBILITY  # noqa: PLC0415
+
+    units = SPEC_UNIT_COMPATIBILITY.get(prop)
+    unit = sorted(units)[0] if units else "<unit>"
+    example = json.dumps({prop: {"value": 0.0, "unit": unit}})
+    hint = f"pass a quantity object, e.g. {example}"
+    if units:
+        hint += f"; run `battinfo properties show {prop}` for accepted units"
+    return hint
+
+
+def render_issue(issue: ValidationIssue) -> str:
+    """One line for one issue: path (translated where possible), message, actionable hint."""
+    path = _full_path(issue)
+    line = f"{path}: {issue.message}" if path else issue.message
+    extras: list[str] = []
+    kwarg = _authoring_kwarg(path)
+    if kwarg:
+        extras.append(f"authoring field: {kwarg}")
+    quantity = _quantity_hint(path)
+    if quantity:
+        extras.append(quantity)
+    if issue.hint:
+        extras.append(issue.hint)
+    if extras:
+        line += " (" + "; ".join(extras) + ")"
+    return line
+
+
+def format_report_errors(report: ValidationReport, *, prefix: str = "Validation failed") -> str:
+    """Aggregate EVERY error in the report into one message (never just the first)."""
+    errors = report.errors
+    if not errors:
+        return prefix
+    if len(errors) == 1:
+        return f"{prefix}: {render_issue(errors[0])}"
+    lines = "\n".join(f"  - {render_issue(issue)}" for issue in errors)
+    return f"{prefix} with {len(errors)} errors:\n{lines}"

--- a/src/battinfo/workspace_state.py
+++ b/src/battinfo/workspace_state.py
@@ -152,7 +152,7 @@ class WorkspaceArtifact(BaseModel):
     path: str
 
 
-class WorkspaceManifest(BaseModel):
+class WorkspaceStateManifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: str = WORKSPACE_STATE_SCHEMA_VERSION
@@ -489,7 +489,7 @@ class WorkspaceStateStore:
         root_path = _as_path(root)
         raw = _read_json(root_path / WORKSPACE_STATE_FILENAME)
         _assert_compatible_state_version(raw)
-        manifest = WorkspaceManifest.model_validate(raw)
+        manifest = WorkspaceStateManifest.model_validate(raw)
         store = cls(
             root_path,
             name=manifest.workspace_id,
@@ -557,8 +557,8 @@ class WorkspaceStateStore:
         if self.descriptions:
             raise ValueError("Workspace state currently supports cell types, cells, tests, and datasets, but not saved cell descriptions.")
 
-    def _manifest(self) -> WorkspaceManifest:
-        return WorkspaceManifest(
+    def _manifest(self) -> WorkspaceStateManifest:
+        return WorkspaceStateManifest(
             workspace_id=self.name,
             title=self.title or self.name,
             description=self.description,
@@ -568,14 +568,14 @@ class WorkspaceStateStore:
             comment=list(self.comment),
         )
 
-    def _persist(self) -> tuple[WorkspaceManifest, dict[str, list[dict[str, Any]]], dict[str, str | None]]:
+    def _persist(self) -> tuple[WorkspaceStateManifest, dict[str, list[dict[str, Any]]], dict[str, str | None]]:
         self._ensure_supported_state()
         records = self.render()
         manifest = self._manifest()
         artifact_map = self._write_workspace(manifest, records)
         return manifest, records, artifact_map
 
-    def _write_workspace(self, manifest: WorkspaceManifest, records: dict[str, list[dict[str, Any]]]) -> dict[str, str | None]:
+    def _write_workspace(self, manifest: WorkspaceStateManifest, records: dict[str, list[dict[str, Any]]]) -> dict[str, str | None]:
         record_groups = {
             "cell_specs": records["cell_specs"],
             "cells": records["cell_instances"],
@@ -992,7 +992,7 @@ class WorkspaceStateStore:
     def _submission_package_path(
         self,
         *,
-        manifest: WorkspaceManifest,
+        manifest: WorkspaceStateManifest,
         target: WorkspaceTarget | None,
         resource: SubmissionResource | None,
     ) -> Path:
@@ -1005,7 +1005,7 @@ class WorkspaceStateStore:
     def _registry_intake_path(
         self,
         *,
-        manifest: WorkspaceManifest,
+        manifest: WorkspaceStateManifest,
         target: WorkspaceTarget | None,
         resource: SubmissionResource | None,
     ) -> Path:
@@ -1099,7 +1099,7 @@ def workspace_build_submission_package(
 __all__ = [
     "WORKSPACE_STATE_FILENAME",
     "WORKSPACE_STATE_SCHEMA_VERSION",
-    "WorkspaceManifest",
+    "WorkspaceStateManifest",
     "WorkspaceStateStore",
     "WorkspaceArtifact",
     "WorkspacePaths",

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -919,10 +919,12 @@ _BDF_CANONICAL_COLUMNS: list[tuple[str, str]] = [
 
 
 class AuthoringWorkspace:
-    """Simplified workspace for authoring BattINFO records.
+    """The blessed authoring surface: a simplified workspace for BattINFO records.
 
-    Wraps the lower-level :class:`battinfo.workspace.Workspace` with a
-    concise API designed for interactive / notebook use.
+    Create one with :func:`battinfo.workspace` and call :meth:`quickstart` for a
+    copy-pasteable end-to-end example. Wraps the lower-level object-graph engine
+    :class:`battinfo.Workspace` (defined in ``battinfo._workspace``) with a concise
+    API designed for interactive / notebook use.
     """
 
     def __init__(

--- a/tests/test_field_descriptions.py
+++ b/tests/test_field_descriptions.py
@@ -1,0 +1,43 @@
+"""Every authoring-model field carries a Field(description=...) (beta-hardening plan 2.2).
+
+The descriptions power help(), IDE hover, and .model_json_schema() — this gate keeps a
+newly added field from shipping undocumented.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.bundle import (
+    CellInstance,
+    CellSpecification,
+    Dataset,
+    ProvenanceInfo,
+    Test,
+    TestSpec,
+)
+
+MODELS = [CellSpecification, CellInstance, Test, TestSpec, Dataset, ProvenanceInfo]
+
+# Structural fields shared via BundleJsonModel — not part of the authoring vocabulary.
+STRUCTURAL = {"kind", "schema_version"}
+
+
+@pytest.mark.parametrize("model", MODELS, ids=lambda m: m.__name__)
+def test_every_authoring_field_has_a_description(model) -> None:
+    undocumented = sorted(
+        name
+        for name, info in model.model_fields.items()
+        if name not in STRUCTURAL and not (info.description or "").strip()
+    )
+    assert not undocumented, f"{model.__name__} fields missing Field(description=...): {undocumented}"
+
+
+def test_descriptions_reach_the_json_schema() -> None:
+    schema = Dataset.model_json_schema()
+    assert "landing page" in schema["properties"]["access_url"]["description"].lower()

--- a/tests/test_friendly_errors.py
+++ b/tests/test_friendly_errors.py
@@ -1,0 +1,106 @@
+"""Validation errors aggregate and teach (beta-hardening plan 2.3).
+
+Save/publish used to surface only the FIRST schema error, phrased in canonical record
+paths. Now: every error in one message, canonical paths translated back to the authoring
+vocabulary (cell_spec.cell_format → format=), quantity-shape errors carry a
+copy-pasteable example, and unknown-kwarg typos get a did-you-mean.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api import _validate_canonical_record
+from battinfo.bundle import CellSpecification, Dataset, Test
+
+SPEC_IRI = "https://w3id.org/battinfo/spec/aaaa-aaaa-aaaa-aaaa"
+
+
+def _bad_cell_spec_doc() -> dict:
+    return {
+        "schema_version": "0.2.0",
+        "cell_spec": {
+            "id": SPEC_IRI,
+            "short_id": "aaaaaa",
+            "name": "X",
+            "manufacturer": {"type": "Organization", "name": "Acme"},
+            "model": "X1",
+            "cell_format": "not-a-real-format",   # enum error
+            "chemistry": "LFP",
+        },
+        "properties": {"nominal_capacity": 2.5},   # bare number, not a quantity object
+        "provenance": {},                           # missing required source_type
+    }
+
+
+def test_all_errors_surface_in_one_message() -> None:
+    with pytest.raises(ValueError) as exc:
+        _validate_canonical_record(_bad_cell_spec_doc())
+    message = str(exc.value)
+    # Previously only the first of these three appeared.
+    assert "cell_format" in message
+    assert "nominal_capacity" in message
+    assert "source_type" in message
+    assert "3 errors" in message
+
+
+def test_canonical_paths_translate_to_authoring_kwargs() -> None:
+    with pytest.raises(ValueError) as exc:
+        _validate_canonical_record(_bad_cell_spec_doc())
+    message = str(exc.value)
+    assert "authoring field: format=" in message          # cell_spec.cell_format
+    assert "authoring field: source_type=" in message     # provenance.'source_type' required
+
+
+def test_quantity_shape_error_shows_example_and_command() -> None:
+    with pytest.raises(ValueError) as exc:
+        _validate_canonical_record(_bad_cell_spec_doc())
+    message = str(exc.value)
+    assert '"nominal_capacity": {"value": 0.0, "unit": "ah"}' in message
+    assert "battinfo properties show nominal_capacity" in message
+
+
+def test_required_error_path_names_the_missing_field() -> None:
+    with pytest.raises(ValueError) as exc:
+        _validate_canonical_record(_bad_cell_spec_doc())
+    # "provenance: 'source_type' is a required property" reads as the parent object;
+    # the rendered path points at the actual missing field.
+    assert "provenance.source_type" in str(exc.value)
+
+
+# ── did-you-mean on unknown kwargs (the manufacture= scenario) ─────────────────
+
+
+def test_kwarg_typo_gets_a_did_you_mean() -> None:
+    with pytest.raises(TypeError, match=r"manufacture=.*did you mean manufacturer=\?"):
+        CellSpecification(manufacture="Acme", model_name="X", chemistry="LFP", format="cylindrical")
+
+
+def test_spec_property_typo_gets_a_did_you_mean() -> None:
+    with pytest.raises(TypeError, match=r"did you mean nominal_capacity=\?"):
+        CellSpecification(
+            manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
+            nominal_capacit={"value": 2.0, "unit": "Ah"},
+        )
+
+
+def test_absorbed_authoring_aliases_still_accepted() -> None:
+    # The pre-flight check must not reject the flat authoring vocabulary that the
+    # custom __init__s absorb (kind=, cell_id=, title=, notes=, source_type=, ...).
+    test = Test(
+        cell_id="https://w3id.org/battinfo/cell/bbbb-bbbb-bbbb-bbbb",
+        name="T", kind="cycling", notes=["n"], source_type="lab",
+    )
+    assert test.test_type.value == "cycling"
+    dataset = Dataset(title="D", access_url="https://x.example/d", source_type="other")
+    assert dataset.name == "D"
+
+
+def test_dataset_kwarg_typo_gets_a_did_you_mean() -> None:
+    with pytest.raises(TypeError, match=r"acces_url=.*did you mean access_url=\?"):
+        Dataset(title="D", acces_url="https://x.example/d")

--- a/tests/test_interop_sharp_edges.py
+++ b/tests/test_interop_sharp_edges.py
@@ -1,0 +1,70 @@
+"""Interop sharp edges (beta-hardening plan 2.5).
+
+- ``import_discovery_eln`` accepts a real ``.eln`` ZIP archive, not just an unpacked crate.
+- Importer JSON errors carry the offending file's path (shared ``load_json_source``).
+- The aurora importer surfaces a present-but-unparseable numeric as a warning on the
+  imported TestSpec instead of silently ignoring the field.
+- A batch import that produces zero records from a real source says so in warnings.
+"""
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import import_discovery_eln
+from battinfo.interop._common import load_json_source
+from battinfo.interop.battery_data_commons import batch_import_bdc
+from battinfo.interop.protocols import import_aurora_unicycler
+
+FX = ROOT / "tests" / "fixtures" / "interop" / "discovery"
+ELN_JSON = FX / "ro-crate-metadata.sample.json"
+
+
+def test_import_discovery_eln_reads_a_real_zip_archive(tmp_path: Path) -> None:
+    archive = tmp_path / "export.eln"
+    with zipfile.ZipFile(archive, "w") as zf:
+        # Real .eln exports nest the crate in a top-level directory.
+        zf.write(ELN_JSON, "my-export/ro-crate-metadata.json")
+    package = import_discovery_eln(archive, validate=False)
+    reference = import_discovery_eln(ELN_JSON, validate=False)
+    assert len(package.cells) == len(reference.cells) > 0
+
+
+def test_import_discovery_eln_zip_without_crate_names_the_problem(tmp_path: Path) -> None:
+    archive = tmp_path / "not-a-crate.eln"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("readme.txt", "hello")
+    with pytest.raises(ValueError, match="ro-crate-metadata.json"):
+        import_discovery_eln(archive)
+
+
+def test_load_json_source_errors_carry_the_file_path(tmp_path: Path) -> None:
+    bad = tmp_path / "broken.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="broken.json"):
+        load_json_source(bad)
+    with pytest.raises(ValueError, match="missing.json"):
+        load_json_source(tmp_path / "missing.json")
+
+
+def test_aurora_unparseable_numeric_field_warns_on_the_record() -> None:
+    spec = import_aurora_unicycler({
+        "method": [
+            {"step": "constant_current", "rate_C": "0.5", "until_voltage_V": "4..2"},
+        ],
+    })
+    assert any("until_voltage_V" in w for w in spec.comment), spec.comment
+    # The parseable setpoint still imports.
+    assert spec.method and spec.method[0].setpoints["c_rate"].value == 0.5
+
+
+def test_bdc_batch_zero_records_is_said_out_loud(tmp_path: Path) -> None:
+    (tmp_path / "notes.txt").write_text("not a record", encoding="utf-8")
+    package = batch_import_bdc(tmp_path)
+    assert any("0 records imported" in w for w in package.warnings), package.warnings

--- a/tests/test_no_silent_drops.py
+++ b/tests/test_no_silent_drops.py
@@ -1,0 +1,138 @@
+"""Nothing accepted by the authoring models is silently dropped (beta-hardening plan 2.1).
+
+- ``specs=`` must be a mapping: a list/scalar used to be popped and discarded without a word.
+- Provenance kwargs (``source_name=``, ``file_hash=``, ``curated_by=``, ...) used to be
+  absorbed into ``source`` and then omitted from the emitted record by four of the five
+  serializers. All records now emit the full provenance block via one shared serializer,
+  the schemas accept it, and from_record reads it back losslessly.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo import validate_record
+from battinfo.api import (
+    _record_from_cell_instance,
+    _record_from_cell_spec,
+    _record_from_dataset,
+    _record_from_test,
+    _record_from_test_protocol,
+)
+from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test, TestSpec
+
+UID = "ffffffffffffffff"
+SPEC_IRI = "https://w3id.org/battinfo/spec/aaaa-aaaa-aaaa-aaaa"
+CELL_IRI = "https://w3id.org/battinfo/cell/bbbb-bbbb-bbbb-bbbb"
+SHA256 = "a" * 64
+
+PROVENANCE_KWARGS = dict(
+    source_name="Acme datasheet portal",
+    file_hash=SHA256,
+    curated_by="https://orcid.org/0000-0002-1825-0097",
+    workflow_version="ingest-1.2",
+)
+
+
+def test_specs_non_mapping_raises_with_the_fix() -> None:
+    with pytest.raises(TypeError, match="specs= must be a mapping"):
+        CellSpecification(
+            manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
+            specs=[("nominal_capacity", 2.5)],
+        )
+
+
+def test_specs_mapping_still_accepted() -> None:
+    spec = CellSpecification(
+        manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
+        specs={"nominal_capacity": {"value": 2.5, "unit": "Ah"}},
+    )
+    assert spec.properties["nominal_capacity"] == {"value": 2.5, "unit": "Ah"}
+
+
+def _assert_provenance_survives(record: dict, model_cls, prov_key: str = "provenance") -> None:
+    prov = record[prov_key]
+    assert prov["source_name"] == PROVENANCE_KWARGS["source_name"]
+    assert prov["file_hash"] == SHA256
+    assert prov["curated_by"] == PROVENANCE_KWARGS["curated_by"]
+    assert prov["workflow_version"] == PROVENANCE_KWARGS["workflow_version"]
+    result = validate_record(record)
+    assert result.ok, [str(e) for e in result.errors][:3]
+    loaded = model_cls.from_record(record)
+    assert loaded.source.name == PROVENANCE_KWARGS["source_name"]
+    assert loaded.source.file_hash == SHA256
+    assert loaded.source.curated_by == PROVENANCE_KWARGS["curated_by"]
+
+
+def test_cell_spec_provenance_round_trip() -> None:
+    record = _record_from_cell_spec(CellSpecification(
+        manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
+        uid=UID, **PROVENANCE_KWARGS,
+    ))
+    _assert_provenance_survives(record, CellSpecification)
+
+
+def test_cell_instance_provenance_round_trip() -> None:
+    record = _record_from_cell_instance(CellInstance(
+        uid=UID, cell_spec_id=SPEC_IRI, **PROVENANCE_KWARGS,
+    ))
+    _assert_provenance_survives(record, CellInstance)
+
+
+def test_test_provenance_round_trip() -> None:
+    record = _record_from_test(Test(
+        uid=UID, cell_id=CELL_IRI, name="T", kind="cycling", **PROVENANCE_KWARGS,
+    ))
+    _assert_provenance_survives(record, Test)
+
+
+def test_test_spec_provenance_round_trip() -> None:
+    record = _record_from_test_protocol(TestSpec(
+        name="P", uid=UID, **PROVENANCE_KWARGS,
+    ))
+    _assert_provenance_survives(record, TestSpec)
+
+
+def test_cell_instance_conflicting_spec_references_raise() -> None:
+    spec = CellSpecification(
+        id=SPEC_IRI, manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
+    )
+    other = "https://w3id.org/battinfo/spec/cccc-cccc-cccc-cccc"
+    with pytest.raises(ValueError, match="Conflicting cell spec references"):
+        CellInstance(spec, cell_spec_id=other)
+
+
+def test_cell_instance_positional_spec_with_matching_id_is_kept() -> None:
+    spec = CellSpecification(
+        id=SPEC_IRI, manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
+    )
+    # Previously the positional object was silently discarded whenever cell_spec_id= was given.
+    instance = CellInstance(spec, cell_spec_id=SPEC_IRI)
+    assert instance.cell_spec is spec
+    assert instance.cell_spec_id == SPEC_IRI
+
+
+def test_test_conflicting_cell_references_raise() -> None:
+    cell = CellInstance(id=CELL_IRI, cell_spec_id=SPEC_IRI)
+    other = "https://w3id.org/battinfo/cell/dddd-dddd-dddd-dddd"
+    with pytest.raises(ValueError, match="Conflicting cell references"):
+        Test(cell, cell_id=other, name="T", kind="cycling")
+
+
+def test_test_positional_cell_with_matching_id_is_kept() -> None:
+    cell = CellInstance(id=CELL_IRI, cell_spec_id=SPEC_IRI)
+    test = Test(cell, cell_id=CELL_IRI, name="T", kind="cycling")
+    assert test.cell is cell
+    assert test.cell_instance_id == CELL_IRI
+
+
+def test_dataset_provenance_round_trip() -> None:
+    record = _record_from_dataset(Dataset(
+        uid=UID, title="D", access_url="https://data.example.com/d", **PROVENANCE_KWARGS,
+    ))
+    _assert_provenance_survives(record, Dataset)


### PR DESCRIPTION
Completes Phase 2 of the beta hardening plan: validation failures now report every error in one message with canonical paths translated back to the authoring vocabulary (cell_spec.cell_format → format=), quantity-shape errors include a copy-pasteable example plus a pointer to battinfo properties show, and misspelled keyword arguments raise a did-you-mean covering fields, aliases, and spec property names; nothing accepted is silently dropped anymore — specs= rejects non-mappings with the expected shape, provenance kwargs (source_name, file_hash, curated_by, workflow_version) are emitted and read back by all five record types through one shared serializer (record schemas extended accordingly; note the registry's vendored schemas need a re-sync before records carrying the new optional fields pass its gate), and a positional cell/spec object with a conflicting id kwarg raises instead of being discarded; every field of the five authoring models carries a Field(description=...) with a test gate against undocumented additions; the authoring workspace is blessed as the one obvious surface (AuthoringWorkspace exported by name, new workspace-authoring doc page, "Which surface do I use?" table in QUICKSTART/README); and the interop importers lose their sharp edges (import_discovery_eln reads real .eln ZIP archives, JSON errors name the offending file, the aurora importer warns on unparseable numeric fields, zero-record batch imports warn instead of returning empty silently). 1236 tests pass, ruff clean; each item ships with regression tests.