### PR TITLE
Scope login() credentials to the workspace instance, not os.environ

### DIFF
--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -943,6 +943,11 @@ class AuthoringWorkspace:
         )
         self._registry_url = registry_url.rstrip("/") if registry_url else None
         _load_credentials(self._root / ".battinfo" / "credentials")
+        # Credentials established by login() in THIS instance. login() must not
+        # mutate os.environ (process-global state would leak one workspace's
+        # identity into every other workspace in the process); _credential()
+        # consults this first, then the environment.
+        self._session_credentials: dict[str, str] = {}
         # name -> CellInstance, keyed by short_id for test matching
         self._cells_by_short_id: dict[str, Any] = {}
         # in-memory search cache; populated lazily from registry API or local index
@@ -1031,6 +1036,16 @@ class AuthoringWorkspace:
             pass
         return path
 
+    def _credential(self, key: str, default: str | None = None) -> str | None:
+        """Look up a credential without relying on process-global state.
+
+        Precedence mirrors the old behaviour minus the env mutation: values set
+        by ``login()`` on THIS instance win, then the process environment
+        (externally exported, or loaded once from ``.battinfo/credentials`` at
+        init), then *default*.
+        """
+        return self._session_credentials.get(key) or os.environ.get(key) or default
+
     def login(self, api_key: str, *, registry_url: str | None = None) -> dict:
         """Log in with a registry API key and cache your workspace identity.
 
@@ -1074,13 +1089,15 @@ class AuthoringWorkspace:
         except Exception:
             profile = {}  # network/registry unavailable — degrade gracefully
 
-        wid = profile.get("workspace_id") or os.environ.get("BATTINFO_WORKSPACE_ID") or "battinfo-records"
-        pid = profile.get("publisher_id") or os.environ.get("BATTINFO_PUBLISHER_ID") or "battinfo-authoring"
+        wid = profile.get("workspace_id") or self._credential("BATTINFO_WORKSPACE_ID") or "battinfo-records"
+        pid = profile.get("publisher_id") or self._credential("BATTINFO_PUBLISHER_ID") or "battinfo-authoring"
         name = profile.get("display_name") or pid
 
-        os.environ["BATTINFO_API_KEY"] = api_key
-        os.environ["BATTINFO_WORKSPACE_ID"] = wid
-        os.environ["BATTINFO_PUBLISHER_ID"] = pid
+        self._session_credentials.update({
+            "BATTINFO_API_KEY": api_key,
+            "BATTINFO_WORKSPACE_ID": wid,
+            "BATTINFO_PUBLISHER_ID": pid,
+        })
         self._ensure_gitignore()
         path = self._set_credentials({
             "BATTINFO_API_KEY": api_key,
@@ -1101,7 +1118,7 @@ class AuthoringWorkspace:
         """Print the identity associated with the current API key."""
         import urllib.request
 
-        key = os.environ.get("BATTINFO_API_KEY")
+        key = self._credential("BATTINFO_API_KEY")
         if not key:
             print("Not logged in. Run ws.login(api_key='...').")
             return {}
@@ -1119,8 +1136,8 @@ class AuthoringWorkspace:
             print(f"  publisher:  {profile.get('publisher_id')}")
             return profile
         except Exception as exc:
-            wid = os.environ.get("BATTINFO_WORKSPACE_ID", "battinfo-records")
-            pid = os.environ.get("BATTINFO_PUBLISHER_ID", "battinfo-authoring")
+            wid = self._credential("BATTINFO_WORKSPACE_ID", "battinfo-records")
+            pid = self._credential("BATTINFO_PUBLISHER_ID", "battinfo-authoring")
             print(f"  (registry profile unavailable: {exc})")
             print(f"  workspace:  {wid}")
             print(f"  publisher:  {pid}")
@@ -2122,7 +2139,7 @@ class AuthoringWorkspace:
         import urllib.request
 
         url = registry_url or self._registry_url or os.environ.get("BATTINFO_REGISTRY_URL")
-        wid = workspace_id or os.environ.get("BATTINFO_WORKSPACE_ID")
+        wid = workspace_id or self._credential("BATTINFO_WORKSPACE_ID")
         if not url:
             raise RuntimeError("registry_url required. Pass it or set BATTINFO_REGISTRY_URL.")
         if not wid:
@@ -2681,7 +2698,8 @@ class AuthoringWorkspace:
         outcome list instead.  Returns a list of per-record outcome dicts (``ok``,
         ``status``, ``error``, ``iri`` …).  No git or filesystem dependency.
 
-        Credentials can be passed as arguments or set as environment variables:
+        Credentials can be passed as arguments, established with ``ws.login()``
+        (scoped to this workspace instance), or set as environment variables:
 
         * ``BATTINFO_REGISTRY_URL``
         * ``BATTINFO_API_KEY``
@@ -2722,9 +2740,9 @@ class AuthoringWorkspace:
         import datetime
 
         url = registry_url or self._registry_url or os.environ.get("BATTINFO_REGISTRY_URL")
-        key = api_key       or os.environ.get("BATTINFO_API_KEY")
-        wid = workspace_id  or os.environ.get("BATTINFO_WORKSPACE_ID")
-        pid = publisher_id  or os.environ.get("BATTINFO_PUBLISHER_ID")
+        key = api_key       or self._credential("BATTINFO_API_KEY")
+        wid = workspace_id  or self._credential("BATTINFO_WORKSPACE_ID")
+        pid = publisher_id  or self._credential("BATTINFO_PUBLISHER_ID")
         ver = source_version or datetime.date.today().isoformat()
 
         # The Zenodo DOI (passed, or stored from ws.zenodo()) is recorded as
@@ -3152,7 +3170,7 @@ class AuthoringWorkspace:
         import urllib.request
 
         url = registry_url or self._registry_url or os.environ.get("BATTINFO_REGISTRY_URL")
-        wid = workspace_id or os.environ.get("BATTINFO_WORKSPACE_ID")
+        wid = workspace_id or self._credential("BATTINFO_WORKSPACE_ID")
         if not url:
             raise RuntimeError("registry_url required. Pass it or set BATTINFO_REGISTRY_URL.")
         if not wid:

--- a/tests/test_authoring_ws.py
+++ b/tests/test_authoring_ws.py
@@ -172,6 +172,87 @@ def test_login_rejects_empty_key(tmp_path: Path) -> None:
         ws.login(api_key="")
 
 
+# ── login() must not leak identity through process-global state (3.7) ─────────
+
+def test_login_does_not_mutate_process_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os
+    import urllib.request
+
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        _fake_urlopen_returning({"publisher_id": "alice-lab", "workspace_id": "alice-workspace"}),
+    )
+    ws = AuthoringWorkspace(root=tmp_path, registry_url="https://registry.example")
+    ws.login(api_key="key-abc")
+
+    for var in ("BATTINFO_API_KEY", "BATTINFO_WORKSPACE_ID", "BATTINFO_PUBLISHER_ID"):
+        assert var not in os.environ, f"login() must not set {var} process-wide"
+    # ...but this instance sees its own identity.
+    assert ws._credential("BATTINFO_API_KEY") == "key-abc"
+    assert ws._credential("BATTINFO_WORKSPACE_ID") == "alice-workspace"
+
+
+def test_login_identity_is_instance_scoped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import urllib.request
+
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        _fake_urlopen_returning({"publisher_id": "alice-lab", "workspace_id": "alice-workspace"}),
+    )
+    ws_a = AuthoringWorkspace(root=tmp_path / "a", registry_url="https://registry.example")
+    ws_a.login(api_key="key-abc")
+
+    ws_b = AuthoringWorkspace(root=tmp_path / "b", registry_url="https://registry.example")
+    assert ws_b._credential("BATTINFO_WORKSPACE_ID") is None, (
+        "a second workspace must not inherit another instance's login"
+    )
+    assert ws_b.whoami() == {}
+
+
+def test_credential_session_wins_over_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import urllib.request
+
+    monkeypatch.setenv("BATTINFO_WORKSPACE_ID", "env-workspace")
+    ws = AuthoringWorkspace(root=tmp_path, registry_url="https://registry.example")
+    assert ws._credential("BATTINFO_WORKSPACE_ID") == "env-workspace"  # env fallback
+
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        _fake_urlopen_returning({"publisher_id": "alice-lab", "workspace_id": "alice-workspace"}),
+    )
+    ws.login(api_key="key-abc")
+    assert ws._credential("BATTINFO_WORKSPACE_ID") == "alice-workspace"  # session wins
+
+
+def test_login_identity_survives_into_a_new_session_via_credentials_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import urllib.request
+
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        _fake_urlopen_returning({"publisher_id": "alice-lab", "workspace_id": "alice-workspace"}),
+    )
+    ws = AuthoringWorkspace(root=tmp_path, registry_url="https://registry.example")
+    ws.login(api_key="key-abc")
+
+    # A fresh instance on the same root (a "new session") loads the persisted
+    # .battinfo/credentials file — no env mutation required for continuity.
+    ws_next = AuthoringWorkspace(root=tmp_path, registry_url="https://registry.example")
+    assert ws_next._credential("BATTINFO_API_KEY") == "key-abc"
+    assert ws_next._credential("BATTINFO_WORKSPACE_ID") == "alice-workspace"
+
+
 # ── discovery helpers (T5.2/T5.3) — must not raise ─────────────────────────────
 
 def test_commands_runs(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
`ws.login()` wrote `BATTINFO_API_KEY` / `BATTINFO_WORKSPACE_ID` /
`BATTINFO_PUBLISHER_ID` into `os.environ`, leaking one workspace's identity into
every other `AuthoringWorkspace` in the same process.

Credentials established by `login()` now live on the instance. Lookups resolve
**session → environment → default**, so nothing else changes:

- explicitly exported env vars still work,
- `.battinfo/credentials` is still loaded at init and still persists identity
  across sessions,
- `submit()` / `whoami()` / `status()` / `pending()` see the same values they
  did before — they just stop seeing *other* workspaces' logins.

Regression tests cover: `login()` leaves `os.environ` untouched, a second
workspace doesn't inherit another's login, session values win over the
environment, and a fresh instance on the same root rehydrates from the
credentials file.

Rebased on post-Phase-2 main; 1239 tests pass, ruff and mypy clean.
