### PR TITLE
Web: make the publishing journey the front door

### DIFF
--- a/tests/test_web_snippets.py
+++ b/tests/test_web_snippets.py
@@ -1,0 +1,85 @@
+"""The website's publishing recipe cannot drift from ws.quickstart().
+
+The homepage hero (web/lib/examples.ts: publishJourneySnippet) and the /publish
+pipeline stages (web/lib/content.ts: publishJourney) show ws.* code. If the
+library renames a verb or reorders the taught sequence, ws.quickstart() changes
+— and these tests fail until the website is updated to match. Same guard
+philosophy as the executable docs funnel, applied to marketing.
+"""
+from __future__ import annotations
+
+import io
+import re
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+import battinfo  # noqa: E402
+
+WEB = ROOT / "web" / "lib"
+
+
+def _quickstart_text(tmp_path: Path) -> str:
+    ws = battinfo.workspace(root=tmp_path)
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        ws.quickstart()
+    return buffer.getvalue()
+
+
+def _ws_verbs(text: str) -> list[str]:
+    return re.findall(r"\bws\.([a-z_]+)\(", text)
+
+
+def _ts_constant(file: Path, name: str) -> str:
+    source = file.read_text(encoding="utf-8")
+    match = re.search(rf"export const {name} = `(.*?)`;", source, re.DOTALL)
+    assert match, f"{name} not found in {file.name}"
+    return match.group(1)
+
+
+def _is_subsequence(needle: list[str], haystack: list[str]) -> bool:
+    it = iter(haystack)
+    return all(item in it for item in needle)
+
+
+@pytest.fixture()
+def quickstart(tmp_path: Path) -> str:
+    return _quickstart_text(tmp_path)
+
+
+def test_hero_snippet_teaches_the_quickstart_sequence(quickstart: str) -> None:
+    hero = _ts_constant(WEB / "examples.ts", "publishJourneySnippet")
+    hero_verbs = _ws_verbs(hero)
+    recipe_verbs = _ws_verbs(quickstart)
+    assert hero_verbs, "hero snippet must contain ws.* calls"
+    assert _is_subsequence(hero_verbs, recipe_verbs), (
+        f"homepage hero teaches {hero_verbs}, but ws.quickstart() teaches "
+        f"{recipe_verbs} — update web/lib/examples.ts to match the library"
+    )
+    assert "battinfo.workspace(" in hero and "battinfo.workspace(" in quickstart
+
+
+def test_publish_page_stages_use_real_verbs(quickstart: str) -> None:
+    content = (WEB / "content.ts").read_text(encoding="utf-8")
+    match = re.search(r"export const publishJourney = \[(.*?)\] as const;", content, re.DOTALL)
+    assert match, "publishJourney not found in content.ts"
+    stage_verbs = set(_ws_verbs(match.group(1)))
+    recipe_verbs = set(_ws_verbs(quickstart))
+    unknown = stage_verbs - recipe_verbs
+    assert not unknown, (
+        f"/publish page uses ws verbs {sorted(unknown)} that ws.quickstart() does not teach — "
+        "update web/lib/content.ts or the quickstart recipe"
+    )
+
+
+def test_quickstart_recipe_itself_mentions_the_payoffs(quickstart: str) -> None:
+    # The web hero promises a DOI and the registry; the recipe must actually
+    # deliver both mentions, or the promise is marketing-only.
+    assert "zenodo" in quickstart.lower()
+    assert "publish" in quickstart.lower()

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,16 +1,18 @@
 import Link from "next/link";
 import { CodeBlock } from "@/components/code-block";
+import { ProofStrip } from "@/components/proof-strip";
 import { SectionHeading } from "@/components/section-heading";
-import { site, standards } from "@/lib/site";
+import { standards } from "@/lib/site";
 import {
   audiences,
   features,
+  payoffs,
   pipeline,
   principles,
   provenanceChain,
   recordModel,
 } from "@/lib/content";
-import { heroSnippet, installSnippet, quickstartPython } from "@/lib/examples";
+import { installSnippet, publishJourneySnippet, quickstartPython } from "@/lib/examples";
 
 export default function HomePage() {
   return (
@@ -25,33 +27,41 @@ export default function HomePage() {
                 Open standard · Beta
               </span>
               <h1 className="mt-5 text-4xl font-bold tracking-tight text-ink sm:text-5xl">
-                The data layer for{" "}
-                <span className="text-brand-600">battery technology</span>
+                Your battery data —{" "}
+                <span className="text-brand-600">citable, machine-readable, findable</span>
               </h1>
               <p className="mt-5 max-w-prose text-lg text-ink-muted">
-                {site.description}
+                Turn a folder of cycler exports into validated, linked records
+                with a DOI on Zenodo and a place in the Battery Genome registry
+                — in about fifteen minutes, without learning RDF.
               </p>
               <div className="mt-8 flex flex-wrap gap-3">
                 <Link
-                  href="/docs"
+                  href="/publish"
                   className="rounded-lg bg-brand-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700"
                 >
-                  Get started
+                  Publish your data
                 </Link>
                 <Link
-                  href="/convert"
+                  href="/validate"
                   className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
                 >
-                  Try the converter
+                  Validate a record
                 </Link>
+              </div>
+              <div className="mt-8">
+                <ProofStrip />
               </div>
             </div>
 
             <div className="lg:pl-6">
-              <CodeBlock label="describe a cell" code={heroSnippet} />
+              <CodeBlock label="the whole journey" code={publishJourneySnippet} />
               <p className="mt-3 text-sm text-ink-muted">
-                You write plain, readable JSON. BattINFO handles the ontology,
-                identifiers, and Linked Data for you.
+                This is the real recipe — the same one <code>ws.quickstart()</code>{" "}
+                prints, kept in sync by the test suite.{" "}
+                <Link href="/publish" className="font-semibold text-brand-600 hover:text-brand-700">
+                  See every step explained →
+                </Link>
               </p>
             </div>
           </div>
@@ -84,8 +94,24 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* How it works — the four-verb pipeline */}
+      {/* What publishing buys you — now, for your lab, for the field */}
       <section className="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+        <SectionHeading
+          kicker="Why bother"
+          title="One afternoon of publishing keeps paying off."
+        />
+        <div className="mt-10 grid gap-6 lg:grid-cols-3">
+          {payoffs.map((p) => (
+            <div key={p.horizon} className="prose-card">
+              <h3 className="text-lg font-semibold text-ink">{p.horizon}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-ink-muted">{p.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* How it works — the four-verb pipeline */}
+      <section className="border-t border-slate-200 mx-auto max-w-6xl px-4 py-20 sm:px-6">
         <SectionHeading
           kicker="How it works"
           title="From datasheet to machine-readable Linked Data — in four steps."
@@ -220,15 +246,15 @@ export default function HomePage() {
         <div className="mx-auto max-w-6xl px-4 py-16 text-center sm:px-6">
           <h2 className="text-2xl font-semibold tracking-tight text-white">Build on the battery genome.</h2>
           <p className="mx-auto mt-3 max-w-xl text-sm text-brand-100">
-            BattINFO is open infrastructure. Read the docs, validate a record, or
-            convert your data to Linked Data in the browser.
+            BattINFO is open infrastructure. Publish your data, validate a
+            record in the browser, or read the docs.
           </p>
           <div className="mt-7 flex flex-wrap justify-center gap-3">
-            <Link href="/docs" className="rounded-lg bg-white px-5 py-3 text-sm font-semibold text-brand-700 transition hover:bg-brand-50">
-              Read the docs
+            <Link href="/publish" className="rounded-lg bg-white px-5 py-3 text-sm font-semibold text-brand-700 transition hover:bg-brand-50">
+              Publish your data
             </Link>
-            <Link href="/convert" className="rounded-lg border border-white/30 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10">
-              Convert a record
+            <Link href="/docs" className="rounded-lg border border-white/30 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10">
+              Read the docs
             </Link>
           </div>
         </div>

--- a/web/app/publish/page.tsx
+++ b/web/app/publish/page.tsx
@@ -1,0 +1,134 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CodeBlock } from "@/components/code-block";
+import { SectionHeading } from "@/components/section-heading";
+import { publishJourney, provenanceChain } from "@/lib/content";
+import { installSnippet } from "@/lib/examples";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Publish your data — BattINFO",
+  description:
+    "The exact procedure for turning raw cycler exports into validated, citable, machine-readable battery records: convert, identify, link, save, publish.",
+};
+
+/**
+ * The centerpiece page: the publishing procedure, stage by stage. Each stage
+ * shows the exact code, what it produces on disk, and why the stage exists.
+ * The code lines are asserted against ws.quickstart() by the test suite
+ * (tests/test_web_snippets.py), so this page cannot drift from the library.
+ */
+export default function PublishPage() {
+  return (
+    <>
+      <section className="border-b border-slate-200 bg-gradient-to-b from-brand-50/60 to-white">
+        <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6">
+          <SectionHeading
+            kicker="The procedure"
+            title="From cycler export to citable dataset — five stages."
+          />
+          <p className="mt-4 max-w-prose text-lg text-ink-muted">
+            You bring a folder of instrument files. BattINFO walks them through
+            five stages, each one checkable before the next. At the end you have
+            validated records with permanent identifiers, a DOI you can put in a
+            paper, and data the whole field can find and read.
+          </p>
+          <div className="mt-6 rounded-lg border border-slate-200 bg-white px-4 py-3">
+            <p className="font-mono text-sm text-brand-700">
+              raw files → BDF tables → {provenanceChain} → JSON-LD → DOI + registry
+            </p>
+          </div>
+          <div className="mt-6">
+            <CodeBlock label="setup (once)" code={installSnippet} />
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-4xl px-4 py-14 sm:px-6">
+        <ol className="space-y-12">
+          {publishJourney.map((stage, i) => (
+            <li key={stage.stage} className="relative">
+              <div className="flex items-center gap-3">
+                <span className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-brand-600 font-mono text-sm font-bold text-white">
+                  {i + 1}
+                </span>
+                <h2 className="text-xl font-semibold text-ink">{stage.stage}</h2>
+                <code className="ml-1 hidden rounded bg-slate-100 px-2 py-0.5 text-xs text-brand-700 sm:inline">
+                  {stage.verb}
+                </code>
+              </div>
+              <div className="mt-4 grid gap-6 lg:grid-cols-2">
+                <div>
+                  <CodeBlock label="python" code={stage.code} />
+                </div>
+                <div className="space-y-3 text-sm leading-relaxed">
+                  <p>
+                    <span className="font-semibold text-ink">You get: </span>
+                    <span className="text-ink-muted">{stage.produces}</span>
+                  </p>
+                  <p>
+                    <span className="font-semibold text-ink">Why this stage exists: </span>
+                    <span className="text-ink-muted">{stage.why}</span>
+                  </p>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="border-t border-slate-200 bg-slate-50">
+        <div className="mx-auto max-w-4xl px-4 py-14 sm:px-6">
+          <SectionHeading kicker="Before you publish" title="Check your record here, in the browser." />
+          <p className="mt-4 max-w-prose text-sm leading-relaxed text-ink-muted">
+            Paste any record into the validator to see exactly what the library
+            and the registry will say about it — same schemas, same verdict. Or
+            explore a finished example first to see where you are heading.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/validate"
+              className="rounded-lg bg-brand-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700"
+            >
+              Validate a record
+            </Link>
+            <Link
+              href="/examples"
+              className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
+            >
+              See a worked example
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-4xl px-4 py-14 sm:px-6">
+        <SectionHeading kicker="Go deeper" title="The full tutorial and reference live in the docs." />
+        <p className="mt-4 max-w-prose text-sm leading-relaxed text-ink-muted">
+          This page is the map. The step-by-step tutorial — with a sample
+          dataset, validation output, and the Zenodo sandbox — plus the complete
+          Python API, CLI, and schema reference, live in the developer
+          documentation.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a
+            href={site.reference}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
+          >
+            Developer reference →
+          </a>
+          <a
+            href={site.genome}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
+          >
+            See published data on Battery Genome →
+          </a>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/web/components/proof-strip.tsx
+++ b/web/components/proof-strip.tsx
@@ -1,0 +1,35 @@
+import { site } from "@/lib/site";
+
+/**
+ * Trust markers under the hero: live badges (CI, PyPI — they update themselves,
+ * so they can never go stale) plus the claims that need no counter: license,
+ * pinned ontology versions, and the projects funding the work. A DOI badge
+ * appears automatically once `site.doi` is set at the 0.8 archive step.
+ */
+export function ProofStrip() {
+  return (
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-3 text-xs text-ink-faint">
+      <a href={site.ciRuns} target="_blank" rel="noreferrer" className="inline-flex">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={site.ciBadge} alt="CI status" className="h-5" />
+      </a>
+      <a href={site.pypi} target="_blank" rel="noreferrer" className="inline-flex">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={site.pypiBadge} alt="Latest release on PyPI" className="h-5" />
+      </a>
+      {site.doi ? (
+        <a href={`https://doi.org/${site.doi}`} target="_blank" rel="noreferrer" className="inline-flex">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`https://img.shields.io/badge/DOI-${encodeURIComponent(site.doi)}-1682D4`}
+            alt={`DOI ${site.doi}`}
+            className="h-5"
+          />
+        </a>
+      ) : null}
+      <span className="font-medium">{site.license}</span>
+      <span>EMMO domain-battery {site.versions.domainBattery}</span>
+      <span>Developed in the EU projects BIG-MAP &amp; DigiBatt</span>
+    </div>
+  );
+}

--- a/web/lib/content.ts
+++ b/web/lib/content.ts
@@ -61,16 +61,77 @@ export const audiences = [
 // The linked data model — record types and how they chain. Used on the home
 // page and docs to show this is one coherent model, not a bag of schemas.
 export const recordModel = [
-  { type: "CellType", blurb: "An as-designed cell specification (a product / SKU)." },
-  { type: "CellInstance", blurb: "A physical, individually-tracked cell of a CellType." },
-  { type: "Test", blurb: "A measurement performed on a CellInstance under a protocol." },
-  { type: "Dataset", blurb: "The data and files a Test produced, with distributions." },
-  { type: "TestProtocol", blurb: "The reusable procedure a Test was run under." },
+  { type: "Cell spec", blurb: "An as-designed cell specification (a product / SKU)." },
+  { type: "Cell", blurb: "A physical, individually-tracked cell of a spec." },
+  { type: "Test", blurb: "A measurement performed on a cell under a protocol." },
+  { type: "Dataset", blurb: "The data and files a test produced, with distributions." },
+  { type: "Test spec", blurb: "The reusable procedure a test was run under." },
   { type: "Organization", blurb: "Manufacturers, labs, and publishers, as linked entities." },
 ] as const;
 
 // The provenance chain, rendered as a single readable line.
-export const provenanceChain = "CellType → CellInstance → Test → Dataset";
+export const provenanceChain = "Cell spec → Cell → Test → Dataset";
+
+// The publishing journey — the five stages of turning raw cycler exports into
+// citable, findable Linked Data. This is the spine of the /publish page and the
+// homepage hero. Code lines are asserted against ws.quickstart() by
+// tests/test_web_snippets.py so this page can never teach a different recipe
+// than the library does.
+export const publishJourney = [
+  {
+    stage: "Convert",
+    verb: "ws.convert()",
+    code: `ws.convert()          # NEWARE / Biologic / Excel auto-detected
+ws.convert("*.csv")   # or force generic CSV exports`,
+    produces: "bdf/*.bdf.csv — every cycler's export in one tidy, documented table format (BDF).",
+    why: "Instrument formats are the first interoperability wall. One canonical table format means every later step — and every colleague — reads the same thing.",
+  },
+  {
+    stage: "Identify",
+    verb: "ws.search() + ws.add(\"cell\")",
+    code: `spec = ws.search("molicel p45b")[0]
+ws.add("cell", spec=spec, serial_numbers=["S1", "S2", "S3"])`,
+    produces: "Cell records for the physical cells you tested, linked to a shared cell spec with a persistent IRI.",
+    why: "Your measurements are about specific physical cells. Naming them once gives every test and dataset an unambiguous subject — the start of the provenance chain.",
+  },
+  {
+    stage: "Link",
+    verb: "ws.add(\"test\")",
+    code: `ws.add("test", type="cycling", cell="S1", data="bdf/S1.bdf.csv")`,
+    produces: "A test record tied to the cell, plus a dataset record pointing at the converted data file.",
+    why: "Data without its test conditions is trivia. The link cell → test → dataset is what makes the numbers reusable by someone who wasn't in the lab.",
+  },
+  {
+    stage: "Save & validate",
+    verb: "ws.save()",
+    code: `ws.save()`,
+    produces: ".battinfo/records/** — canonical JSON records, schema-validated, with deterministic w3id.org IRIs minted from each record's identity.",
+    why: "Validation runs before anything leaves your machine. Re-running the same save is a no-op — identical inputs always mint identical identifiers.",
+  },
+  {
+    stage: "Publish",
+    verb: "ws.publish()",
+    code: `ws.publish(note="Cycling campaign, 2026")  # add zenodo=True for a DOI`,
+    produces: "A citable archive (Zenodo DOI) and records staged for the Battery Genome registry, where curators review and index them.",
+    why: "This is the payoff: a DOI reviewers can cite, machine-readable JSON-LD any tool can consume, and a record the whole field can find.",
+  },
+] as const;
+
+// What publishing buys you — now, for your lab, for the field. Homepage cards.
+export const payoffs = [
+  {
+    horizon: "For you, today",
+    body: "A citable DOI for your dataset, validated records instead of folder chaos, and a provenance chain reviewers can actually check.",
+  },
+  {
+    horizon: "For your lab",
+    body: "Every cell, test, and file linked and findable when the student who made them has graduated. Re-running an ingest never duplicates records.",
+  },
+  {
+    horizon: "For the field",
+    body: "Your data joins the Battery Genome: EMMO-aligned, machine-readable records that models and meta-analyses can consume without asking you for a spreadsheet.",
+  },
+] as const;
 
 // Project principles — the OBO Foundry move: state the governance commitments
 // that make a standard dependable, not just functional.

--- a/web/lib/examples.ts
+++ b/web/lib/examples.ts
@@ -66,9 +66,24 @@ export const cellSpecJsonLd = {
   ],
 };
 
-// A deliberately friendly, single-record snippet for the hero — plain authored
-// JSON, NOT JSON-LD. The point of the homepage is "this is easy"; the Linked
-// Data machinery is shown later (Examples page) once people are interested.
+// The hero: the data-first publishing journey, condensed from ws.quickstart().
+// DO NOT EDIT the ws.* calls freely — tests/test_web_snippets.py asserts every
+// ws.<verb> here appears (in order) in the recipe ws.quickstart() prints, so
+// the homepage can never teach a different sequence than the library does.
+export const publishJourneySnippet = `import battinfo
+ws = battinfo.workspace(".")
+
+ws.convert()                          # cycler files -> tidy tables
+spec = ws.search("molicel p45b")[0]   # find your cell
+ws.add("cell", spec=spec, serial_numbers=["S1", "S2"])
+ws.add("test", type="cycling", cell="S1", data="bdf/S1.bdf.csv")
+
+ws.save()                             # validated records + stable IRIs
+ws.publish(zenodo=True)               # citable DOI + registry`;
+
+// A deliberately friendly, single-record snippet — plain authored JSON, NOT
+// JSON-LD. Used where we show how readable the authored records are; the
+// Linked Data machinery is shown later (Examples page).
 export const heroSnippet = `{
   "name": "A123 ANR26650M1-B",
   "manufacturer": "A123",

--- a/web/lib/site.ts
+++ b/web/lib/site.ts
@@ -16,6 +16,13 @@ export const site = {
   reference: "https://github.com/BIG-MAP/BattINFO/tree/main/docs",
   github: "https://github.com/BIG-MAP/BattINFO",
   pypi: "https://pypi.org/project/battinfo/",
+  genome: "https://www.battery-genome.org",
+  ciBadge: "https://github.com/BIG-MAP/BattINFO/actions/workflows/ci.yml/badge.svg?branch=main",
+  ciRuns: "https://github.com/BIG-MAP/BattINFO/actions/workflows/ci.yml",
+  pypiBadge: "https://img.shields.io/pypi/v/battinfo?label=PyPI&color=0e7c86",
+  // Zenodo concept DOI — set when the 0.8 release is archived (D.1); the proof
+  // strip renders the badge only when non-empty.
+  doi: "",
   emmo: "https://github.com/emmo-repo/domain-battery",
   emmoElectrochem: "https://github.com/emmo-repo/domain-electrochemistry",
   license: "Apache-2.0",
@@ -27,12 +34,14 @@ export const site = {
   },
 } as const;
 
+// Publish first: the primary action a visitor with data should see.
 export const primaryNav = [
-  { label: "Federation", href: "/federation" },
-  { label: "Docs", href: "/docs" },
-  { label: "Examples", href: "/examples" },
+  { label: "Publish", href: "/publish" },
   { label: "Validate", href: "/validate" },
   { label: "Convert", href: "/convert" },
+  { label: "Examples", href: "/examples" },
+  { label: "Why", href: "/federation" },
+  { label: "Docs", href: "/docs" },
 ] as const;
 
 // Standards this project builds on or aligns with — the "we did not invent our
@@ -74,6 +83,7 @@ export const footerNav = [
   {
     heading: "Get started",
     links: [
+      { label: "Publish your data", href: "/publish" },
       { label: "Documentation", href: "/docs" },
       { label: "Quickstart", href: "/docs#quickstart" },
       { label: "Examples", href: "/examples" },


### PR DESCRIPTION
The homepage led with authoring a cell spec; the visitor we care most about has a folder of cycler data and wants a citable, findable dataset. This PR reshapes the site around that journey.

- **Hero rewritten**: "Your battery data — citable, machine-readable, findable", showing the real data-first recipe (convert → search → add →  save → publish), with "Publish your data" as the primary action.
- **New /publish page**: the five-stage pipeline explained — for each stage  the exact code, what it produces on disk, and why the stage exists, ending in handoffs to the validator, examples, docs, and Battery Genome.
- **Proof strip**: live CI and PyPI badges, license, pinned ontology versions, BIG-MAP/DigiBatt affiliation; a DOI badge appears automatically once the release is archived.
- **Anti-drift guard**: a new test asserts the hero snippet matches the sequence `ws.quickstart()` actually prints, and that /publish only uses verbs the recipe teaches — the site cannot teach a different procedure than the library.
- Also: nav puts Publish first, payoff cards added, homepage record-model naming updated to "cell spec" / "test spec".