### PR TITLE
Rename record classes to one consistent short scheme: CellSpec, Cell, TestSpec, Test, Dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed (breaking-with-shims — naming)
+
+- **The record classes use one consistent short scheme:** `CellSpec`, `Cell`,
+  `TestSpec`, `Test`, `Dataset`. `CellSpecification` and `CellInstance` remain
+  importable everywhere they worked before — as silent aliases from `battinfo.bundle`
+  and as one-release `DeprecationWarning` shims at the package level. The JSON record
+  keys (`cell_spec`, `cell_instance`), IRIs, and schemas are unchanged: this renames
+  the Python surface, not the data contract.
+- `properties=` is the taught keyword for spec properties everywhere (docs, guides,
+  workspace engine); `specs=` stays accepted as a quiet alias.
+- CLI: `test-spec` is the command name (`battinfo query|save|template test-spec`);
+  `test-protocol` still works as a hidden alias for one release.
+- Committed guide-notebook outputs are scrubbed of machine-local paths
+  (`scripts/execute_guides.py` executes + scrubs; a hygiene test keeps it that way).
+
 ### Added
 
 - **Generated reference documentation** that cannot rot: the full CLI reference is

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -7,7 +7,7 @@ BattINFO turns battery metadata into machine-readable Linked Data. In five minut
 | You want to… | Use | Entry point |
 |---|---|---|
 | Describe cells/tests/datasets interactively and publish them (the common case) | **Authoring workspace** | `ws = battinfo.workspace(".")` then `ws.quickstart()` |
-| Create a single record in code and save/publish it | **Models + functions** | `CellSpecification(...)` + `battinfo.publish(...)` (this page) |
+| Create a single record in code and save/publish it | **Models + functions** | `CellSpec(...)` + `battinfo.publish(...)` (this page) |
 | Build or script the full object graph programmatically (ingest pipelines, batch tooling) | **Object-graph engine** | `battinfo.Workspace` — the lower-level engine the authoring workspace wraps |
 
 If in doubt, start with `battinfo.workspace(".")` — it wraps everything else. See
@@ -31,9 +31,9 @@ pip install battinfo
 A **cell spec** is a product specification — the datasheet-level description of a battery model. Create one in three lines:
 
 ```python
-from battinfo import CellSpecification, publish
+from battinfo import CellSpec, publish
 
-cell_spec = CellSpecification(
+cell_spec = CellSpec(
     manufacturer="Panasonic",
     model="NCR18650B",
     format="cylindrical",

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ JSON. BattINFO turns that into a single, semantically-grounded record model:
 
 - **Write plain JSON or Python** — get validated, EMMO-aligned JSON-LD.
 - **Interoperable by construction** — records share one ontology, one context, and one identifier scheme.
-- **Provenance built in** — a `CellSpecification → CellInstance → Test → Dataset` chain links every measurement back to the cell that produced it.
+- **Provenance built in** — a `CellSpec → Cell → Test → Dataset` chain links every measurement back to the cell that produced it.
 - **Standards-ready** — Battery Pass-compatible output, pinned per release.
 
 ## Installation
@@ -98,10 +98,10 @@ uv sync --all-extras   # creates .venv and installs from uv.lock
 ## Quickstart
 
 ```python
-from battinfo import CellSpecification, publish
+from battinfo import CellSpec, publish
 
 result = publish(
-    CellSpecification(
+    CellSpec(
         manufacturer="Panasonic",
         model="NCR18650B",
         format="cylindrical",
@@ -156,7 +156,7 @@ repo root with the `.venv` kernel.
 - Produces **Battery Pass-compatible JSON-LD** (pinned to v1.2.0).
 - Provides profiles, examples, and mapping rules for all common battery record types.
 - Supports a reusable cell-spec library, curated once as BattINFO descriptors and published as generated RDF/JSON-LD.
-- Publishes dataset metadata with a core `CellSpecification → CellInstance → Test → Dataset` provenance chain.
+- Publishes dataset metadata with a core `CellSpec → Cell → Test → Dataset` provenance chain.
 
 ## Semantic foundation
 

--- a/docs/cell-fleet.md
+++ b/docs/cell-fleet.md
@@ -25,14 +25,14 @@ when a basis/inline node is also present, the `@id` is merged onto it.
 ```python
 import battinfo as bi
 
-rec = bi.save_cell_spec(bi.CellSpecification(
+rec = bi.save_cell_spec(bi.CellSpec(
     model_name="COIN-NMC811-D", manufacturer="EMPA", format="coin", chemistry="Li-ion",
     positive_electrode_spec_id=NMC811_CATHODE_IRI,
     negative_electrode_spec_id=GRAPHITE_ANODE_IRI,
     electrolyte_spec_id=ORGANIC_ELECTROLYTE_IRI,
     separator_spec_id=CELGARD_IRI,
     housing_spec_id=COIN_HOUSING_IRI,
-    specs={"nominal_capacity": {"value": 0.0038, "unit": "Ah"}, "nominal_voltage": {"value": 3.8, "unit": "V"}},
+    properties={"nominal_capacity": {"value": 0.0038, "unit": "Ah"}, "nominal_voltage": {"value": 3.8, "unit": "V"}},
 ), source_root="examples")
 ```
 

--- a/docs/guides/01-concepts.ipynb
+++ b/docs/guides/01-concepts.ipynb
@@ -21,10 +21,10 @@
    "id": "d1bde660",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:32.165860Z",
-     "iopub.status.busy": "2026-07-05T20:36:32.165860Z",
-     "iopub.status.idle": "2026-07-05T20:36:32.185483Z",
-     "shell.execute_reply": "2026-07-05T20:36:32.181945Z"
+     "iopub.execute_input": "2026-07-06T20:02:35.174572Z",
+     "iopub.status.busy": "2026-07-06T20:02:35.173557Z",
+     "iopub.status.idle": "2026-07-06T20:02:35.181967Z",
+     "shell.execute_reply": "2026-07-06T20:02:35.181967Z"
     }
    },
    "outputs": [
@@ -32,7 +32,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repo root: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\n"
+      "Running from the repo root.\n"
      ]
     }
    ],
@@ -49,7 +49,7 @@
     "else:\n",
     "    REPO = _here\n",
     "\n",
-    "print(f\"Repo root: {REPO}\")"
+    "print(\"Running from the repo root.\")"
    ]
   },
   {
@@ -62,10 +62,10 @@
     "Every battery experiment generates four kinds of record. BattINFO formalises them as a provenance chain:\n",
     "\n",
     "```\n",
-    "CellSpecification  ─────────────────────────────────\n",
+    "CellSpec  ─────────────────────────────────\n",
     "  │  \"Panasonic NCR18650B is a cylindrical Li-ion cell, 3.4 Ah\"\n",
     "  │\n",
-    "  └─► CellInstance  ───────────────────────────────\n",
+    "  └─► Cell  ───────────────────────────────\n",
     "        │  \"This specific cell, serial number LAB-001\"\n",
     "        │\n",
     "        └─► Test  ──────────────────────────────\n",
@@ -92,10 +92,10 @@
    "id": "af9f7f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:32.189514Z",
-     "iopub.status.busy": "2026-07-05T20:36:32.189514Z",
-     "iopub.status.idle": "2026-07-05T20:36:32.196753Z",
-     "shell.execute_reply": "2026-07-05T20:36:32.196753Z"
+     "iopub.execute_input": "2026-07-06T20:02:35.181967Z",
+     "iopub.status.busy": "2026-07-06T20:02:35.181967Z",
+     "iopub.status.idle": "2026-07-06T20:02:35.193775Z",
+     "shell.execute_reply": "2026-07-06T20:02:35.193775Z"
     }
    },
    "outputs": [
@@ -126,10 +126,10 @@
    "id": "2876af4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:32.198759Z",
-     "iopub.status.busy": "2026-07-05T20:36:32.198759Z",
-     "iopub.status.idle": "2026-07-05T20:36:32.206417Z",
-     "shell.execute_reply": "2026-07-05T20:36:32.206417Z"
+     "iopub.execute_input": "2026-07-06T20:02:35.193775Z",
+     "iopub.status.busy": "2026-07-06T20:02:35.193775Z",
+     "iopub.status.idle": "2026-07-06T20:02:35.201411Z",
+     "shell.execute_reply": "2026-07-06T20:02:35.201411Z"
     }
    },
    "outputs": [
@@ -172,10 +172,10 @@
    "id": "8d47a257",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:32.206417Z",
-     "iopub.status.busy": "2026-07-05T20:36:32.206417Z",
-     "iopub.status.idle": "2026-07-05T20:36:32.221764Z",
-     "shell.execute_reply": "2026-07-05T20:36:32.218746Z"
+     "iopub.execute_input": "2026-07-06T20:02:35.203996Z",
+     "iopub.status.busy": "2026-07-06T20:02:35.203996Z",
+     "iopub.status.idle": "2026-07-06T20:02:35.210863Z",
+     "shell.execute_reply": "2026-07-06T20:02:35.210347Z"
     }
    },
    "outputs": [
@@ -273,7 +273,7 @@
    "source": [
     "## Record types\n",
     "\n",
-    "### CellSpecification — the specification\n",
+    "### CellSpec — the specification\n",
     "\n",
     "A cell spec is a **product specification**: datasheet-level information about a battery model, not a physical item.\n",
     "\n",
@@ -283,7 +283,7 @@
     "\n",
     "The physical EMMO classes for format and chemistry (`BatteryCell`, `CylindricalBattery`, `LithiumIonBattery`, ...) are placed on an `isDescriptionFor` anonymous node — not on the specification itself — because the specification is an information entity, not a physical cell.\n",
     "\n",
-    "### CellInstance — the physical item\n",
+    "### Cell — the physical item\n",
     "\n",
     "A cell instance is a **specific physical cell** with a serial number. It always links to a cell spec.\n",
     "\n",
@@ -312,10 +312,10 @@
    "id": "e85e0b8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:32.226761Z",
-     "iopub.status.busy": "2026-07-05T20:36:32.226761Z",
-     "iopub.status.idle": "2026-07-05T20:36:32.232536Z",
-     "shell.execute_reply": "2026-07-05T20:36:32.231009Z"
+     "iopub.execute_input": "2026-07-06T20:02:35.212243Z",
+     "iopub.status.busy": "2026-07-06T20:02:35.212243Z",
+     "iopub.status.idle": "2026-07-06T20:02:35.217196Z",
+     "shell.execute_reply": "2026-07-06T20:02:35.217196Z"
     }
    },
    "outputs": [
@@ -365,10 +365,10 @@
    "id": "e670cfbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:32.236513Z",
-     "iopub.status.busy": "2026-07-05T20:36:32.236513Z",
-     "iopub.status.idle": "2026-07-05T20:36:34.134105Z",
-     "shell.execute_reply": "2026-07-05T20:36:34.131538Z"
+     "iopub.execute_input": "2026-07-06T20:02:35.220257Z",
+     "iopub.status.busy": "2026-07-06T20:02:35.217196Z",
+     "iopub.status.idle": "2026-07-06T20:02:37.020874Z",
+     "shell.execute_reply": "2026-07-06T20:02:37.019845Z"
     }
    },
    "outputs": [
@@ -381,9 +381,9 @@
     }
    ],
    "source": [
-    "from battinfo import CellSpecification, publish\n",
+    "from battinfo import CellSpec, publish\n",
     "\n",
-    "cell_spec = CellSpecification(\n",
+    "cell_spec = CellSpec(\n",
     "    manufacturer=\"A123 Systems\",\n",
     "    model=\"ANR26650M1-B\",\n",
     "    format=\"cylindrical\",\n",
@@ -406,10 +406,10 @@
    "id": "0f9bd621",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:34.134105Z",
-     "iopub.status.busy": "2026-07-05T20:36:34.134105Z",
-     "iopub.status.idle": "2026-07-05T20:36:34.284700Z",
-     "shell.execute_reply": "2026-07-05T20:36:34.284700Z"
+     "iopub.execute_input": "2026-07-06T20:02:37.023310Z",
+     "iopub.status.busy": "2026-07-06T20:02:37.023310Z",
+     "iopub.status.idle": "2026-07-06T20:02:37.164183Z",
+     "shell.execute_reply": "2026-07-06T20:02:37.164183Z"
     }
    },
    "outputs": [
@@ -442,10 +442,10 @@
    "id": "50971f8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:34.288149Z",
-     "iopub.status.busy": "2026-07-05T20:36:34.284700Z",
-     "iopub.status.idle": "2026-07-05T20:36:34.293025Z",
-     "shell.execute_reply": "2026-07-05T20:36:34.293025Z"
+     "iopub.execute_input": "2026-07-06T20:02:37.168799Z",
+     "iopub.status.busy": "2026-07-06T20:02:37.168799Z",
+     "iopub.status.idle": "2026-07-06T20:02:37.176879Z",
+     "shell.execute_reply": "2026-07-06T20:02:37.175869Z"
     }
    },
    "outputs": [
@@ -485,10 +485,10 @@
    "id": "4bb41daf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:34.293025Z",
-     "iopub.status.busy": "2026-07-05T20:36:34.293025Z",
-     "iopub.status.idle": "2026-07-05T20:36:34.301807Z",
-     "shell.execute_reply": "2026-07-05T20:36:34.301807Z"
+     "iopub.execute_input": "2026-07-06T20:02:37.180420Z",
+     "iopub.status.busy": "2026-07-06T20:02:37.179876Z",
+     "iopub.status.idle": "2026-07-06T20:02:37.185359Z",
+     "shell.execute_reply": "2026-07-06T20:02:37.184783Z"
     }
    },
    "outputs": [
@@ -572,10 +572,10 @@
    "id": "bfc0b477",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:34.301807Z",
-     "iopub.status.busy": "2026-07-05T20:36:34.301807Z",
-     "iopub.status.idle": "2026-07-05T20:36:34.322921Z",
-     "shell.execute_reply": "2026-07-05T20:36:34.322921Z"
+     "iopub.execute_input": "2026-07-06T20:02:37.187362Z",
+     "iopub.status.busy": "2026-07-06T20:02:37.187362Z",
+     "iopub.status.idle": "2026-07-06T20:02:37.207466Z",
+     "shell.execute_reply": "2026-07-06T20:02:37.206713Z"
     }
    },
    "outputs": [
@@ -583,7 +583,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ok: True | errors: 0 | warnings: 0\n"
+      "ok:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " True | errors: 0 | warnings: 0\n"
      ]
     }
    ],

--- a/docs/guides/02-first-cell-type.ipynb
+++ b/docs/guides/02-first-cell-type.ipynb
@@ -21,10 +21,10 @@
    "id": "6aa2a3a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:40.828503Z",
-     "iopub.status.busy": "2026-07-05T20:36:40.828503Z",
-     "iopub.status.idle": "2026-07-05T20:36:40.844176Z",
-     "shell.execute_reply": "2026-07-05T20:36:40.844176Z"
+     "iopub.execute_input": "2026-07-06T20:02:43.398825Z",
+     "iopub.status.busy": "2026-07-06T20:02:43.398825Z",
+     "iopub.status.idle": "2026-07-06T20:02:43.407491Z",
+     "shell.execute_reply": "2026-07-06T20:02:43.407491Z"
     }
    },
    "outputs": [
@@ -32,8 +32,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repo root: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\n",
-      "Workspace: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\\.battinfo\\notebooks\\guide-02\n"
+      "Running from the repo root.\n",
+      "Workspace: .battinfo\\notebooks\\guide-02\n"
      ]
     }
    ],
@@ -50,11 +50,11 @@
     "else:\n",
     "    REPO = _here\n",
     "\n",
-    "print(f\"Repo root: {REPO}\")\n",
+    "print(\"Running from the repo root.\")\n",
     "\n",
     "WORKSPACE = REPO / '.battinfo/notebooks/guide-02'\n",
     "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
-    "print('Workspace:', WORKSPACE)"
+    "print(\"Workspace:\", WORKSPACE.relative_to(REPO))"
    ]
   },
   {
@@ -73,10 +73,10 @@
    "id": "3e2a2bcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:40.844176Z",
-     "iopub.status.busy": "2026-07-05T20:36:40.844176Z",
-     "iopub.status.idle": "2026-07-05T20:36:42.764986Z",
-     "shell.execute_reply": "2026-07-05T20:36:42.764986Z"
+     "iopub.execute_input": "2026-07-06T20:02:43.410105Z",
+     "iopub.status.busy": "2026-07-06T20:02:43.410105Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.133809Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.132793Z"
     }
    },
    "outputs": [
@@ -89,9 +89,9 @@
     }
    ],
    "source": [
-    "from battinfo import CellSpecification, publish\n",
+    "from battinfo import CellSpec, publish\n",
     "\n",
-    "cell_spec = CellSpecification(\n",
+    "cell_spec = CellSpec(\n",
     "    manufacturer=\"Samsung SDI\",\n",
     "    model=\"INR21700-50E\",\n",
     "    format=\"cylindrical\",\n",
@@ -104,7 +104,7 @@
     "        \"name\": \"INR21700-50E Product Specification Rev 1.0\",\n",
     "        \"url\": \"https://example.com/samsung-inr21700-50e.pdf\",\n",
     "    },\n",
-    "    specs={\n",
+    "    properties={\n",
     "        \"nominal_capacity\":                      {\"value\": 5.0,   \"unit\": \"Ah\"},\n",
     "        \"nominal_voltage\":                       {\"value\": 3.6,   \"unit\": \"V\"},\n",
     "        \"rated_energy\":                          {\"value\": 18.0,  \"unit\": \"Wh\"},\n",
@@ -129,10 +129,10 @@
    "id": "0bd7097b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:42.764986Z",
-     "iopub.status.busy": "2026-07-05T20:36:42.764986Z",
-     "iopub.status.idle": "2026-07-05T20:36:42.771953Z",
-     "shell.execute_reply": "2026-07-05T20:36:42.771953Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.135797Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.135797Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.142358Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.141350Z"
     }
    },
    "outputs": [
@@ -208,7 +208,8 @@
       "    \"source_type\": \"datasheet\",\n",
       "    \"source_name\": \"INR21700-50E Product Specification Rev 1.0\",\n",
       "    \"source_url\": \"https://example.com/samsung-inr21700-50e.pdf\",\n",
-      "    \"retrieved_at\": 1783283802\n",
+      "    \"retrieved_at\": 1783368164,\n",
+      "    \"battinfo_version\": \"0.7.0\"\n",
       "  }\n",
       "}\n"
      ]
@@ -226,10 +227,10 @@
    "id": "65e1f16b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:42.771953Z",
-     "iopub.status.busy": "2026-07-05T20:36:42.771953Z",
-     "iopub.status.idle": "2026-07-05T20:36:42.945120Z",
-     "shell.execute_reply": "2026-07-05T20:36:42.943110Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.145357Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.145357Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.281273Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.280707Z"
     }
    },
    "outputs": [
@@ -299,10 +300,10 @@
    "id": "d7efdd70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:42.950125Z",
-     "iopub.status.busy": "2026-07-05T20:36:42.949182Z",
-     "iopub.status.idle": "2026-07-05T20:36:42.959089Z",
-     "shell.execute_reply": "2026-07-05T20:36:42.957998Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.281983Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.281983Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.288389Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.288389Z"
     }
    },
    "outputs": [
@@ -362,10 +363,10 @@
    "id": "b67136fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:42.962086Z",
-     "iopub.status.busy": "2026-07-05T20:36:42.962086Z",
-     "iopub.status.idle": "2026-07-05T20:36:42.969715Z",
-     "shell.execute_reply": "2026-07-05T20:36:42.968707Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.291530Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.291530Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.296709Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.296709Z"
     }
    },
    "outputs": [
@@ -402,10 +403,10 @@
    "id": "620158b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:42.975757Z",
-     "iopub.status.busy": "2026-07-05T20:36:42.975757Z",
-     "iopub.status.idle": "2026-07-05T20:36:42.980733Z",
-     "shell.execute_reply": "2026-07-05T20:36:42.980733Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.296709Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.296709Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.304882Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.304882Z"
     }
    },
    "outputs": [
@@ -456,10 +457,10 @@
    "id": "b4f7cd0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:42.980733Z",
-     "iopub.status.busy": "2026-07-05T20:36:42.980733Z",
-     "iopub.status.idle": "2026-07-05T20:36:42.993961Z",
-     "shell.execute_reply": "2026-07-05T20:36:42.993961Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.308662Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.307653Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.316272Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.315264Z"
     }
    },
    "outputs": [
@@ -507,10 +508,10 @@
    "id": "eca67433",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:42.993961Z",
-     "iopub.status.busy": "2026-07-05T20:36:42.993961Z",
-     "iopub.status.idle": "2026-07-05T20:36:43.003054Z",
-     "shell.execute_reply": "2026-07-05T20:36:43.003054Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.319271Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.318303Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.325474Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.324468Z"
     }
    },
    "outputs": [
@@ -518,7 +519,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Separator material: Polypropylene\n",
+      "Separator material:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Polypropylene\n",
       "Assembly: wound / jelly-roll\n"
      ]
     }
@@ -553,10 +561,10 @@
    "id": "7a8e2003",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:43.004773Z",
-     "iopub.status.busy": "2026-07-05T20:36:43.004773Z",
-     "iopub.status.idle": "2026-07-05T20:36:43.013133Z",
-     "shell.execute_reply": "2026-07-05T20:36:43.013133Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.329476Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.329476Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.335063Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.335063Z"
     }
    },
    "outputs": [
@@ -573,7 +581,7 @@
     "from battinfo.authoring import cell_description, source\n",
     "\n",
     "# The id is the BattINFO IRI for this cell spec.\n",
-    "# For new records: publish a CellSpecification first to receive the IRI, then enrich it here.\n",
+    "# For new records: publish a CellSpec first to receive the IRI, then enrich it here.\n",
     "# For this tutorial we use the known IRI for the A123 ANR26650M1-B example.\n",
     "A123_IRI = \"https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8\"\n",
     "\n",
@@ -617,10 +625,10 @@
    "id": "bfa47a36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:43.013133Z",
-     "iopub.status.busy": "2026-07-05T20:36:43.013133Z",
-     "iopub.status.idle": "2026-07-05T20:36:43.025925Z",
-     "shell.execute_reply": "2026-07-05T20:36:43.025925Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.337113Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.337113Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.348663Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.347657Z"
     }
    },
    "outputs": [
@@ -678,7 +686,7 @@
    ],
    "source": [
     "# Write the descriptor dict to a JSON file for inspection and downstream use.\n",
-    "# The CellSpecification is both the authoring object and the record that publishing uses.\n",
+    "# The CellSpec is both the authoring object and the record that publishing uses.\n",
     "desc_dir = WORKSPACE / \"descriptors\"\n",
     "desc_dir.mkdir(parents=True, exist_ok=True)\n",
     "desc_path = desc_dir / \"a123-anr26650m1-b.descriptor.json\"\n",
@@ -696,7 +704,7 @@
    "source": [
     "### Export descriptor to domain-battery JSON-LD\n",
     "\n",
-    "The `CellSpecification` maps to EMMO-aligned JSON-LD via `to_jsonld(target=\"domain-battery\")`. This is the rich semantic representation: it includes electrode composition nodes (constituents with mass fractions, loading, current collector), the electrolyte (salt, solvents, additives with concentrations and volume fractions), and the separator (material, thickness, porosity).\n",
+    "The `CellSpec` maps to EMMO-aligned JSON-LD via `to_jsonld(target=\"domain-battery\")`. This is the rich semantic representation: it includes electrode composition nodes (constituents with mass fractions, loading, current collector), the electrolyte (salt, solvents, additives with concentrations and volume fractions), and the separator (material, thickness, porosity).\n",
     "\n",
     "The descriptor pipeline expects the specification wrapped in a document envelope (`{\"schema_version\": ..., \"specification\": ...}`)."
    ]
@@ -707,10 +715,10 @@
    "id": "1632d66b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:43.025925Z",
-     "iopub.status.busy": "2026-07-05T20:36:43.025925Z",
-     "iopub.status.idle": "2026-07-05T20:36:43.195904Z",
-     "shell.execute_reply": "2026-07-05T20:36:43.195363Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.350666Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.350666Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.464905Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.464905Z"
     }
    },
    "outputs": [
@@ -792,10 +800,10 @@
    "id": "c2ae6a1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:43.195904Z",
-     "iopub.status.busy": "2026-07-05T20:36:43.195904Z",
-     "iopub.status.idle": "2026-07-05T20:36:43.267815Z",
-     "shell.execute_reply": "2026-07-05T20:36:43.267815Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.464905Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.464905Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.518906Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.518906Z"
     }
    },
    "outputs": [
@@ -852,10 +860,10 @@
    "id": "f63cc430",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:43.271472Z",
-     "iopub.status.busy": "2026-07-05T20:36:43.271472Z",
-     "iopub.status.idle": "2026-07-05T20:36:43.277319Z",
-     "shell.execute_reply": "2026-07-05T20:36:43.277319Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.520916Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.520916Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.525052Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.525052Z"
     }
    },
    "outputs": [
@@ -1297,10 +1305,10 @@
    "id": "30c2de71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:43.277319Z",
-     "iopub.status.busy": "2026-07-05T20:36:43.277319Z",
-     "iopub.status.idle": "2026-07-05T20:36:43.284341Z",
-     "shell.execute_reply": "2026-07-05T20:36:43.284341Z"
+     "iopub.execute_input": "2026-07-06T20:02:45.528296Z",
+     "iopub.status.busy": "2026-07-06T20:02:45.528296Z",
+     "iopub.status.idle": "2026-07-06T20:02:45.533176Z",
+     "shell.execute_reply": "2026-07-06T20:02:45.532824Z"
     }
    },
    "outputs": [

--- a/docs/guides/03-linked-records.ipynb
+++ b/docs/guides/03-linked-records.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Guide 3 — Linked records: instance, test, dataset, and publishing\n",
     "\n",
-    "This guide builds the full provenance chain — CellSpecification → CellInstance → TestSpec → Test → Dataset — using the `Workspace` API, validates it, and publishes it.\n",
+    "This guide builds the full provenance chain — CellSpec → Cell → TestSpec → Test → Dataset — using the `Workspace` API, validates it, and publishes it.\n",
     "\n",
     "**Estimated time:** 30 minutes\n",
     "**Prerequisites:** [Guide 2 — First cell spec](02-first-cell-type.ipynb)\n",
@@ -21,10 +21,10 @@
    "id": "58a9385f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:50.203728Z",
-     "iopub.status.busy": "2026-07-05T20:36:50.203728Z",
-     "iopub.status.idle": "2026-07-05T20:36:50.216239Z",
-     "shell.execute_reply": "2026-07-05T20:36:50.214230Z"
+     "iopub.execute_input": "2026-07-06T20:02:50.972460Z",
+     "iopub.status.busy": "2026-07-06T20:02:50.972460Z",
+     "iopub.status.idle": "2026-07-06T20:02:50.984239Z",
+     "shell.execute_reply": "2026-07-06T20:02:50.984239Z"
     }
    },
    "outputs": [
@@ -32,8 +32,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repo root: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\n",
-      "Workspace: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\\.battinfo\\notebooks\\guide-03\n"
+      "Running from the repo root.\n",
+      "Workspace: .battinfo\\notebooks\\guide-03\n"
      ]
     }
    ],
@@ -50,11 +50,11 @@
     "else:\n",
     "    REPO = _here\n",
     "\n",
-    "print(f\"Repo root: {REPO}\")\n",
+    "print(\"Running from the repo root.\")\n",
     "\n",
     "WORKSPACE = REPO / '.battinfo/notebooks/guide-03'\n",
     "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
-    "print('Workspace:', WORKSPACE)"
+    "print(\"Workspace:\", WORKSPACE.relative_to(REPO))"
    ]
   },
   {
@@ -73,10 +73,10 @@
    "id": "ab862669",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:50.219238Z",
-     "iopub.status.busy": "2026-07-05T20:36:50.219238Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.026066Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.026066Z"
+     "iopub.execute_input": "2026-07-06T20:02:50.990843Z",
+     "iopub.status.busy": "2026-07-06T20:02:50.990285Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.360627Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.360115Z"
     }
    },
    "outputs": [
@@ -84,7 +84,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workspace root: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\\.battinfo\\notebooks\\guide-03\n"
+      "Workspace root: <repo>\\.battinfo\\notebooks\\guide-03\n"
      ]
     }
    ],
@@ -109,10 +109,10 @@
    "id": "5c110179",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.030663Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.030663Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.039513Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.039513Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.360627Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.360627Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.366649Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.366649Z"
     }
    },
    "outputs": [
@@ -132,7 +132,7 @@
     "    chemistry=\"Li-ion\",\n",
     "    positive_electrode_basis=\"NMC\",\n",
     "    negative_electrode_basis=\"graphite\",\n",
-    "    specs={\n",
+    "    properties={\n",
     "        \"nominal_capacity\": {\"value\": 5.0,  \"unit\": \"Ah\"},\n",
     "        \"nominal_voltage\":  {\"value\": 3.6,  \"unit\": \"V\"},\n",
     "        \"rated_energy\":     {\"value\": 18.0, \"unit\": \"Wh\"},\n",
@@ -158,10 +158,10 @@
    "id": "b40a6c5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.039513Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.039513Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.053082Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.053082Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.368843Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.368843Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.374780Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.374780Z"
     }
    },
    "outputs": [
@@ -200,10 +200,10 @@
    "id": "2a6d7acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.053082Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.053082Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.063369Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.063369Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.376852Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.376852Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.382334Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.381824Z"
     }
    },
    "outputs": [
@@ -340,10 +340,10 @@
    "id": "fcc598be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.063369Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.063369Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.074341Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.074341Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.384341Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.384341Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.389250Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.388242Z"
     }
    },
    "outputs": [
@@ -382,10 +382,10 @@
    "id": "7fa1dbbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.074341Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.074341Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.087219Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.087219Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.390940Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.390940Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.401002Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.400482Z"
     }
    },
    "outputs": [
@@ -436,10 +436,10 @@
    "id": "65d4b2d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.087219Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.087219Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.357458Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.356446Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.404886Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.403886Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.624415Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.624415Z"
     }
    },
    "outputs": [
@@ -451,12 +451,12 @@
       "Cell instance IRI:  https://w3id.org/battinfo/cell/7nq8-4h5y-febz-zbgf\n",
       "Test spec IRI:      https://w3id.org/battinfo/spec/m6v9-nnpe-krwk-f652\n",
       "Test IRI:           https://w3id.org/battinfo/test/v8gg-g6as-hync-2wb9\n",
-      "Dataset IRI:        https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\n",
+      "Dataset IRI:        https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\n",
       "\n",
       "Records written:\n",
       "  examples\\cell-instance\\cell-7nq8-4h5y-febz-zbgf.json\n",
       "  examples\\cell-spec\\cell-spec-me0t-k16f-eh5y-rq0k.json\n",
-      "  examples\\dataset\\dataset-8d4r-85ra-2bqm-d0m6.json\n",
+      "  examples\\dataset\\dataset-96kd-vyes-9dp1-6cx6.json\n",
       "  examples\\test\\test-v8gg-g6as-hync-2wb9.json\n",
       "  examples\\test-protocol\\test-protocol-m6v9-nnpe-krwk-f652.json\n"
      ]
@@ -494,10 +494,10 @@
    "id": "a9550242",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.359451Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.359451Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.702299Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.702299Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.627421Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.626421Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.981881Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.980875Z"
     }
    },
    "outputs": [
@@ -507,7 +507,7 @@
      "text": [
       "Resolver JSON-LD files written (5):\n",
       "  resolver\\cell\\7nq8-4h5y-febz-zbgf\\index.jsonld\n",
-      "  resolver\\dataset\\8d4r-85ra-2bqm-d0m6\\index.jsonld\n",
+      "  resolver\\dataset\\96kd-vyes-9dp1-6cx6\\index.jsonld\n",
       "  resolver\\spec\\m6v9-nnpe-krwk-f652\\index.jsonld\n",
       "  resolver\\spec\\me0t-k16f-eh5y-rq0k\\index.jsonld\n",
       "  resolver\\test\\v8gg-g6as-hync-2wb9\\index.jsonld\n"
@@ -540,10 +540,10 @@
    "id": "3560d2aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.702299Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.702299Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.713140Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.711648Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.984117Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.984117Z",
+     "iopub.status.idle": "2026-07-06T20:02:52.993129Z",
+     "shell.execute_reply": "2026-07-06T20:02:52.993129Z"
     }
    },
    "outputs": [
@@ -582,10 +582,10 @@
    "id": "1d83e0e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.713140Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.713140Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.946121Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.946121Z"
+     "iopub.execute_input": "2026-07-06T20:02:52.993129Z",
+     "iopub.status.busy": "2026-07-06T20:02:52.993129Z",
+     "iopub.status.idle": "2026-07-06T20:02:53.199902Z",
+     "shell.execute_reply": "2026-07-06T20:02:53.199902Z"
     }
    },
    "outputs": [
@@ -596,7 +596,7 @@
       "Package: publication\\sdi-a001-cycle-life\\battinfo.publish.jsonld\n",
       "Nodes in @graph: 5\n",
       "  ['dcat:Catalog', 'schema:DataCatalog', 'schema:Dataset']  —  sdi-a001-cycle-life\n",
-      "  ['dcat:Dataset', 'schema:Dataset']  —  8d4r-85ra-2bqm-d0m6\n",
+      "  ['dcat:Dataset', 'schema:Dataset']  —  96kd-vyes-9dp1-6cx6\n",
       "  ['BatteryCellSpecification', 'schema:CreativeWork']  —  me0t-k16f-eh5y-rq0k\n",
       "  ['BatteryCell', 'CylindricalBattery', 'LithiumIonBattery']  —  7nq8-4h5y-febz-zbgf\n",
       "  ['BatteryTest', 'schema:Action', 'prov:Activity']  —  v8gg-g6as-hync-2wb9\n"
@@ -633,10 +633,10 @@
    "id": "07c27fec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.946121Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.946121Z",
-     "iopub.status.idle": "2026-07-05T20:36:52.961896Z",
-     "shell.execute_reply": "2026-07-05T20:36:52.960422Z"
+     "iopub.execute_input": "2026-07-06T20:02:53.203363Z",
+     "iopub.status.busy": "2026-07-06T20:02:53.202115Z",
+     "iopub.status.idle": "2026-07-06T20:02:53.207242Z",
+     "shell.execute_reply": "2026-07-06T20:02:53.207242Z"
     }
    },
    "outputs": [
@@ -950,16 +950,16 @@
       "        \"schema:DataCatalog\",\n",
       "        \"schema:Dataset\"\n",
       "      ],\n",
-      "      \"@id\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
-      "      \"schema:url\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
+      "      \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
+      "      \"schema:url\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
       "      \"dcat:dataset\": [\n",
       "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "        }\n",
       "      ],\n",
       "      \"schema:hasPart\": [\n",
       "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "        }\n",
       "      ],\n",
       "      \"rdfs:seeAlso\": {\n",
@@ -968,40 +968,40 @@
       "      \"schema:distribution\": [\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
       "          \"schema:encodingFormat\": \"application/vnd.battinfo.dataset-directory\",\n",
       "          \"schema:name\": \"sdi-a001-cycle-life\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          }\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
       "          \"schema:encodingFormat\": \"application/json\",\n",
       "          \"schema:name\": \"datacite-metadata.json\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          },\n",
-      "          \"schema:sha256\": \"ac26d4566f59e4017e7735cefb07c79961883aad09db4187c29ad2b8ac983bd3\"\n",
+      "          \"schema:sha256\": \"71ec2531c00a52b7ef4afd301c550a12ae690363d61ba94441f37166c2850a60\"\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
       "          \"schema:encodingFormat\": \"application/json\",\n",
       "          \"schema:name\": \"ro-crate-metadata.json\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          },\n",
-      "          \"schema:sha256\": \"8d34d4560192f68d74026f73619c649235b6ab7199f7a8d0629a11c1ee7f52e4\"\n",
+      "          \"schema:sha256\": \"3a4998201bf15f4414843be26e226440c36731f22d0c1bf973090c625684b86a\"\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
       "          \"schema:encodingFormat\": \"application/vnd.ms-excel\",\n",
       "          \"schema:name\": \"sdi-a001-cycle-life.csv\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          },\n",
       "          \"schema:sha256\": \"96969df113b96d2eb06ec66053d03351116ac55828caea0a13441e0e0e5a3bd6\"\n",
       "        }\n",
@@ -1037,19 +1037,19 @@
       "        \"dcat:Dataset\",\n",
       "        \"schema:Dataset\"\n",
       "      ],\n",
-      "      \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\",\n",
+      "      \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\",\n",
       "      \"schema:name\": \"INR21700-50E A001 cycle-life dataset\",\n",
       "      \"dcat:distribution\": [\n",
       "        {\n",
       "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
+      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
       "          \"dcat:mediaType\": {\n",
       "            \"@id\": \"https://www.iana.org/assignments/media-types/application/vnd.battinfo.dataset-directory\"\n",
       "          },\n",
       "          \"schema:name\": \"sdi-a001-cycle-life\",\n",
-      "          \"@id\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
+      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
       "          \"prov:wasDerivedFrom\": {\n",
-      "            \"@id\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\"\n",
+      "            \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\"\n",
       "          },\n",
       "          \"prov:wasGeneratedBy\": {\n",
       "            \"@id\": \"https://w3id.org/battinfo/test/v8gg-g6as-hync-2wb9\"\n",
@@ -1057,44 +1057,44 @@
       "        },\n",
       "        {\n",
       "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
+      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
       "          \"dcat:mediaType\": {\n",
       "            \"@id\": \"https://www.iana.org/assignments/media-types/application/json\"\n",
       "          },\n",
       "          \"schema:name\": \"datacite-metadata.json\",\n",
-      "          \"@id\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
+      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
       "          \"spdx:checksum\": {\n",
       "            \"@type\": \"spdx:Checksum\",\n",
       "            \"spdx:checksumAlgorithm\": {\n",
       "              \"@id\": \"spdx:checksumAlgorithm_sha256\"\n",
       "            },\n",
-      "            \"spdx:checksumValue\": \"ac26d4566f59e4017e7735cefb07c79961883aad09db4187c29ad2b8ac983bd3\"\n",
+      "            \"spdx:checksumValue\": \"71ec2531c00a52b7ef4afd301c550a12ae690363d61ba94441f37166c2850a60\"\n",
       "          }\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
+      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
       "          \"dcat:mediaType\": {\n",
       "            \"@id\": \"https://www.iana.org/assignments/media-types/application/json\"\n",
       "          },\n",
       "          \"schema:name\": \"ro-crate-metadata.json\",\n",
-      "          \"@id\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
+      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
       "          \"spdx:checksum\": {\n",
       "            \"@type\": \"spdx:Checksum\",\n",
       "            \"spdx:checksumAlgorithm\": {\n",
       "              \"@id\": \"spdx:checksumAlgorithm_sha256\"\n",
       "            },\n",
-      "            \"spdx:checksumValue\": \"8d34d4560192f68d74026f73619c649235b6ab7199f7a8d0629a11c1ee7f52e4\"\n",
+      "            \"spdx:checksumValue\": \"3a4998201bf15f4414843be26e226440c36731f22d0c1bf973090c625684b86a\"\n",
       "          }\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
+      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
       "          \"dcat:mediaType\": {\n",
       "            \"@id\": \"https://www.iana.org/assignments/media-types/application/vnd.ms-excel\"\n",
       "          },\n",
       "          \"schema:name\": \"sdi-a001-cycle-life.csv\",\n",
-      "          \"@id\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
+      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
       "          \"spdx:checksum\": {\n",
       "            \"@type\": \"spdx:Checksum\",\n",
       "            \"spdx:checksumAlgorithm\": {\n",
@@ -1107,46 +1107,46 @@
       "      \"schema:distribution\": [\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
       "          \"schema:encodingFormat\": \"application/vnd.battinfo.dataset-directory\",\n",
       "          \"schema:name\": \"sdi-a001-cycle-life\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          }\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
       "          \"schema:encodingFormat\": \"application/json\",\n",
       "          \"schema:name\": \"datacite-metadata.json\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          },\n",
-      "          \"schema:sha256\": \"ac26d4566f59e4017e7735cefb07c79961883aad09db4187c29ad2b8ac983bd3\"\n",
+      "          \"schema:sha256\": \"71ec2531c00a52b7ef4afd301c550a12ae690363d61ba94441f37166c2850a60\"\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
       "          \"schema:encodingFormat\": \"application/json\",\n",
       "          \"schema:name\": \"ro-crate-metadata.json\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          },\n",
-      "          \"schema:sha256\": \"8d34d4560192f68d74026f73619c649235b6ab7199f7a8d0629a11c1ee7f52e4\"\n",
+      "          \"schema:sha256\": \"3a4998201bf15f4414843be26e226440c36731f22d0c1bf973090c625684b86a\"\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
+      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
       "          \"schema:encodingFormat\": \"application/vnd.ms-excel\",\n",
       "          \"schema:name\": \"sdi-a001-cycle-life.csv\",\n",
       "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "          },\n",
       "          \"schema:sha256\": \"96969df113b96d2eb06ec66053d03351116ac55828caea0a13441e0e0e5a3bd6\"\n",
       "        }\n",
       "      ],\n",
       "      \"dcterms:isPartOf\": {\n",
-      "        \"@id\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\"\n",
+      "        \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\"\n",
       "      },\n",
       "      \"schema:about\": [\n",
       "        {\n",
@@ -1155,10 +1155,10 @@
       "      ],\n",
       "      \"schema:description\": \"Voltage, current, and temperature time-series, 500 cycles.\",\n",
       "      \"schema:license\": \"CC-BY-4.0\",\n",
-      "      \"schema:dateCreated\": \"2026-07-05T20:36:52Z\",\n",
-      "      \"schema:dateModified\": \"2026-07-05T20:36:52Z\",\n",
-      "      \"schema:url\": \"file:///C:/Users/simonc/Documents/Github-local/battery-genome/BattINFO-docs-funnel/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
-      "      \"schema:datePublished\": 1783283812\n",
+      "      \"schema:dateCreated\": \"2026-07-06T20:02:52Z\",\n",
+      "      \"schema:dateModified\": \"2026-07-06T20:02:52Z\",\n",
+      "      \"schema:url\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
+      "      \"schema:datePublished\": 1783368172\n",
       "    },\n",
       "    {\n",
       "      \"@type\": [\n",
@@ -1265,12 +1265,12 @@
       "      },\n",
       "      \"hasOutput\": [\n",
       "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "        }\n",
       "      ],\n",
       "      \"prov:generated\": [\n",
       "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/8d4r-85ra-2bqm-d0m6\"\n",
+      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
       "        }\n",
       "      ]\n",
       "    }\n",
@@ -1297,10 +1297,10 @@
    "id": "500848dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:52.961896Z",
-     "iopub.status.busy": "2026-07-05T20:36:52.961896Z",
-     "iopub.status.idle": "2026-07-05T20:36:53.024498Z",
-     "shell.execute_reply": "2026-07-05T20:36:53.024498Z"
+     "iopub.execute_input": "2026-07-06T20:02:53.210249Z",
+     "iopub.status.busy": "2026-07-06T20:02:53.210249Z",
+     "iopub.status.idle": "2026-07-06T20:02:53.253324Z",
+     "shell.execute_reply": "2026-07-06T20:02:53.252304Z"
     }
    },
    "outputs": [
@@ -1346,10 +1346,10 @@
    "id": "6881e18a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:53.028327Z",
-     "iopub.status.busy": "2026-07-05T20:36:53.027898Z",
-     "iopub.status.idle": "2026-07-05T20:36:53.035888Z",
-     "shell.execute_reply": "2026-07-05T20:36:53.035888Z"
+     "iopub.execute_input": "2026-07-06T20:02:53.255313Z",
+     "iopub.status.busy": "2026-07-06T20:02:53.255313Z",
+     "iopub.status.idle": "2026-07-06T20:02:53.260838Z",
+     "shell.execute_reply": "2026-07-06T20:02:53.260838Z"
     }
    },
    "outputs": [
@@ -1393,10 +1393,10 @@
    "id": "756b68ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:53.035888Z",
-     "iopub.status.busy": "2026-07-05T20:36:53.035888Z",
-     "iopub.status.idle": "2026-07-05T20:36:53.049685Z",
-     "shell.execute_reply": "2026-07-05T20:36:53.049685Z"
+     "iopub.execute_input": "2026-07-06T20:02:53.262850Z",
+     "iopub.status.busy": "2026-07-06T20:02:53.262850Z",
+     "iopub.status.idle": "2026-07-06T20:02:53.267911Z",
+     "shell.execute_reply": "2026-07-06T20:02:53.267911Z"
     }
    },
    "outputs": [

--- a/docs/guides/04-semantic-layer.ipynb
+++ b/docs/guides/04-semantic-layer.ipynb
@@ -19,10 +19,10 @@
    "id": "b9975261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:36:59.811169Z",
-     "iopub.status.busy": "2026-07-05T20:36:59.810170Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.030251Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.030251Z"
+     "iopub.execute_input": "2026-07-06T20:02:58.573233Z",
+     "iopub.status.busy": "2026-07-06T20:02:58.573233Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.222597Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.222092Z"
     }
    },
    "outputs": [
@@ -30,7 +30,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repo root: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\n"
+      "Running from the repo root.\n"
      ]
     },
     {
@@ -54,15 +54,15 @@
     "else:\n",
     "    REPO = _here\n",
     "\n",
-    "print(f\"Repo root: {REPO}\")\n",
+    "print(\"Running from the repo root.\")\n",
     "\n",
-    "from battinfo import CellSpecification, publish, Workspace\n",
+    "from battinfo import CellSpec, publish, Workspace\n",
     "from battinfo.api import publish_record\n",
     "\n",
     "WORKSPACE = REPO / '.battinfo/notebooks/guide-04'\n",
     "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "cell_spec = CellSpecification(\n",
+    "cell_spec = CellSpec(\n",
     "    manufacturer=\"A123 Systems\",\n",
     "    model=\"ANR26650M1-B\",\n",
     "    format=\"cylindrical\",\n",
@@ -70,7 +70,7 @@
     "    positive_electrode_basis=\"LFP\",\n",
     "    negative_electrode_basis=\"graphite\",\n",
     "    size_code=\"R26650\",\n",
-    "    specs={\n",
+    "    properties={\n",
     "        \"nominal_capacity\":   {\"value\": 2.5,  \"unit\": \"Ah\"},\n",
     "        \"nominal_voltage\":    {\"value\": 3.3,  \"unit\": \"V\"},\n",
     "        \"rated_energy\":       {\"value\": 8.25, \"unit\": \"Wh\"},\n",
@@ -107,10 +107,10 @@
    "id": "df15cfe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.030251Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.030251Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.039125Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.039125Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.225603Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.225603Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.229933Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.228920Z"
     }
    },
    "outputs": [
@@ -255,10 +255,10 @@
    "id": "310d641b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.039125Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.039125Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.045105Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.045105Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.230943Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.230943Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.234583Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.234583Z"
     }
    },
    "outputs": [
@@ -335,10 +335,10 @@
    "id": "idf-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.045105Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.045105Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.052804Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.052214Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.234583Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.234583Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.242028Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.241390Z"
     }
    },
    "outputs": [
@@ -373,10 +373,10 @@
    "id": "117501cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.052804Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.052804Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.062924Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.062924Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.244040Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.244040Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.247505Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.247505Z"
     }
    },
    "outputs": [
@@ -430,10 +430,10 @@
    "id": "cfe8dd30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.062924Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.062924Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.176608Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.174772Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.250163Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.250163Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.324961Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.324961Z"
     }
    },
    "outputs": [
@@ -474,10 +474,10 @@
    "id": "8b6bd11a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.178617Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.178617Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.731608Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.729580Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.328129Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.328129Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.900805Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.900283Z"
     }
    },
    "outputs": [
@@ -506,10 +506,10 @@
    "id": "efb494cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.737303Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.736319Z",
-     "iopub.status.idle": "2026-07-05T20:37:02.745476Z",
-     "shell.execute_reply": "2026-07-05T20:37:02.744451Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.900805Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.900805Z",
+     "iopub.status.idle": "2026-07-06T20:03:00.908232Z",
+     "shell.execute_reply": "2026-07-06T20:03:00.907867Z"
     }
    },
    "outputs": [
@@ -517,68 +517,68 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  N138b540997dd48b598f982aac947f370  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N138b540997dd48b598f982aac947f370  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
-      "  N1b2179f28aa347258329821a7ce97134  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N1b2179f28aa347258329821a7ce97134  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
-      "  N1b2179f28aa347258329821a7ce97134  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N2b25aee0d33d44bd8fe01518d32594b0\n",
-      "  N1b2179f28aa347258329821a7ce97134  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
-      "  N2800dda69ef646dda76574c1938c8de7  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N2800dda69ef646dda76574c1938c8de7  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
-      "  N2b25aee0d33d44bd8fe01518d32594b0  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N2b25aee0d33d44bd8fe01518d32594b0  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
-      "  N3be654fcceea4ba5ab017008f2aa2a87  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N3be654fcceea4ba5ab017008f2aa2a87  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
-      "  N3be654fcceea4ba5ab017008f2aa2a87  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N2800dda69ef646dda76574c1938c8de7\n",
-      "  N3be654fcceea4ba5ab017008f2aa2a87  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
-      "  N3f488ee170cd41099dd1c127702bd62a  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N3f488ee170cd41099dd1c127702bd62a  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
-      "  N4e8c206b1d24438686c9833c35b02c1e  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
-      "  N4e8c206b1d24438686c9833c35b02c1e  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N4e8c206b1d24438686c9833c35b02c1e  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N3f488ee170cd41099dd1c127702bd62a\n",
-      "  N4e8c206b1d24438686c9833c35b02c1e  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
-      "  N5501318bab0c4ecd86979628beadfe31  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N5501318bab0c4ecd86979628beadfe31  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
-      "  N6a4fbd1fbf1b46b4863003949a914d9f  →  type  →  Organization\n",
-      "  N6a4fbd1fbf1b46b4863003949a914d9f  →  name  →  A123 Systems\n",
-      "  N7667b0dc02ed4747bbd86402769f47a6  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N7667b0dc02ed4747bbd86402769f47a6  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
-      "  N8a84a9c241f543b886cce1b0adec4984  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N8a84a9c241f543b886cce1b0adec4984  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
-      "  N8a84a9c241f543b886cce1b0adec4984  →  value  →  >1000\n",
-      "  N8a84a9c241f543b886cce1b0adec4984  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
-      "  Nc2f6efc9706f41ff82dc1b34bdc309a2  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nc2f6efc9706f41ff82dc1b34bdc309a2  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
-      "  Nc2f6efc9706f41ff82dc1b34bdc309a2  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Nd916198e87c247ab9d20fec77937a12f\n",
-      "  Nc2f6efc9706f41ff82dc1b34bdc309a2  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
-      "  Ncad3b1b484914bcd840e8070dfa2e246  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
-      "  Ncad3b1b484914bcd840e8070dfa2e246  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Ncad3b1b484914bcd840e8070dfa2e246  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N138b540997dd48b598f982aac947f370\n",
-      "  Ncad3b1b484914bcd840e8070dfa2e246  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
-      "  Ncf8714767d2d4d249196304756752197  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Ncf8714767d2d4d249196304756752197  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
-      "  Ncf8714767d2d4d249196304756752197  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N7667b0dc02ed4747bbd86402769f47a6\n",
-      "  Ncf8714767d2d4d249196304756752197  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
-      "  Nd916198e87c247ab9d20fec77937a12f  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  Nd916198e87c247ab9d20fec77937a12f  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
-      "  Nffc9a2c2ea0543e0bdfbddf4786c3f13  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nffc9a2c2ea0543e0bdfbddf4786c3f13  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
-      "  Nffc9a2c2ea0543e0bdfbddf4786c3f13  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N5501318bab0c4ecd86979628beadfe31\n",
-      "  Nffc9a2c2ea0543e0bdfbddf4786c3f13  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
+      "  N1d3e1e9c7f124e6fb970956779aaf50a  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N1d3e1e9c7f124e6fb970956779aaf50a  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
+      "  N3462097cbee64177b0a774a5fbe26dbc  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N3462097cbee64177b0a774a5fbe26dbc  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
+      "  N3462097cbee64177b0a774a5fbe26dbc  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N7742f700df934ae5b5c455f4cb59ad69\n",
+      "  N3462097cbee64177b0a774a5fbe26dbc  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
+      "  N38eac6c93bd24d57b0b7cc3a311e072c  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N38eac6c93bd24d57b0b7cc3a311e072c  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
+      "  N4017de0fdb5746e9bba3a37a50d3adfa  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N4017de0fdb5746e9bba3a37a50d3adfa  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
+      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
+      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  value  →  >1000\n",
+      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
+      "  N59d1b51113b94e67b7e854a2b3e31d59  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N59d1b51113b94e67b7e854a2b3e31d59  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
+      "  N59d1b51113b94e67b7e854a2b3e31d59  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N4017de0fdb5746e9bba3a37a50d3adfa\n",
+      "  N59d1b51113b94e67b7e854a2b3e31d59  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
+      "  N662170ea88794178be978ed0c04a4203  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
+      "  N662170ea88794178be978ed0c04a4203  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N662170ea88794178be978ed0c04a4203  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N7490722fb7ce4c408b10c103476c2920\n",
+      "  N662170ea88794178be978ed0c04a4203  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  N72d63abe691c46738ae43e6f80c95d30  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
+      "  N72d63abe691c46738ae43e6f80c95d30  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N72d63abe691c46738ae43e6f80c95d30  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N85703d1cd50548ada56c0bf072be6bc3\n",
+      "  N72d63abe691c46738ae43e6f80c95d30  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  N7490722fb7ce4c408b10c103476c2920  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N7490722fb7ce4c408b10c103476c2920  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
+      "  N7742f700df934ae5b5c455f4cb59ad69  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N7742f700df934ae5b5c455f4cb59ad69  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
+      "  N85703d1cd50548ada56c0bf072be6bc3  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N85703d1cd50548ada56c0bf072be6bc3  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
+      "  N8fb8bf41565a47ada3ecc495cc006e54  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N8fb8bf41565a47ada3ecc495cc006e54  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
+      "  N8fb8bf41565a47ada3ecc495cc006e54  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N1d3e1e9c7f124e6fb970956779aaf50a\n",
+      "  N8fb8bf41565a47ada3ecc495cc006e54  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
+      "  Na2e070ae2c3f49888e4c6ffa1bc0498c  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Na2e070ae2c3f49888e4c6ffa1bc0498c  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
+      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
+      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Na2e070ae2c3f49888e4c6ffa1bc0498c\n",
+      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
+      "  Nb46ae90a1af64e0f9eec363ade23d2f0  →  type  →  Organization\n",
+      "  Nb46ae90a1af64e0f9eec363ade23d2f0  →  name  →  A123 Systems\n",
+      "  Nca4c488c619b40acb7c4616118adbf4b  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nca4c488c619b40acb7c4616118adbf4b  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
+      "  Nca4c488c619b40acb7c4616118adbf4b  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N38eac6c93bd24d57b0b7cc3a311e072c\n",
+      "  Nca4c488c619b40acb7c4616118adbf4b  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  CreativeWork\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  battery_1cfbba6c_8824_4932_a23e_2141483acef7\n",
       "  wckm-y5a4-he0k-2scd  →  identifier  →  wckm-y5a4-he0k-2scd\n",
-      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  N6a4fbd1fbf1b46b4863003949a914d9f\n",
+      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  Nb46ae90a1af64e0f9eec363ade23d2f0\n",
       "  wckm-y5a4-he0k-2scd  →  name  →  A123 Systems ANR26650M1-B\n",
       "  wckm-y5a4-he0k-2scd  →  size  →  R26650\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N1b2179f28aa347258329821a7ce97134\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N3be654fcceea4ba5ab017008f2aa2a87\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N4e8c206b1d24438686c9833c35b02c1e\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N8a84a9c241f543b886cce1b0adec4984\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nc2f6efc9706f41ff82dc1b34bdc309a2\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ncad3b1b484914bcd840e8070dfa2e246\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ncf8714767d2d4d249196304756752197\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nffc9a2c2ea0543e0bdfbddf4786c3f13\n"
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N3462097cbee64177b0a774a5fbe26dbc\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N4fc85383ee2c427096ff71b4b9c3be0f\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N59d1b51113b94e67b7e854a2b3e31d59\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N662170ea88794178be978ed0c04a4203\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N72d63abe691c46738ae43e6f80c95d30\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N8fb8bf41565a47ada3ecc495cc006e54\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nac9ed68bb617479e8ac93b18e3aeec28\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nca4c488c619b40acb7c4616118adbf4b\n"
      ]
     }
    ],
@@ -605,10 +605,10 @@
    "id": "f05bb577",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:02.748868Z",
-     "iopub.status.busy": "2026-07-05T20:37:02.747866Z",
-     "iopub.status.idle": "2026-07-05T20:37:04.064641Z",
-     "shell.execute_reply": "2026-07-05T20:37:04.064641Z"
+     "iopub.execute_input": "2026-07-06T20:03:00.910743Z",
+     "iopub.status.busy": "2026-07-06T20:03:00.910743Z",
+     "iopub.status.idle": "2026-07-06T20:03:02.228025Z",
+     "shell.execute_reply": "2026-07-06T20:03:02.226534Z"
     }
    },
    "outputs": [
@@ -626,7 +626,7 @@
     "    manufacturer=\"A123 Systems\", model=\"ANR26650M1-B\",\n",
     "    format=\"cylindrical\", chemistry=\"Li-ion\",\n",
     "    positive_electrode_basis=\"LFP\", negative_electrode_basis=\"graphite\",\n",
-    "    specs={\"nominal_capacity\": {\"value\": 2.5, \"unit\": \"Ah\"}},\n",
+    "    properties={\"nominal_capacity\": {\"value\": 2.5, \"unit\": \"Ah\"}},\n",
     ")\n",
     "ws.cell(ct, serial_number=\"a123-demo-multi-001\")\n",
     "ws.save()\n",
@@ -670,10 +670,10 @@
    "id": "97dfdfc6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:04.068703Z",
-     "iopub.status.busy": "2026-07-05T20:37:04.068703Z",
-     "iopub.status.idle": "2026-07-05T20:37:04.076517Z",
-     "shell.execute_reply": "2026-07-05T20:37:04.076517Z"
+     "iopub.execute_input": "2026-07-06T20:03:02.229999Z",
+     "iopub.status.busy": "2026-07-06T20:03:02.229999Z",
+     "iopub.status.idle": "2026-07-06T20:03:02.235748Z",
+     "shell.execute_reply": "2026-07-06T20:03:02.234742Z"
     }
    },
    "outputs": [

--- a/docs/guides/05-descriptors.ipynb
+++ b/docs/guides/05-descriptors.ipynb
@@ -21,10 +21,10 @@
    "id": "1cf55ef0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:13.048240Z",
-     "iopub.status.busy": "2026-07-05T20:37:13.048240Z",
-     "iopub.status.idle": "2026-07-05T20:37:13.059785Z",
-     "shell.execute_reply": "2026-07-05T20:37:13.058774Z"
+     "iopub.execute_input": "2026-07-06T20:03:07.327667Z",
+     "iopub.status.busy": "2026-07-06T20:03:07.327667Z",
+     "iopub.status.idle": "2026-07-06T20:03:07.338011Z",
+     "shell.execute_reply": "2026-07-06T20:03:07.336537Z"
     }
    },
    "outputs": [
@@ -32,8 +32,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repo root: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\n",
-      "Workspace: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-docs-funnel\\.battinfo\\notebooks\\guide-05\n"
+      "Running from the repo root.\n",
+      "Workspace: .battinfo\\notebooks\\guide-05\n"
      ]
     }
    ],
@@ -50,11 +50,11 @@
     "else:\n",
     "    REPO = _here\n",
     "\n",
-    "print(f\"Repo root: {REPO}\")\n",
+    "print(\"Running from the repo root.\")\n",
     "\n",
     "WORKSPACE = REPO / '.battinfo/notebooks/guide-05'\n",
     "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
-    "print('Workspace:', WORKSPACE)"
+    "print(\"Workspace:\", WORKSPACE.relative_to(REPO))"
    ]
   },
   {
@@ -71,10 +71,10 @@
    "id": "ddcca263",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:13.059785Z",
-     "iopub.status.busy": "2026-07-05T20:37:13.059785Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.834132Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.834132Z"
+     "iopub.execute_input": "2026-07-06T20:03:07.341083Z",
+     "iopub.status.busy": "2026-07-06T20:03:07.341083Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.871547Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.870996Z"
     }
    },
    "outputs": [
@@ -120,10 +120,10 @@
    "id": "4b04c30f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.834132Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.834132Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.849232Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.849232Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.873943Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.872895Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.879493Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.878940Z"
     }
    },
    "outputs": [
@@ -160,10 +160,10 @@
    "id": "38095956",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.849232Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.849232Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.862209Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.862209Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.882069Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.882069Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.887307Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.887307Z"
     }
    },
    "outputs": [
@@ -214,10 +214,10 @@
    "id": "3fcb31b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.862209Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.862209Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.870851Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.870851Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.890669Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.890127Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.895932Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.895932Z"
     }
    },
    "outputs": [
@@ -268,10 +268,10 @@
    "id": "7e673ceb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.875124Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.874092Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.880469Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.879462Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.895932Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.895932Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.904098Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.902855Z"
     }
    },
    "outputs": [
@@ -314,10 +314,10 @@
    "id": "70bef49a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.882515Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.882515Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.886606Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.886606Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.904098Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.904098Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.912518Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.912009Z"
     }
    },
    "outputs": [
@@ -356,10 +356,10 @@
    "id": "b6297d58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.886606Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.886606Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.895597Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.895597Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.916529Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.915534Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.922153Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.921045Z"
     }
    },
    "outputs": [
@@ -401,10 +401,10 @@
    "id": "f9d5ffe7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.895597Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.895597Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.903509Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.903509Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.924155Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.924155Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.930685Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.929660Z"
     }
    },
    "outputs": [
@@ -421,7 +421,7 @@
     "from battinfo.authoring import cell_description\n",
     "\n",
     "# Use the known IRI for the A123 ANR26650M1-B example cell spec.\n",
-    "# For new records: publish a CellSpecification first to get the IRI, then use it here.\n",
+    "# For new records: publish a CellSpec first to get the IRI, then use it here.\n",
     "A123_IRI = \"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\"\n",
     "\n",
     "spec = cell_description(\n",
@@ -463,10 +463,10 @@
    "id": "0c953dd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.903509Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.903509Z",
-     "iopub.status.idle": "2026-07-05T20:37:14.914038Z",
-     "shell.execute_reply": "2026-07-05T20:37:14.914038Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.932294Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.932294Z",
+     "iopub.status.idle": "2026-07-06T20:03:08.939313Z",
+     "shell.execute_reply": "2026-07-06T20:03:08.938306Z"
     }
    },
    "outputs": [
@@ -504,10 +504,10 @@
    "id": "cc431ddd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:14.914038Z",
-     "iopub.status.busy": "2026-07-05T20:37:14.914038Z",
-     "iopub.status.idle": "2026-07-05T20:37:15.046597Z",
-     "shell.execute_reply": "2026-07-05T20:37:15.046597Z"
+     "iopub.execute_input": "2026-07-06T20:03:08.941400Z",
+     "iopub.status.busy": "2026-07-06T20:03:08.941400Z",
+     "iopub.status.idle": "2026-07-06T20:03:09.068066Z",
+     "shell.execute_reply": "2026-07-06T20:03:09.068066Z"
     }
    },
    "outputs": [
@@ -515,7 +515,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "@type: ['BatteryCellSpecification', 'schema:CreativeWork']\n",
+      "@type:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " ['BatteryCellSpecification', 'schema:CreativeWork']\n",
       "\n",
       "Positive electrode @type: LithiumIronPhosphateElectrode\n",
       "Negative electrode @type: GraphiteElectrode\n"
@@ -543,10 +550,10 @@
    "id": "6cc0a7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:15.046597Z",
-     "iopub.status.busy": "2026-07-05T20:37:15.046597Z",
-     "iopub.status.idle": "2026-07-05T20:37:15.056296Z",
-     "shell.execute_reply": "2026-07-05T20:37:15.055476Z"
+     "iopub.execute_input": "2026-07-06T20:03:09.073427Z",
+     "iopub.status.busy": "2026-07-06T20:03:09.072420Z",
+     "iopub.status.idle": "2026-07-06T20:03:09.081577Z",
+     "shell.execute_reply": "2026-07-06T20:03:09.081577Z"
     }
    },
    "outputs": [
@@ -1011,10 +1018,10 @@
    "id": "1b0ac8c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:15.060182Z",
-     "iopub.status.busy": "2026-07-05T20:37:15.059181Z",
-     "iopub.status.idle": "2026-07-05T20:37:15.169812Z",
-     "shell.execute_reply": "2026-07-05T20:37:15.169812Z"
+     "iopub.execute_input": "2026-07-06T20:03:09.089914Z",
+     "iopub.status.busy": "2026-07-06T20:03:09.088406Z",
+     "iopub.status.idle": "2026-07-06T20:03:09.191877Z",
+     "shell.execute_reply": "2026-07-06T20:03:09.191877Z"
     }
    },
    "outputs": [
@@ -1050,10 +1057,10 @@
    "id": "8e638265",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:15.177902Z",
-     "iopub.status.busy": "2026-07-05T20:37:15.177902Z",
-     "iopub.status.idle": "2026-07-05T20:37:15.375393Z",
-     "shell.execute_reply": "2026-07-05T20:37:15.372385Z"
+     "iopub.execute_input": "2026-07-06T20:03:09.191877Z",
+     "iopub.status.busy": "2026-07-06T20:03:09.191877Z",
+     "iopub.status.idle": "2026-07-06T20:03:09.303652Z",
+     "shell.execute_reply": "2026-07-06T20:03:09.302091Z"
     }
    },
    "outputs": [
@@ -1066,10 +1073,10 @@
     }
    ],
    "source": [
-    "from battinfo import CellSpecification, publish\n",
+    "from battinfo import CellSpec, publish\n",
     "from battinfo.api import publish_record\n",
     "\n",
-    "ct = CellSpecification(\n",
+    "ct = CellSpec(\n",
     "    manufacturer=spec.manufacturer, model=spec.model,\n",
     "    format=spec.format, chemistry=spec.chemistry,\n",
     "    positive_electrode_basis=spec.positive_electrode_basis,\n",
@@ -1086,10 +1093,10 @@
    "id": "e7e19b64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T20:37:15.379448Z",
-     "iopub.status.busy": "2026-07-05T20:37:15.379448Z",
-     "iopub.status.idle": "2026-07-05T20:37:15.457399Z",
-     "shell.execute_reply": "2026-07-05T20:37:15.457399Z"
+     "iopub.execute_input": "2026-07-06T20:03:09.303652Z",
+     "iopub.status.busy": "2026-07-06T20:03:09.303652Z",
+     "iopub.status.idle": "2026-07-06T20:03:09.365572Z",
+     "shell.execute_reply": "2026-07-06T20:03:09.365572Z"
     }
    },
    "outputs": [

--- a/docs/guides/06-publish-your-data.ipynb
+++ b/docs/guides/06-publish-your-data.ipynb
@@ -30,10 +30,10 @@
    "id": "e43cee13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T13:19:23.551217Z",
-     "iopub.status.busy": "2026-07-06T13:19:23.551217Z",
-     "iopub.status.idle": "2026-07-06T13:19:24.979275Z",
-     "shell.execute_reply": "2026-07-06T13:19:24.977758Z"
+     "iopub.execute_input": "2026-07-06T20:03:14.521030Z",
+     "iopub.status.busy": "2026-07-06T20:03:14.520513Z",
+     "iopub.status.idle": "2026-07-06T20:03:16.348721Z",
+     "shell.execute_reply": "2026-07-06T20:03:16.347373Z"
     }
    },
    "outputs": [
@@ -41,7 +41,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workspace ready: C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-phase3\\.battinfo\\notebooks\\guide-06\n"
+      "Workspace ready: .battinfo\\notebooks\\guide-06\n"
      ]
     }
    ],
@@ -70,7 +70,7 @@
     "\n",
     "import battinfo\n",
     "ws = battinfo.workspace(root=WORKSPACE)\n",
-    "print(\"Workspace ready:\", WORKSPACE)"
+    "print(\"Workspace ready:\", WORKSPACE.relative_to(REPO))"
    ]
   },
   {
@@ -91,10 +91,10 @@
    "id": "e2c1ddca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T13:19:24.983281Z",
-     "iopub.status.busy": "2026-07-06T13:19:24.982282Z",
-     "iopub.status.idle": "2026-07-06T13:19:25.603894Z",
-     "shell.execute_reply": "2026-07-06T13:19:25.603894Z"
+     "iopub.execute_input": "2026-07-06T20:03:16.352413Z",
+     "iopub.status.busy": "2026-07-06T20:03:16.351816Z",
+     "iopub.status.idle": "2026-07-06T20:03:16.975873Z",
+     "shell.execute_reply": "2026-07-06T20:03:16.975873Z"
     }
    },
    "outputs": [
@@ -104,7 +104,7 @@
      "text": [
       "  neware-sample.csv  ->  neware-sample.bdf.csv  (0.0 MB)\n",
       "\n",
-      "Converted 1 file(s) -> C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-phase3\\.battinfo\\notebooks\\guide-06\\bdf\n",
+      "Converted 1 file(s) -> <repo>\\.battinfo\\notebooks\\guide-06\\bdf\n",
       "\n",
       "BDF columns: test_time_second,voltage_volt,current_ampere,step_index,unix_time_second\n"
      ]
@@ -136,10 +136,10 @@
    "id": "c7d97399",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T13:19:25.606410Z",
-     "iopub.status.busy": "2026-07-06T13:19:25.606410Z",
-     "iopub.status.idle": "2026-07-06T13:19:27.508162Z",
-     "shell.execute_reply": "2026-07-06T13:19:27.507154Z"
+     "iopub.execute_input": "2026-07-06T20:03:16.975873Z",
+     "iopub.status.busy": "2026-07-06T20:03:16.975873Z",
+     "iopub.status.idle": "2026-07-06T20:03:19.002996Z",
+     "shell.execute_reply": "2026-07-06T20:03:19.002996Z"
     }
    },
    "outputs": [
@@ -160,7 +160,7 @@
     "    spec = hits[0]           # found in the registry — reuse its identity\n",
     "else:\n",
     "    # Offline / unregistered: describe the product yourself.\n",
-    "    spec = battinfo.CellSpecification(\n",
+    "    spec = battinfo.CellSpec(\n",
     "        manufacturer=\"Molicel\",\n",
     "        model=\"INR21700-P45B\",\n",
     "        format=\"cylindrical\",\n",
@@ -189,10 +189,10 @@
    "id": "d9a22b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T13:19:27.510719Z",
-     "iopub.status.busy": "2026-07-06T13:19:27.510719Z",
-     "iopub.status.idle": "2026-07-06T13:19:27.520882Z",
-     "shell.execute_reply": "2026-07-06T13:19:27.520882Z"
+     "iopub.execute_input": "2026-07-06T20:03:19.002996Z",
+     "iopub.status.busy": "2026-07-06T20:03:19.002996Z",
+     "iopub.status.idle": "2026-07-06T20:03:19.021488Z",
+     "shell.execute_reply": "2026-07-06T20:03:19.021488Z"
     }
    },
    "outputs": [
@@ -236,10 +236,10 @@
    "id": "241ee167",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T13:19:27.523890Z",
-     "iopub.status.busy": "2026-07-06T13:19:27.523890Z",
-     "iopub.status.idle": "2026-07-06T13:19:27.757611Z",
-     "shell.execute_reply": "2026-07-06T13:19:27.756595Z"
+     "iopub.execute_input": "2026-07-06T20:03:19.024494Z",
+     "iopub.status.busy": "2026-07-06T20:03:19.023492Z",
+     "iopub.status.idle": "2026-07-06T20:03:19.389407Z",
+     "shell.execute_reply": "2026-07-06T20:03:19.389407Z"
     }
    },
    "outputs": [
@@ -247,7 +247,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Saved 4 record(s) under C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\BattINFO-phase3\\.battinfo\\notebooks\\guide-06\\.battinfo\\records:\n",
+      "Saved 4 record(s) under <repo>\\.battinfo\\notebooks\\guide-06\\.battinfo\\records:\n",
       "  cell spec   Molicel INR21700-P45B                [created]  .battinfo\\records\\examples\\cell-spec\\cell-spec-fpdr-z1qt-23v0-stzx.json\n",
       "  cell        S1                                   [created]  .battinfo\\records\\examples\\cell-instance\\cell-d6tp-jgqy-a3s9-4qem.json\n",
       "  test        S1 cycling                           [created]  .battinfo\\records\\examples\\test\\test-9f4c-mxny-yhym-2zh4.json\n",
@@ -275,10 +275,10 @@
    "id": "03b2dfb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T13:19:27.758601Z",
-     "iopub.status.busy": "2026-07-06T13:19:27.758601Z",
-     "iopub.status.idle": "2026-07-06T13:19:27.765407Z",
-     "shell.execute_reply": "2026-07-06T13:19:27.764401Z"
+     "iopub.execute_input": "2026-07-06T20:03:19.392110Z",
+     "iopub.status.busy": "2026-07-06T20:03:19.392110Z",
+     "iopub.status.idle": "2026-07-06T20:03:19.398118Z",
+     "shell.execute_reply": "2026-07-06T20:03:19.398118Z"
     }
    },
    "outputs": [
@@ -296,7 +296,7 @@
       "...\n",
       "provenance: {\n",
       "  \"source_type\": \"measurement\",\n",
-      "  \"retrieved_at\": 1783343967,\n",
+      "  \"retrieved_at\": 1783368199,\n",
       "  \"battinfo_version\": \"0.7.0\"\n",
       "}\n"
      ]
@@ -335,10 +335,10 @@
    "id": "5e115f9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T13:19:27.768447Z",
-     "iopub.status.busy": "2026-07-06T13:19:27.767450Z",
-     "iopub.status.idle": "2026-07-06T13:19:27.772446Z",
-     "shell.execute_reply": "2026-07-06T13:19:27.772446Z"
+     "iopub.execute_input": "2026-07-06T20:03:19.400056Z",
+     "iopub.status.busy": "2026-07-06T20:03:19.400056Z",
+     "iopub.status.idle": "2026-07-06T20:03:19.405584Z",
+     "shell.execute_reply": "2026-07-06T20:03:19.404576Z"
     }
    },
    "outputs": [

--- a/docs/how-battinfo-is-built.md
+++ b/docs/how-battinfo-is-built.md
@@ -1,0 +1,171 @@
+# How BattINFO is built
+
+An orientation map for someone who knows Python, pydantic, and JSON Schema at
+a working level and wants to understand how this package fits together —
+before reading source code or contributing. Ten minutes, no ontology
+background needed.
+
+## The one-paragraph version
+
+BattINFO turns battery data into **plain JSON files with a contract**. You
+author records through pydantic models (or a friendlier workspace wrapper);
+each record is saved as a JSON file that validates against a canonical JSON
+Schema and carries a permanent identifier; a mapping-driven transform can then
+render any record as EMMO-aligned JSON-LD for the semantic web. Everything
+else in the package — CLI, importers, publishing, registry client — is
+plumbing around that pipeline:
+
+```text
+your data ──► authoring surface ──► pydantic models ──► JSON records on disk
+                                                              │
+                                        JSON Schemas validate ┤
+                                                              ▼
+                                              JSON-LD (EMMO semantics)
+                                                              ▼
+                                            Zenodo DOI · Battery Genome registry
+```
+
+## Two ideas everything follows
+
+**1. Everything is a spec or an instance.** A *spec* is a reusable
+description (a cell product's datasheet, a test protocol); an *instance* is a
+physical or concrete realization (the cell on your bench, the test you ran
+Tuesday). The record types chain into a provenance line:
+
+```text
+cell spec ──► cell ──► test ──► dataset        (+ test spec, materials, components…)
+```
+
+Every record type is one entry in a single registry
+(`src/battinfo/entities.py`): its JSON discriminator key, its schema file, its
+on-disk folder, its IRI namespace. Adding a record type means adding one entry
+there — every dispatch table in the package derives from it.
+
+**2. The pydantic models are the single source of truth.** There is no
+separate "input DTO" layer: `CellSpecification`, `CellInstance`, `Test`,
+`TestSpec`, and `Dataset` (in `src/battinfo/bundle.py`) are simultaneously
+
+- the **authoring input** — construct them with flat datasheet-style kwargs
+  (`manufacturer=`, `nominal_capacity={"value": 2.5, "unit": "Ah"}`),
+- the **validator** — `extra="forbid"` plus did-you-mean errors, so a typo'd
+  field teaches instead of disappearing,
+- the **serializer** — `to_record()` / `from_record()` convert to and from the
+  canonical JSON shape, losslessly.
+
+If you know pydantic, you already know the core of BattINFO.
+
+## The layers, top to bottom
+
+### Authoring surfaces — three doors into the same house
+
+| Surface | Module | For |
+|---|---|---|
+| `battinfo.workspace(".")` → `ws.convert() / search / add / save / publish` | `ws.py` | People with **data files** — the blessed, data-first path (`ws.quickstart()` prints the recipe) |
+| Models + `battinfo.publish(...)` | `bundle.py`, `_publish.py` | People authoring **spec records** directly in Python |
+| `battinfo.Workspace` | `_workspace.py` | The object-graph engine underneath: build linked spec/cell/test/dataset objects, then `save()` mints IRIs and writes everything |
+
+The friendly `AuthoringWorkspace` (door 1) delegates to the engine (door 3);
+`save_*`/`query_*` functions in `api.py` are the record-file-level operations
+all of them share.
+
+### Records on disk — the actual product
+
+A record is one JSON file: a `schema_version`, one discriminator key holding
+the body (`"cell_spec": {...}`), and a `provenance` block (which also carries
+`battinfo_version`, stamping which library build wrote it). Files live under a
+*source root* (`examples/<type>/…` in this repo; `.battinfo/records/…` in a
+workspace). IRIs like `https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq8`
+are minted **deterministically** from each record's natural identity
+(manufacturer :: model :: … for a spec), so re-running an identical ingest
+lands on the same files instead of duplicating them.
+
+### Validation — one contract, three consumers
+
+The canonical JSON Schemas (draft 2020-12) live in
+`src/battinfo/data/schemas/` and are enforced in three places, each with a CI
+drift gate: this package (`validate/` — schema, then semantic rules,
+cross-record references, and optional SHACL), the registry's publish gate
+(vendored copy), and the browser validator at battinfo.org/validate (vendored
+copy compiled with Ajv). Same record, same verdict, everywhere. Details in
+[the infrastructure contract](pages/contract.md).
+
+### The semantic layer — mapping tables, not magic
+
+`record_to_jsonld()` (`jsonld.py` + `transform/`) turns a record into
+EMMO-aligned JSON-LD. It is **table-driven**: curated mapping files in
+`assets/mappings/domain-battery/` say that the key `nominal_capacity` *is*
+`emmo:NominalCapacity` and the unit `"Ah"` *is* `emmo:AmpereHour`. The
+transform stacks types (a cylindrical LFP cell is simultaneously
+`BatteryCell`, `CylindricalBattery`, `LithiumIronPhosphateBattery`) and emits
+the canonical EMMO quantity pattern. No inference, no LLMs, no network —
+deterministic output from those tables, which is why the website can show
+[real before/after pairs](https://battinfo.org/examples) generated at build
+time.
+
+Two files carry the EMMO annotations in Python: `bundle_generated.py` is
+generated from LinkML schemas and holds IRI metadata; application code never
+imports it directly — `bundle_adapter.py` is the one crossing point.
+
+### Getting data in and out — `interop/` and BDF
+
+Importers (`interop/`) accept records from other ecosystems — BPX, PyBaMM
+experiments, aurora-unicycler protocols, Battery Data Commons, converter
+JSON-LD, spreadsheet exports — as an adoption funnel: express your existing
+data in BattINFO first, adopt natively later. Raw cycler files are a separate
+concern: `ws.convert()` (backed by the `bdf` package) normalises instrument
+exports into one documented table format before any records exist.
+
+### Publishing — the payoff
+
+`publication.py` builds the publication package (schema.org JSON-LD,
+RO-Crate, DataCite); `zenodo.py` archives it for a DOI; `api.py`'s registry
+client submits records to the Battery Genome registry (staged for curator
+review), with retries, a resumable outcome journal, and structured conflict
+responses. `ws.publish()` is the one-call wrapper over all of it.
+
+### The CLI — the same functions, spelled differently
+
+`cli.py` is a typer app; every command wraps a function from `api.py` or the
+workspace. Nothing exists "only in the CLI", which is why the
+[CLI reference](pages/cli-reference.md) can be generated from the app itself.
+
+## Where things live
+
+```text
+src/battinfo/
+├── bundle.py            the five record models — START HERE
+├── entities.py          the record-type registry (one entry per type)
+├── ws.py                AuthoringWorkspace: convert/search/add/save/publish
+├── _workspace.py        Workspace engine: object graph, finalize, IRI minting
+├── api.py               save_*/query_*/template_* + registry client
+├── validate/            schema → semantic → references → SHACL layers
+├── jsonld.py, transform/  record → EMMO JSON-LD (mapping-table driven)
+├── interop/             importers from other ecosystems
+├── publication.py, zenodo.py, _publish.py   publication package, DOI, publish()
+├── cli.py               typer CLI over the same api functions
+├── data/schemas/        the canonical JSON Schemas (the contract)
+├── data/examples/       packaged canonical example records
+└── bundle_generated.py + bundle_adapter.py   EMMO-annotated schema layer (generated)
+```
+
+Supporting cast: `_jsonio.py` (atomic JSON file I/O), `_record_index.py`
+(the bulk-save id→path cache), `canonical_aliases.py` (legacy key
+normalisation), `testmethod.py` (structured test-method steps),
+`metadata.py` (CSVW/DCAT dataset enrichment).
+
+## How it stays correct
+
+The repo leans hard on **generated-and-drift-checked** artifacts: if two
+things must agree, one is generated from the other and a test fails when they
+diverge. The guide notebooks and doc snippets execute in CI; the website's
+hero recipe is asserted against `ws.quickstart()`; the CLI and schema
+reference pages regenerate from the code; the registry and website re-vendor
+the schemas behind CI gates. When you change behavior, expect a test to point
+at every place the story is told — that is by design.
+
+## Where to go next
+
+- **Use it:** [Guide 06 — publish your first dataset](guides/06-publish-your-data.ipynb)
+- **Author records:** [Python API tour](python-api.md) · [API reference](pages/api-reference.rst)
+- **Build on it:** [the infrastructure contract](pages/contract.md) · [identifier policy](https://github.com/BIG-MAP/BattINFO/blob/main/IDENTIFIER_POLICY.md)
+- **Contribute:** [CONTRIBUTING](https://github.com/BIG-MAP/BattINFO/blob/main/CONTRIBUTING.md)

--- a/docs/how-battinfo-is-built.md
+++ b/docs/how-battinfo-is-built.md
@@ -42,7 +42,7 @@ on-disk folder, its IRI namespace. Adding a record type means adding one entry
 there — every dispatch table in the package derives from it.
 
 **2. The pydantic models are the single source of truth.** There is no
-separate "input DTO" layer: `CellSpecification`, `CellInstance`, `Test`,
+separate "input DTO" layer: `CellSpec`, `Cell`, `Test`,
 `TestSpec`, and `Dataset` (in `src/battinfo/bundle.py`) are simultaneously
 
 - the **authoring input** — construct them with flat datasheet-style kwargs

--- a/docs/howto/fix-validation-errors.md
+++ b/docs/howto/fix-validation-errors.md
@@ -9,7 +9,7 @@ message you get and the line that resolves it.
 import battinfo
 
 try:
-    battinfo.CellSpecification(manufacture="Acme", model="X", format="coin", chemistry="Li-ion")
+    battinfo.CellSpec(manufacture="Acme", model="X", format="coin", chemistry="Li-ion")
 except TypeError as exc:
     print(exc)  # Unknown field(s), with a did-you-mean for manufacturer=
 ```
@@ -17,7 +17,7 @@ except TypeError as exc:
 **2. A bare-number quantity** — quantities are objects, units are never implicit:
 
 ```python
-spec = battinfo.CellSpecification(
+spec = battinfo.CellSpec(
     manufacturer="Acme", model="X", format="coin", chemistry="Li-ion",
     nominal_capacity={"value": 2.5, "unit": "Ah"},   # not nominal_capacity=2.5
 )
@@ -37,7 +37,7 @@ except Exception as exc:
 
 ```python
 try:
-    battinfo.CellSpecification(
+    battinfo.CellSpec(
         manufacturer="Acme", model="X", format="coin", chemistry="Li-ion",
         specs=[("nominal_voltage", 3.0)],
     )

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ Open notebooks from the repo root with the `.venv` kernel selected.
 
 | | |
 |---|---|
+| **[How BattINFO is built](how-battinfo-is-built.md)** | The orientation roadmap: layers, modules, and the two ideas everything follows |
 | **[Data federation](data-federation.md)** | Why battery data needs federation, how BattINFO is the backbone, and Battery Genome in practice |
 | **[Cell descriptor standard](internal/cell-descriptor-standard.md)** | Normative cell descriptor specification |
 | **[Ontology / profile architecture](ontology-profile-architecture.md)** | How BattINFO, EMMO, and schema.org compose |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,9 +22,9 @@ Here is a minimal example that creates a canonical cell-spec record and publishe
 
       .. code-block:: python
 
-         from battinfo import CellSpecification, publish
+         from battinfo import CellSpec, publish
 
-         spec = CellSpecification(
+         spec = CellSpec(
              manufacturer="A123",
              model="ANR26650M1-B",
              cell_format="cylindrical",

--- a/docs/internal/beta-hardening-plan.md
+++ b/docs/internal/beta-hardening-plan.md
@@ -71,7 +71,7 @@ Outcome notes: `cycle_life` resolved by standardizing docs on `kind="cycling"` (
 addition); all five guide notebooks execute under nbmake in CI. The pre-Phase-1 docs/web
 WIP is parked on `wip/docs-web` and needs reconciliation against these changes before it lands.
 
-- **1.1 Guide notebooks** — update all five (`CellType`→`CellSpecification`,
+- **1.1 Guide notebooks** — update all five (`CellType`→`CellSpec`,
   `workspace.cell_type`→`.cell_spec`, `query_cell_types`→`query_cell_specs`,
   `TestProtocol`→`TestSpec`), re-execute, commit executed outputs.
 - **1.2 CI guard** — `pytest --nbmake docs/guides/` job so the funnel can't rot again.

--- a/docs/internal/celltype-rename-runbook.md
+++ b/docs/internal/celltype-rename-runbook.md
@@ -1,7 +1,7 @@
 # Runbook: coordinated `cell_type`/`cell-type` → `cell_spec`/`cell-spec` migration
 
 Status prerequisite: **Phases 1–2 are already done** in BattINFO (the two models are
-merged into one `CellSpecification`; the class symbol is renamed; suite green). This
+merged into one `CellSpec`; the class symbol is renamed; suite green). This
 runbook covers the remaining **lockstep token rename** across the on-disk format, the
 index/query API, the four repos, and the live registry DB — plus removing the transient
 `CellType` alias and `nominal_properties` bridge at the end.
@@ -17,7 +17,7 @@ half-state. Renaming **both sides together** makes a near-blanket sweep correct.
 
 | Surface | Old | New |
 |---|---|---|
-| Python class | `CellType` (alias) | `CellSpecification` (already canonical) |
+| Python class | `CellType` (alias) | `CellSpec` (already canonical) |
 | Python ident / var / param | `cell_type` | `cell_spec` |
 | Collections / index keys | `cell_types`, `cell_type_count` | `cell_specs`, `cell_spec_count` |
 | Field / FK / query kwarg | `cell_type_id`, `cell_type_iri` | `cell_spec_id`, `cell_spec_iri` |
@@ -27,12 +27,12 @@ half-state. Renaming **both sides together** makes a near-blanket sweep correct.
 | Record wrapper key | `"product"` | `"cell_spec"` |
 | Record specs key | `"specs"` | `"properties"` |
 | Cell-instance FK key | `"type_id"` | `"cell_spec_id"` |
-| `kind` discriminator | `"CellType"` | `"CellSpecification"` |
+| `kind` discriminator | `"CellType"` | `"CellSpec"` |
 | Compact identifier | `cell-type:{uid}` | `cell-spec:{uid}` |
 | Validation profile | `"cell-type"` | `"cell-spec"` |
 | Filenames | `cell-type.json`, `cell-type.schema.json`, `cell-type.shapes.ttl`, `cell-type.jsonld`, `cell-type.index.json` | `cell-spec.*` equivalents |
 | Directories | `examples/cell-type/`, `data/library/cell-type/`, `.battinfo/library/cell-type/` | `…/cell-spec/` |
-| LinkML schema | `schema/cell-type.yaml`, class `CellType` | `schema/cell-spec.yaml`, class `CellSpecification` |
+| LinkML schema | `schema/cell-type.yaml`, class `CellType` | `schema/cell-spec.yaml`, class `CellSpec` |
 
 **MUST NOT change** (leave exactly as-is):
 - The canonical IRI **path** `https://w3id.org/battinfo/spec/{uid}` — already migrated to
@@ -70,7 +70,7 @@ half-state. Renaming **both sides together** makes a near-blanket sweep correct.
 
 ### Step 1 — BattINFO: LinkML schema + regenerate
 1. `git mv schema/cell-type.yaml schema/cell-spec.yaml`; rename the LinkML class
-   `CellType`→`CellSpecification` and slots (`type_id`→`cell_spec_id`, etc.); update
+   `CellType`→`CellSpec` and slots (`type_id`→`cell_spec_id`, etc.); update
    `schema/battinfo.yaml` imports.
 2. Regenerate: `make gen-context`, `make gen-schema`, and `gen-pydantic --meta full`
    (review `bundle_generated.py`). Sync packaged copies (`assets/` ↔
@@ -88,7 +88,7 @@ imports and EMMO IRIs:
 3. Kebab/string tokens: `"cell-type"`→`"cell-spec"`, `cell-type:`→`cell-spec:`,
    `/cell-type/`→`/cell-spec/`, and the record keys `"product"`→`"cell_spec"`,
    `"specs"`→`"properties"`, `"type_id"`→`"cell_spec_id"`, `kind "CellType"`→
-   `"CellSpecification"`.
+   `"CellSpec"`.
 4. `git mv` the directories/filenames (`examples/cell-type/`→`examples/cell-spec/`, the
    two `cell-type.schema.json`, `cell-type.shapes.ttl`, library dirs, etc.) and update
    `default_filename`, `EXAMPLES_ROOT` constants, and any path globs.
@@ -98,7 +98,7 @@ imports and EMMO IRIs:
    readers, accept the **old** keys (`product`/`specs`/`type_id`/`cell-type:`) as
    fallbacks so existing records still load during re-ingest. Mark `# DEPRECATED: remove
    after registry migration`.
-7. Remove the transient `CellType = CellSpecification` alias and its `__init__` export;
+7. Remove the transient `CellType = CellSpec` alias and its `__init__` export;
    rename `CellTypeInput`/`CellTypeBundle`/`BatteryCellType`.
 8. Regenerate the LR03 preview; run the full suite + the gold-standard/SHACL validators.
 

--- a/docs/internal/celltype-rename-scope.md
+++ b/docs/internal/celltype-rename-scope.md
@@ -1,8 +1,8 @@
-# Scope: rename/merge `CellType` → `CellSpecification`
+# Scope: rename/merge `CellType` → `CellSpec`
 
 ## TL;DR
 
-`CellType` and `CellSpecification` are **two coexisting full Pydantic models**
+`CellType` and `CellSpec` are **two coexisting full Pydantic models**
 ([bundle.py:979](../src/battinfo/bundle.py) and [:1150](../src/battinfo/bundle.py))
 that represent the same entity (a `BatteryCellSpecification`). So this is a **model
 merge + identifier rename**, not a mechanical find-replace. It touches code, schemas,
@@ -24,16 +24,16 @@ Plus non-code surfaces: `schema/cell-type.yaml`, `assets/schemas/cell-type.schem
 
 ## The rename has five distinct layers (each a separate decision)
 
-1. **Python model & API (in-repo).** Merge `CellType` into `CellSpecification`:
-   - reconcile fields — `CellType.nominal_properties` vs `CellSpecification.properties`;
+1. **Python model & API (in-repo).** Merge `CellType` into `CellSpec`:
+   - reconcile fields — `CellType.nominal_properties` vs `CellSpec.properties`;
      `CellType.cell_specification_id` (back-ref) becomes self; both have manufacturer/
      model/format/chemistry/size_code/product_type/source but `CellType` adds
-     `country_of_origin`/`year`, `CellSpecification` adds `specification_comment`;
+     `country_of_origin`/`year`, `CellSpec` adds `specification_comment`;
    - the `CellType.__init__` that absorbs ~40 spec kwargs into `nominal_properties`
      (per CLAUDE.md) must move onto the merged class;
    - rename API methods: `ws.cell_type()`, `Workspace.cell_type()`, `derive_cell_type`,
      `build_publication_package` params, etc.;
-   - `CellInstance.cell_type` / `cell_type_id` → `cell_specification` / `cell_specification_id`;
+   - `Cell.cell_type` / `cell_type_id` → `cell_specification` / `cell_specification_id`;
    - `BattinfoBundle.cell_type` and `ZenodoCellRecord.cell_type` → `cell_specification`
      (the bundle already carries a separate `cell_specification` — these merge).
    - `bundle_generated.py` (LinkML-generated) — regenerate from the schema after the
@@ -70,7 +70,7 @@ Plus non-code surfaces: `schema/cell-type.yaml`, `assets/schemas/cell-type.schem
   `type_id`), the `cell-type` profile token, and remaining `/cell-type/` IRI references
   change, or stay as compatibility shims. This gates everything else.
 - **Phase 1 — merge the models (in-repo, no on-disk change).** Make `CellType` a
-  deprecated alias of a merged `CellSpecification` (re-export `CellType = CellSpecification`
+  deprecated alias of a merged `CellSpec` (re-export `CellType = CellSpec`
   with a `DeprecationWarning`), unify fields, keep `from_record`/`to_record` reading the
   existing on-disk keys. Update internal call sites incrementally. Largest code diff;
   back-compat preserved via the alias.
@@ -108,10 +108,10 @@ Plus non-code surfaces: `schema/cell-type.yaml`, `assets/schemas/cell-type.schem
 ## Execution status (2026-06-15)
 
 - **Phase 1 — model merge: DONE, suite green.** `CellType` merged into one
-  `CellSpecification` (union of authoring API + datasheet structure; `properties`
+  `CellSpec` (union of authoring API + datasheet structure; `properties`
   canonical; transient `nominal_properties` bridge + transient `CellType` alias).
   `Workspace.add` dispatch and `_append_unique` reconciled for the collapsed type.
-- **Phase 2 — `CellType`→`CellSpecification` symbol rename: DONE, suite green.** All
+- **Phase 2 — `CellType`→`CellSpec` symbol rename: DONE, suite green.** All
   application-layer + test references renamed (the LinkML-generated `bundle_generated`
   `CellType` and the `CellType as Gen…` adapter imports were correctly preserved).
 
@@ -131,7 +131,7 @@ index/query/registry say `cell_type`).
 **Recommendation:** fold the `cell_type`→`cell_spec` identifier rename INTO the
 coordinated Phase-4/5 migration (records + index + query API + registry DB + the three
 downstream repos), done as one lockstep change — not as an in-repo-only Phase 3. The
-cleanly-separable in-repo work (the model merge + the `CellSpecification` class symbol)
+cleanly-separable in-repo work (the model merge + the `CellSpec` class symbol)
 is complete. The transient `CellType` alias and `nominal_properties` bridge remain until
 that coordinated migration removes them.
 
@@ -140,13 +140,13 @@ that coordinated migration removes them.
 1. **Depth:** all the way through (Phases 1–5).
 2. **Back-compat:** hard-break, no permanent aliases (a *transient* alias is used only
    during the refactor to keep the suite green between phases, removed at the end).
-3. **Target term:** `cell_spec` / `CellSpecification`.
+3. **Target term:** `cell_spec` / `CellSpec`.
 
 ## Concrete merge design (Phase 1)
 
-The two models become **one** `CellSpecification` that is the union:
+The two models become **one** `CellSpec` that is the union:
 
-- **Canonical class:** `CellSpecification` absorbs `CellType`'s authoring surface — the
+- **Canonical class:** `CellSpec` absorbs `CellType`'s authoring surface — the
   kwarg-absorbing `__init__`, the `_mapping_property` descriptors + `specs` proxy, the
   `_populate_name` validator, and `id`/`name` being optional — **and keeps its own**
   datasheet structure (`positive_electrode`/`negative_electrode`/`electrolyte`/
@@ -162,8 +162,8 @@ The two models become **one** `CellSpecification` that is the union:
   `to_library_record`/`from_library_record` (`specification`/`property`, the datasheet
   library format). Phase 4 decides whether/how these on-disk keys rename — **this is the
   one that touches the live registry** (records carry `product`/`type_id`).
-- `kind` discriminator and `default_filename` become the `CellSpecification` values.
-- Transient `CellType = CellSpecification` alias added, removed in Phase 5.
+- `kind` discriminator and `default_filename` become the `CellSpec` values.
+- Transient `CellType = CellSpec` alias added, removed in Phase 5.
 
 ### The gating sub-decision (affects the registry contract)
 
@@ -182,7 +182,7 @@ done. This avoids a flag-day break of the live registry.
 2. **Back-compat:** keep `CellType` as a deprecated alias and accept old record keys, or
    hard-break (you noted legacy graphs can be remade — does that extend to record files
    and the registry)?
-3. **Target name:** `CellSpecification` everywhere, and what user-facing/API term —
+3. **Target name:** `CellSpec` everywhere, and what user-facing/API term —
    `cell_specification`, `cell_spec`, or `spec` (the canonical display term is "cell
    spec" per the nomenclature decision)?
 4. **Record-key/profile rename:** rename `product`/`type_id`/`cell-type` profile, or

--- a/docs/internal/coincell-canonical.md
+++ b/docs/internal/coincell-canonical.md
@@ -52,7 +52,7 @@ BatteryCell (CoinCell)
 └─ hasConstituent / hasComponent → Spring, Spacer
 ```
 
-The BattINFO bundle mirrors this with `CellSpecification` → `positive_electrode`
+The BattINFO bundle mirrors this with `CellSpec` → `positive_electrode`
 /`negative_electrode` (`Electrode`→`Coating`/`CurrentCollector`), `electrolyte`
 (`Electrolyte`→`SolventMixture`/`Salt`/`additive[]`), `separator`, and a `housing`
 model (`Case`/`Cap`/`Terminal`/`Seal`/`HardwarePart`; coin case/spring/spacer are

--- a/docs/internal/engineering-cell-description.md
+++ b/docs/internal/engineering-cell-description.md
@@ -29,7 +29,7 @@ is limited to: the pydantic sub-models, the JSON-LD **relations** (`hasTerminal`
 
 ### 3.1 Housing (generalises `coin_hardware` to all formats)
 
-New `Housing` model on `CellSpecification` (field `housing`). `coin_hardware` is retained
+New `Housing` model on `CellSpec` (field `housing`). `coin_hardware` is retained
 and **mapped into `housing` on load** for back-compat (see §7 migration).
 
 ```python
@@ -150,7 +150,7 @@ The swelling cascade (thickness after calendering/baking/wetting/@SOC/@cycle) an
 impedance decomposition (electrode/CC/terminal/module/pack) are **state- and cycle-dependent
 functions**, not static design facts. Recommendation: model them as **measurement outputs**
 (a thickness-vs-SOC / thickness-vs-cycle series, an impedance breakdown table) attached to a
-`Test`/`Dataset`, not as `CellSpecification` properties. Tracked as a separate initiative;
+`Test`/`Dataset`, not as `CellSpec` properties. Tracked as a separate initiative;
 out of scope here.
 
 ## 7. Implementation plan
@@ -169,7 +169,7 @@ out of scope here.
   loading-side/`ceramic_coating`; add the missing EMMO terms (§4) and wire the stub co-types.
 - **E5 — Authoring + validation.** `housing()`, `terminal()`, `tab=`, construction stack
   kwargs; then build a scraper for `Cell_Design_Tool*.xlsx` (analogous to the Discovery
-  scraper) as the end-to-end proof, producing one prismatic `CellSpecification` + instances.
+  scraper) as the end-to-end proof, producing one prismatic `CellSpec` + instances.
 
 ## 8. Open decisions
 

--- a/docs/internal/history/ROBUSTNESS_REVIEW_2026-06-27.md
+++ b/docs/internal/history/ROBUSTNESS_REVIEW_2026-06-27.md
@@ -33,7 +33,7 @@ Flagged by: Authoring->record->submit (AC-01), Test-suite (TS-06). Verdict: **co
 Flagged by: Authoring->record->submit (AC-02). Verdict: **confirmed**, repro run.
 
 `src/battinfo/_workspace.py:146-172, 1945-1956` | **high** |
-- Repro (run): two `CellInstance`s, identical identity, distinct measured mass [10,20]. Order [10,20] -> `{10:.../cell/dnqz, 20:.../cell/5gg0}`; order [20,10] -> `{20:.../cell/dnqz, 10:.../cell/5gg0}`. Same physical cell (mass=20) gets a different IRI across runs; IRIs swap.
+- Repro (run): two `Cell`s, identical identity, distinct measured mass [10,20]. Order [10,20] -> `{10:.../cell/dnqz, 20:.../cell/5gg0}`; order [20,10] -> `{20:.../cell/dnqz, 10:.../cell/5gg0}`. Same physical cell (mass=20) gets a different IRI across runs; IRIs swap.
 - Root cause: `_disambiguate_entity_ids` re-mints colliding entities with `_entity_iri(type, f'{current}::{ordinal}')` where `ordinal` is iteration order, not content. On re-save (upsert) the mass=20 cell's new content lands on the mass=10 cell's prior IRI file — wrong record clobbered, prior IRI orphaned.
 - Proposed fix: seed the collision re-mint from a hash of the entity's distinguishing/canonical content (the finalized objects retain `.measured`), not `f'{id}::{ordinal}'`.
 - Proposed test: `tests/test_workspace.py::test_disambiguation_is_order_independent` — finalize the same two content-distinct, identity-colliding cells in both orders; assert each cell's IRI (keyed by content) is identical across orderings.

--- a/docs/internal/library-canonical-unification.md
+++ b/docs/internal/library-canonical-unification.md
@@ -5,7 +5,7 @@ sweep). This note records why, and the plan to finish it later.
 
 ## Where things stand (already true)
 
-The "one model" goal is met. `CellSpecification` (`bundle.py`) is the single source of truth for a
+The "one model" goal is met. `CellSpec` (`bundle.py`) is the single source of truth for a
 cell specification. It serializes into two envelopes:
 
 - **Canonical** (`cell_spec` key) — `to_record()` / `from_record()`. Schema-validated, IRI-minted,
@@ -43,7 +43,7 @@ defaults (`source_type`, etc.) that `_record_from_cell_spec` applies on the cano
 library docs' canonical projections fail schema on `provenance.source_type`. Making them valid means
 adding provenance-defaulting to the library path — which is part of the deferred collapse, not a
 one-liner. Folded into the post-beta plan below. For beta the library subsystem is unchanged and
-`CellSpecification` remains the documented single source of truth.
+`CellSpec` remains the documented single source of truth.
 
 ## Post-beta plan (one unified effort: envelope collapse + shared JSON-LD core)
 

--- a/docs/pages/api-reference.rst
+++ b/docs/pages/api-reference.rst
@@ -13,10 +13,10 @@ The five record models are both the canonical source of truth and the
 authoring input: construct them with the flat field names you know from the
 datasheet and hand them to ``publish`` or the matching ``save_*`` function.
 
-.. autopydantic_model:: battinfo.CellSpecification
+.. autopydantic_model:: battinfo.CellSpec
    :members: false
 
-.. autopydantic_model:: battinfo.CellInstance
+.. autopydantic_model:: battinfo.Cell
    :members: false
 
 .. autopydantic_model:: battinfo.TestSpec

--- a/docs/pages/cli-reference.md
+++ b/docs/pages/cli-reference.md
@@ -159,6 +159,7 @@ $ battinfo query [OPTIONS] COMMAND [ARGS]...
 * `cell-instance`: Query canonical cell instances.
 * `dataset`: Query canonical dataset records.
 * `test-protocol`: Query canonical test protocols.
+* `test-spec`: Query canonical test protocols.
 * `tests`: Query canonical tests.
 
 ### `battinfo query cell-spec`
@@ -243,6 +244,27 @@ Query canonical test protocols.
 
 ```console
 $ battinfo query test-protocol [OPTIONS]
+```
+
+**Options**:
+
+* `--id TEXT`: Filter by canonical test-protocol IRI.
+* `--kind TEXT`: Filter by protocol kind.
+* `--name-contains TEXT`: Case-insensitive substring filter on protocol name.
+* `--source-type TEXT`: Filter by source type.
+* `--limit INTEGER RANGE`: Maximum rows.  [default: 50; x&gt;=1]
+* `--offset INTEGER RANGE`: Start offset.  [default: 0; x&gt;=0]
+* `--format TEXT`: Output format: table|json.  [default: table]
+* `--help`: Show this message and exit.
+
+### `battinfo query test-spec`
+
+Query canonical test protocols.
+
+**Usage**:
+
+```console
+$ battinfo query test-spec [OPTIONS]
 ```
 
 **Options**:
@@ -501,6 +523,7 @@ $ battinfo save [OPTIONS] COMMAND [ARGS]...
 * `cell-instance`: Save a cell-instance using either --input...
 * `dataset`: Save a dataset using either --input JSON...
 * `test-protocol`: Save a reusable test protocol using either...
+* `test-spec`: Save a reusable test protocol using either...
 * `test`: Save a test using either --input JSON or...
 
 ### `battinfo save record`
@@ -691,6 +714,38 @@ $ battinfo save test-protocol [OPTIONS]
 * `--format TEXT`: Output format: table|json.  [default: json]
 * `--help`: Show this message and exit.
 
+### `battinfo save test-spec`
+
+Save a reusable test protocol using either --input JSON or inline draft fields.
+
+**Usage**:
+
+```console
+$ battinfo save test-spec [OPTIONS]
+```
+
+**Options**:
+
+* `--input FILE`: Draft or canonical JSON.
+* `--name TEXT`: Protocol name (required when --input omitted).
+* `--kind TEXT`: Test kind.  [default: other]
+* `--description TEXT`: Optional protocol description.
+* `--version TEXT`: Optional protocol version.
+* `--protocol-url TEXT`: Optional protocol URL.
+* `--source-type TEXT`: Source type: manual|lab|simulation|other.  [default: manual]
+* `--uid TEXT`: Optional 16-char UID (dashed or undashed).
+* `--source-root PATH`: Save source root.  [default: examples]
+* `--mode TEXT`: Save mode: create_only|upsert.  [default: create_only]
+* `--duplicate-policy TEXT`: Duplicate handling: error|return_existing.  [default: error]
+* `--resolve-references / --no-resolve-references`: Resolve linked IDs against source_root.  [default: resolve-references]
+* `--publish / --no-publish`: Publish resolver artifacts after saving.  [default: no-publish]
+* `--publish-root PATH`: Resolver artifact root.  [default: .battinfo/resolver-site]
+* `--validate / --no-validate`: Validate record before saving.  [default: validate]
+* `--validation-policy TEXT`: Validation policy: default|strict|publisher|ingest.  [default: default]
+* `--dry-run`: Preview save without writing files.
+* `--format TEXT`: Output format: table|json.  [default: json]
+* `--help`: Show this message and exit.
+
 ### `battinfo save test`
 
 Save a test using either --input JSON or inline draft fields.
@@ -748,6 +803,7 @@ $ battinfo template [OPTIONS] COMMAND [ARGS]...
 * `cell-instance`: Generate a starter template for a...
 * `dataset`: Generate a starter template for a dataset...
 * `test-protocol`: Generate a starter template for a reusable...
+* `test-spec`: Generate a starter template for a reusable...
 * `test`: Generate a starter template for a test...
 
 ### `battinfo template cell-spec`
@@ -848,6 +904,26 @@ Generate a starter template for a reusable test-protocol record.
 
 ```console
 $ battinfo template test-protocol [OPTIONS]
+```
+
+**Options**:
+
+* `--name TEXT`: Human-readable protocol name.  [default: Example Test Protocol]
+* `--kind TEXT`: Test kind.  [default: other]
+* `--source-type TEXT`: Source type: manual|lab|simulation|other.  [default: manual]
+* `--uid TEXT`: Optional 16-char UID.  [default: 0000000000000000]
+* `--out PATH`: Optional output JSON path.
+* `--format TEXT`: Output format: table|json.  [default: json]
+* `--help`: Show this message and exit.
+
+### `battinfo template test-spec`
+
+Generate a starter template for a reusable test-protocol record.
+
+**Usage**:
+
+```console
+$ battinfo template test-spec [OPTIONS]
 ```
 
 **Options**:

--- a/docs/pages/concepts.rst
+++ b/docs/pages/concepts.rst
@@ -6,6 +6,7 @@ Architecture, ontology design, and authoring workflow documentation for BattINFO
 .. toctree::
    :maxdepth: 1
 
+   ../how-battinfo-is-built
    ../data-federation
    ../ontology-profile-architecture
    ../instance-test-dataset-workflow

--- a/docs/pages/getting-started.rst
+++ b/docs/pages/getting-started.rst
@@ -34,9 +34,9 @@ The fastest path is the ``publish`` shortcut:
 
 .. code-block:: python
 
-   from battinfo import CellSpecification, publish
+   from battinfo import CellSpec, publish
 
-   cell_spec = CellSpecification(
+   cell_spec = CellSpec(
        manufacturer="Energizer",
        model="CR2032",
        format="coin",
@@ -117,7 +117,7 @@ What to read next
 
         :octicon:`code;1em;sd-text-info`  Python API reference
         ^^^^^^^^^^^^^^^^^^^^^^
-        Full surface documentation for ``Workspace``, ``CellSpecification``, ingest helpers, and publishing utilities.
+        Full surface documentation for ``Workspace``, ``CellSpec``, ingest helpers, and publishing utilities.
 
     .. grid-item-card::
         :link: ../ontology-profile-architecture.html

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -81,13 +81,13 @@ chain, call `build_publication_package(...)`, then reload with
 ```python
 from pathlib import Path
 
-from battinfo import CellInstance, CellSpecification, Dataset, Test, build_publication_package, load_publication_package
+from battinfo import Cell, CellSpec, Dataset, Test, build_publication_package, load_publication_package
 
 dataset_dir = Path("data/cr2032-run")
 dataset_dir.mkdir(parents=True, exist_ok=True)
 (dataset_dir / "capacity.csv").write_text("cycle,capacity_ah\n1,0.225\n")
 
-cell_spec = CellSpecification(
+cell_spec = CellSpec(
     manufacturer="Energizer",
     model="CR2032",
     format="coin",
@@ -96,7 +96,7 @@ cell_spec = CellSpecification(
     nominal_voltage={"value": 3.0, "unit": "V"},
 )
 
-cell = CellInstance(
+cell = Cell(
     cell_spec=cell_spec,
     serial_number="energizer-cr2032-202602-dtjrga",
 )
@@ -132,7 +132,7 @@ Notes:
 - `ro-crate-metadata.json` is emitted alongside it for RO-Crate alignment.
 - `datacite-metadata.json` is emitted alongside it for DataCite-aligned deposit metadata.
 - `battinfo.dcat.jsonld` is available as an optional export.
-- `CellSpecification` is optional provenance support, not required core bundle content.
+- `CellSpec` is optional provenance support, not required core bundle content.
 - `emit_bundle_dir=True` writes the optional debug JSON files under `dataset_dir/battinfo/`.
 - `publish_dataset_metadata(...)` is the generic helper for low-plumbing workflows.
 - `publish_cr2032_dataset_metadata(...)` is kept as a CR2032 convenience wrapper.
@@ -191,9 +191,9 @@ Terminology note:
 Cell-spec publish shortcut:
 
 ```python
-from battinfo import CellSpecification, publish
+from battinfo import CellSpec, publish
 
-cell_spec = CellSpecification(
+cell_spec = CellSpec(
     manufacturer="Google",
     model="G20M7",
     format="pouch",

--- a/docs/workspace-authoring.md
+++ b/docs/workspace-authoring.md
@@ -53,19 +53,19 @@ Every verb is a method on the returned `AuthoringWorkspace` (also importable as
 | You want to… | Use | Entry point |
 |---|---|---|
 | Describe cells/tests/datasets interactively and publish them (the common case) | **Authoring workspace** | `ws = battinfo.workspace(".")` — this page |
-| Create a single record in code and save/publish it | **Models + functions** | `CellSpecification(...)` + `battinfo.publish(...)` — see the [Python API](python-api.md) |
+| Create a single record in code and save/publish it | **Models + functions** | `CellSpec(...)` + `battinfo.publish(...)` — see the [Python API](python-api.md) |
 | Build or script the full object graph programmatically (ingest pipelines, batch tooling) | **Object-graph engine** | `battinfo.Workspace` |
 
 ## The layers underneath
 
 - **`battinfo.Workspace`** (in `battinfo._workspace`) is the object-graph engine: it
-  holds linked `CellSpecification` / `CellInstance` / `Test` / `Dataset` objects,
+  holds linked `CellSpec` / `Cell` / `Test` / `Dataset` objects,
   finalizes ids and provenance, and writes the canonical records. The authoring
   workspace delegates to it; script against it directly when you are building
   pipelines rather than working interactively.
-- **The record models** (`CellSpecification`, `CellInstance`, `Test`, `TestSpec`,
+- **The record models** (`CellSpec`, `Cell`, `Test`, `TestSpec`,
   `Dataset`) are both the canonical source of truth and the authoring input — every
-  field carries a description (`help(battinfo.CellSpecification)`), and misspelled
+  field carries a description (`help(battinfo.CellSpec)`), and misspelled
   arguments get a did-you-mean.
 - **`battinfo.publish(...)`** takes a single model (or a linked graph of them) and
   writes/publishes the canonical records without a workspace.

--- a/scripts/execute_guides.py
+++ b/scripts/execute_guides.py
@@ -1,0 +1,66 @@
+"""Execute the guide notebooks and scrub machine-local paths from outputs.
+
+Library prints legitimately show absolute paths when YOU run them; committed
+outputs must not carry the executing machine's directories. This script
+re-executes every guide, then replaces the repository root (path and file://
+URI forms) with the neutral marker `<repo>` in all outputs.
+tests/test_notebook_hygiene.py fails if a committed output leaks a local path.
+
+Usage:
+    uv run python scripts/execute_guides.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDES = sorted((ROOT / "docs" / "guides").glob("0*.ipynb"))
+
+
+def scrub(notebook: Path) -> int:
+    nb = json.loads(notebook.read_text(encoding="utf-8"))
+    root_win = str(ROOT)
+    root_fwd = root_win.replace("\\", "/")
+    root_uri = Path(ROOT).as_uri()  # file:///C:/...
+    hits = 0
+
+    def clean(text: str) -> str:
+        nonlocal hits
+        for needle, marker in ((root_uri, "file:///<repo>"), (root_win, "<repo>"), (root_fwd, "<repo>")):
+            if needle in text:
+                hits += text.count(needle)
+                text = text.replace(needle, marker)
+        return text
+
+    for cell in nb.get("cells", []):
+        for out in cell.get("outputs", []):
+            if isinstance(out.get("text"), list):
+                out["text"] = [clean(line) for line in out["text"]]
+            data = out.get("data", {})
+            for key, value in list(data.items()):
+                if isinstance(value, list):
+                    data[key] = [clean(v) if isinstance(v, str) else v for v in value]
+                elif isinstance(value, str):
+                    data[key] = clean(value)
+    notebook.write_text(json.dumps(nb, indent=1, ensure_ascii=False), encoding="utf-8")
+    return hits
+
+
+def main() -> int:
+    for nb in GUIDES:
+        subprocess.run(
+            [sys.executable, "-m", "jupyter", "nbconvert", "--to", "notebook",
+             "--execute", "--inplace", str(nb)],
+            check=True,
+            cwd=ROOT,
+        )
+        scrubbed = scrub(nb)
+        print(f"{nb.name}: executed, scrubbed {scrubbed} path reference(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/battinfo/__init__.py
+++ b/src/battinfo/__init__.py
@@ -81,10 +81,10 @@ from battinfo.bundle import (
     BattinfoBundle,
     BillOfMaterials,
     Case,
+    Cell,
     CellConstruction,
-    CellInstance,
     CellProductType,
-    CellSpecification,
+    CellSpec,
     ChecksumInfo,
     Coating,
     Conformance,
@@ -205,9 +205,8 @@ from battinfo.validate import (
 from battinfo.ws import AuthoringWorkspace, validate_jsonld, workspace
 from battinfo.zenodo import ZenodoClient, ZenodoError, patch_zenodo_urls, upload_zenodo_package
 
-BatteryCellSpecification = CellSpecification
-BatteryCell = CellInstance
-Cell = CellInstance
+BatteryCellSpecification = CellSpec  # legacy alias
+BatteryCell = Cell  # legacy alias
 
 __all__ = [
     "__version__",
@@ -221,8 +220,7 @@ __all__ = [
     "CellConstruction",
     "ChecksumInfo",
     "Coating",
-    "CellSpecification",
-    "CellInstance",
+    "CellSpec",
     "CurrentCollector",
     "Dataset",
     "Electrode",
@@ -432,8 +430,11 @@ __version__ = "0.7.0"
 # The consolidation retired the per-record-type *Input DTOs; the models are the
 # authoring input. Downstream pinners get a migration message, not an ImportError.
 _DEPRECATED_ALIASES: dict[str, tuple[str, object]] = {
-    "CellSpecificationInput": ("CellSpecification", CellSpecification),
-    "CellInstanceInput": ("CellInstance", CellInstance),
+    # Pre-0.8 long-form class names (renamed to the consistent short scheme).
+    "CellSpecification": ("CellSpec", CellSpec),
+    "CellInstance": ("Cell", Cell),
+    "CellSpecificationInput": ("CellSpec", CellSpec),
+    "CellInstanceInput": ("Cell", Cell),
     "TestInput": ("Test", Test),
     "DatasetInput": ("Dataset", Dataset),
     "TestSpecInput": ("TestSpec", TestSpec),

--- a/src/battinfo/_publish.py
+++ b/src/battinfo/_publish.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from battinfo._workspace import Workspace
 from battinfo.api import build_curated_cell_spec_submission, submit_publication_package
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellSpec
 from battinfo.config import resolve_destination_config
 from battinfo.publication import publish as _legacy_publish
 
@@ -57,17 +57,17 @@ def publish(obj: Any = None, destination: str | None = None, **kwargs: Any) -> P
         raise TypeError("publish() requires a BattINFO object or the legacy publication-package keyword arguments.")
 
     resolved_destination = destination or "local"
-    if isinstance(obj, CellSpecification):
+    if isinstance(obj, CellSpec):
         return _publish_cell_spec(obj, destination=resolved_destination, **kwargs)
 
     raise TypeError(
-        "publish(obj, destination=...) currently supports CellSpecification objects. "
+        "publish(obj, destination=...) currently supports CellSpec objects. "
         "Use the legacy keyword form for dataset publication packages."
     )
 
 
 def _publish_cell_spec(
-    cell_spec: CellSpecification,
+    cell_spec: CellSpec,
     *,
     destination: str,
     root: PathLike | None = None,
@@ -98,7 +98,7 @@ def _publish_cell_spec(
     workspace.save(validation_policy=validation_policy)
 
     if not isinstance(cell_spec.id, str) or not cell_spec.id:
-        raise RuntimeError("CellSpecification did not receive a canonical id during save().")
+        raise RuntimeError("CellSpec did not receive a canonical id during save().")
 
     canonical_id = cell_spec.id.rsplit("/", 1)[-1]
     record_path = workspace.source_root / "cell-spec" / f"cell-spec-{canonical_id}.json"
@@ -197,7 +197,7 @@ def _looks_like_legacy_publication_call(obj: Any, destination: str | None, kwarg
     return any(key in kwargs for key in legacy_keys)
 
 
-def _cell_spec_slug(cell_spec: CellSpecification) -> str:
+def _cell_spec_slug(cell_spec: CellSpec) -> str:
     parts = [cell_spec.manufacturer or "cell", cell_spec.model or "type"]
     value = "-".join(parts).strip().lower()
     slug = re.sub(r"[^a-z0-9]+", "-", value).strip("-")

--- a/src/battinfo/_workspace.py
+++ b/src/battinfo/_workspace.py
@@ -37,8 +37,8 @@ from battinfo.api import (
 )
 from battinfo.authoring import cell_description as build_cell_description
 from battinfo.bundle import (
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     ChecksumInfo,
     Dataset,
     ProtocolInfo,
@@ -312,9 +312,9 @@ class Workspace:
         self.version = version
         self.comment = list(comment or [])
 
-        self.descriptions: list[CellSpecification] = []
-        self.cell_specs: list[CellSpecification] = []
-        self.cells: list[CellInstance] = []
+        self.descriptions: list[CellSpec] = []
+        self.cell_specs: list[CellSpec] = []
+        self.cells: list[Cell] = []
         self.test_specs: list[TestSpec] = []
         self.tests: list[Test] = []
         self.datasets: list[Dataset] = []
@@ -337,7 +337,7 @@ class Workspace:
 
     def bundle_workspace(
         self,
-        target: CellSpecification | CellInstance | Test | Dataset | None = None,
+        target: CellSpec | Cell | Test | Dataset | None = None,
         *,
         name: str | None = None,
         title: str | None = None,
@@ -364,15 +364,15 @@ class Workspace:
     def add(self, *objects: Any) -> "Workspace":
         """Add one or more authoring objects to the workspace by type."""
         def _add(obj: Any) -> None:
-            # The authoring model and the datasheet model are now one CellSpecification
+            # The authoring model and the datasheet model are now one CellSpec
             # (a BatteryCellSpecification); add() routes it to the canonical cell-spec
             # collection. The datasheet-library workflow uses the dedicated
             # add_description/save_descriptions methods.
-            if isinstance(obj, CellSpecification):
+            if isinstance(obj, CellSpec):
                 _append_unique(self.cell_specs, obj)
             elif isinstance(obj, TestSpec):
                 _append_unique(self.test_specs, obj)
-            elif isinstance(obj, CellInstance):
+            elif isinstance(obj, Cell):
                 if obj.cell_spec is not None:
                     _add(obj.cell_spec)
                 _append_unique(self.cells, obj)
@@ -390,7 +390,7 @@ class Workspace:
                 _append_unique(self.datasets, obj)
             else:
                 raise TypeError(
-                    "Workspace.add() supports CellSpecification, CellSpecification, TestSpec, Cell/CellInstance, Test, and Dataset objects."
+                    "Workspace.add() supports CellSpec, CellSpec, TestSpec, Cell/Cell, Test, and Dataset objects."
                 )
         for obj in objects:
             _add(obj)
@@ -398,11 +398,11 @@ class Workspace:
 
     def load_cell_spec(
         self,
-        source: CellSpecification | dict[str, Any] | PathLike,
+        source: CellSpec | dict[str, Any] | PathLike,
         *,
         validate: bool = True,
         validation_policy: str = "strict",
-    ) -> CellSpecification:
+    ) -> CellSpec:
         """Load one cell-spec JSON source into the workspace.
 
         The source can be either a canonical BattINFO `cell-spec` record with a
@@ -411,7 +411,7 @@ class Workspace:
         Draft inputs are canonized later when the workspace renders or saves.
         """
 
-        if isinstance(source, CellSpecification):
+        if isinstance(source, CellSpec):
             cell_spec = source.model_copy(deep=True)
         else:
             payload = _load_json(_as_path(source)) if isinstance(source, (str, Path)) else dict(source)
@@ -426,7 +426,7 @@ class Workspace:
                     report = validate_record_report(payload, policy=validation_policy)
                     if not report.ok:
                         raise ValueError(f"cell-spec validation failed: {'; '.join(report.render_errors())}")
-                cell_spec = CellSpecification.from_record(payload)
+                cell_spec = CellSpec.from_record(payload)
             else:
                 cell_spec = self._cell_spec_from_authoring_payload(payload)
 
@@ -435,15 +435,15 @@ class Workspace:
 
     def load_cell_specs(
         self,
-        *sources: CellSpecification | dict[str, Any] | PathLike,
+        *sources: CellSpec | dict[str, Any] | PathLike,
         directory: PathLike | None = None,
         glob: str = "*.json",
         validate: bool = True,
         validation_policy: str = "strict",
-    ) -> list[CellSpecification]:
+    ) -> list[CellSpec]:
         """Load multiple cell-spec JSON sources into the workspace."""
 
-        inputs: list[CellSpecification | dict[str, Any] | PathLike] = list(sources)
+        inputs: list[CellSpec | dict[str, Any] | PathLike] = list(sources)
         if directory is not None:
             directory_path = _as_path(directory)
             if not directory_path.exists() or not directory_path.is_dir():
@@ -519,7 +519,7 @@ class Workspace:
             for item in inputs
         ]
 
-    def _cell_spec_from_authoring_payload(self, payload: dict[str, Any]) -> CellSpecification:
+    def _cell_spec_from_authoring_payload(self, payload: dict[str, Any]) -> CellSpec:
         model = payload.get("model")
         if model is None:
             model = payload.get("model_name")
@@ -566,7 +566,7 @@ class Workspace:
         year = payload.get("year")
         name = payload.get("name")
 
-        return CellSpecification(
+        return CellSpec(
             name=name if isinstance(name, str) and name.strip() else None,
             manufacturer=manufacturer,
             model=model,
@@ -708,7 +708,7 @@ class Workspace:
         source: ProvenanceInfo | None = None,
         specification_comment: str | list[str] | None = None,
         comment: str | list[str] | None = None,
-    ) -> CellSpecification:
+    ) -> CellSpec:
         specification = build_cell_description(
             id=_entity_iri(
                 "cell-spec",
@@ -756,7 +756,8 @@ class Workspace:
         format: str,
         chemistry: str,
         product_type: str | None = None,
-        specs: Any = None,
+        properties: Any = None,
+        specs: Any = None,   # quiet alias for properties=
         size_code: str | None = None,
         iec_code: str | None = None,
         country_of_origin: str | None = None,
@@ -771,10 +772,10 @@ class Workspace:
         citation: str | None = None,
         retrieved_at: int | str | None = None,
         comment: list[str] | None = None,
-    ) -> CellSpecification:
+    ) -> CellSpec:
         from battinfo.bundle import CellProductType
         resolved_pt = CellProductType(product_type) if product_type is not None else None
-        cell_spec = CellSpecification(
+        cell_spec = CellSpec(
             manufacturer=manufacturer,
             model=model,
             format=format,
@@ -788,7 +789,7 @@ class Workspace:
             positive_electrode_basis=positive_electrode_basis,
             negative_electrode_basis=negative_electrode_basis,
             datasheet_revision=datasheet_revision,
-            properties=_mapping_value(specs),
+            properties=_mapping_value(properties if properties is not None else specs),
             source=ProvenanceInfo(
                 type=source_type,
                 file=source_file,
@@ -803,7 +804,7 @@ class Workspace:
 
     def cell(
         self,
-        cell_spec: CellSpecification,
+        cell_spec: CellSpec,
         *,
         name: str | None = None,
         serial_number: str | None = None,
@@ -818,11 +819,11 @@ class Workspace:
         citation: str | None = None,
         retrieved_at: int | str | None = None,
         comment: list[str] | None = None,
-    ) -> CellInstance:
+    ) -> Cell:
         from battinfo.bundle import Conformance as _Conformance
         if isinstance(conformance, dict):
             conformance = _Conformance.from_record(conformance)
-        cell = CellInstance(
+        cell = Cell(
             cell_spec=cell_spec,
             name=name,
             serial_number=serial_number,
@@ -907,7 +908,7 @@ class Workspace:
 
     def test(
         self,
-        cell: CellInstance,
+        cell: Cell,
         *,
         type: str | None = None,
         kind: str | None = None,   # backward-compat alias for type
@@ -965,7 +966,7 @@ class Workspace:
 
     def record_test(
         self,
-        cell: CellInstance,
+        cell: Cell,
         *,
         type: str | None = None,
         kind: str | None = None,   # backward-compat alias for type
@@ -1048,7 +1049,7 @@ class Workspace:
 
     def dataset(
         self,
-        cell: CellInstance,
+        cell: Cell,
         *,
         title: str,
         description: str | None = None,
@@ -1151,7 +1152,7 @@ class Workspace:
 
     def from_battdat(
         self,
-        cell: CellInstance,
+        cell: Cell,
         path: PathLike,
         *,
         kind: str | None = None,
@@ -1254,12 +1255,12 @@ class Workspace:
         source_type: str = "simulation",
         source_file: str | None = None,
         comment: list[str] | None = None,
-    ) -> CellSpecification:
-        """Create a CellSpecification from a BPX battery parameter file.
+    ) -> CellSpec:
+        """Create a CellSpec from a BPX battery parameter file.
 
         Reads *path* and maps the BPX ``Parameterisation.Cell`` parameters
         that have direct BattINFO spec equivalents (capacity, voltage limits,
-        mass, dimensions) to a BattINFO CellSpecification.  Physics parameters are
+        mass, dimensions) to a BattINFO CellSpec.  Physics parameters are
         silently skipped.
 
         Parameters
@@ -1311,9 +1312,9 @@ class Workspace:
         dataset: Dataset,
         *,
         test: Test | None = None,
-        cell: CellInstance | None = None,
-        cell_spec: CellSpecification | None = None,
-        cell_specification: CellSpecification | dict[str, Any] | PathLike | None = None,
+        cell: Cell | None = None,
+        cell_spec: CellSpec | None = None,
+        cell_specification: CellSpec | dict[str, Any] | PathLike | None = None,
         datasheet_path: PathLike | None = None,
         publication_root: PathLike | None = None,
         publish_filename: str = DEFAULT_PUBLISH_FILENAME,
@@ -1344,9 +1345,9 @@ class Workspace:
         dataset: Dataset,
         *,
         test: Test | None = None,
-        cell: CellInstance | None = None,
-        cell_spec: CellSpecification | None = None,
-        cell_specification: CellSpecification | dict[str, Any] | PathLike | None = None,
+        cell: Cell | None = None,
+        cell_spec: CellSpec | None = None,
+        cell_specification: CellSpec | dict[str, Any] | PathLike | None = None,
         datasheet_path: PathLike | None = None,
         publication_root: PathLike | None = None,
         publish_filename: str = DEFAULT_PUBLISH_FILENAME,
@@ -1397,8 +1398,8 @@ class Workspace:
         registry: Any,
         root: PathLike | None = None,
         test: Test | None = None,
-        cell: CellInstance | None = None,
-        cell_spec: CellSpecification | None = None,
+        cell: Cell | None = None,
+        cell_spec: CellSpec | None = None,
         workspace_id: str | None = None,
         publisher_id: str | None = None,
         version: str | None = None,
@@ -1438,8 +1439,8 @@ class Workspace:
         registry: Any,
         root: PathLike | None = None,
         test: Test | None = None,
-        cell: CellInstance | None = None,
-        cell_spec: CellSpecification | None = None,
+        cell: Cell | None = None,
+        cell_spec: CellSpec | None = None,
         workspace_id: str | None = None,
         publisher_id: str | None = None,
         version: str | None = None,
@@ -1496,8 +1497,8 @@ class Workspace:
         registry: Any,
         root: PathLike | None = None,
         test: Test | None = None,
-        cell: CellInstance | None = None,
-        cell_spec: CellSpecification | None = None,
+        cell: Cell | None = None,
+        cell_spec: CellSpec | None = None,
         workspace_id: str | None = None,
         publisher_id: str | None = None,
         version: str | None = None,
@@ -1539,8 +1540,8 @@ class Workspace:
         registry: Any,
         root: PathLike | None = None,
         test: Test | None = None,
-        cell: CellInstance | None = None,
-        cell_spec: CellSpecification | None = None,
+        cell: Cell | None = None,
+        cell_spec: CellSpec | None = None,
         workspace_id: str | None = None,
         publisher_id: str | None = None,
         version: str | None = None,
@@ -1899,7 +1900,7 @@ class Workspace:
             return self.tests[0]
         return None
 
-    def _resolve_dataset_cell(self, dataset: Dataset) -> CellInstance | None:
+    def _resolve_dataset_cell(self, dataset: Dataset) -> Cell | None:
         if dataset.cell_instance_id is not None:
             for candidate in self.cells:
                 if candidate.id == dataset.cell_instance_id:
@@ -1912,7 +1913,7 @@ class Workspace:
             return self.cells[0]
         return None
 
-    def _resolve_dataset_cell_spec(self, dataset: Dataset, cell: CellInstance) -> CellSpecification | None:
+    def _resolve_dataset_cell_spec(self, dataset: Dataset, cell: Cell) -> CellSpec | None:
         if cell.cell_spec is not None:
             return cell.cell_spec
         if dataset.cell_instance_id is not None:
@@ -1928,10 +1929,10 @@ class Workspace:
         dataset: Dataset,
         *,
         test: Test | None = None,
-        cell: CellInstance | None = None,
-        cell_spec: CellSpecification | None = None,
+        cell: Cell | None = None,
+        cell_spec: CellSpec | None = None,
         action: str,
-    ) -> tuple[Test, CellInstance, CellSpecification]:
+    ) -> tuple[Test, Cell, CellSpec]:
         resolved_test = test or dataset.test or self._resolve_dataset_test(dataset)
         if resolved_test is None:
             raise ValueError(f"Workspace.{action}() requires a Test or a Dataset linked to a Test.")
@@ -1942,11 +1943,11 @@ class Workspace:
 
         resolved_cell_spec = cell_spec or resolved_cell.cell_spec or self._resolve_dataset_cell_spec(dataset, resolved_cell)
         if resolved_cell_spec is None:
-            raise ValueError(f"Workspace.{action}() requires a CellSpecification or a linked Cell with cell_spec set.")
+            raise ValueError(f"Workspace.{action}() requires a CellSpec or a linked Cell with cell_spec set.")
 
         return resolved_test, resolved_cell, resolved_cell_spec
 
-    def _finalize_description(self, specification: CellSpecification) -> CellSpecification:
+    def _finalize_description(self, specification: CellSpec) -> CellSpec:
         # source_type is schema-required, so an unprovided one takes the documented category
         # default; source_file is optional and stays absent unless the author provided it — a
         # fabricated placeholder ("manual.json") would masquerade as real provenance (applies
@@ -1958,7 +1959,7 @@ class Workspace:
             finalized.source.retrieved_at = _now_unix()
         return finalized
 
-    def _finalize_cell_spec(self, cell_spec: CellSpecification) -> CellSpecification:
+    def _finalize_cell_spec(self, cell_spec: CellSpec) -> CellSpec:
         finalized = cell_spec.model_copy(deep=True)
         if finalized.id is None:
             finalized.id = _entity_iri(
@@ -1981,7 +1982,7 @@ class Workspace:
             finalized.source.retrieved_at = _now_unix()
         return finalized
 
-    def _finalize_cell(self, cell: CellInstance, cell_spec_map: dict[int, CellSpecification]) -> CellInstance:
+    def _finalize_cell(self, cell: Cell, cell_spec_map: dict[int, CellSpec]) -> Cell:
         finalized = cell.model_copy(deep=True, update={"cell_spec": None})
         linked_type = cell_spec_map.get(id(cell.cell_spec)) if cell.cell_spec is not None else None
         if finalized.cell_spec_id is None and linked_type is not None:
@@ -2032,7 +2033,7 @@ class Workspace:
     def _finalize_test(
         self,
         test: Test,
-        cell_map: dict[int, CellInstance],
+        cell_map: dict[int, Cell],
         test_spec_map: dict[int, TestSpec],
     ) -> Test:
         finalized = test.model_copy(deep=True, update={"cell": None, "protocol_entity": None})
@@ -2071,7 +2072,7 @@ class Workspace:
     def _finalize_dataset(
         self,
         dataset: Dataset,
-        cell_map: dict[int, CellInstance],
+        cell_map: dict[int, Cell],
         test_map: dict[int, Test],
     ) -> Dataset:
         finalized = dataset.model_copy(deep=True, update={"cell": None, "test": None})

--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -23,8 +23,8 @@ from battinfo._record_index import active_record_cache, bulk_save_session
 from battinfo.bundle import (
     SCHEMA_VERSION,
     BatteryTestType,
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     Dataset,
     Test,
     TestSpec,
@@ -144,7 +144,7 @@ def _citation_url_value(citation: object = None, citation_doi: object = None) ->
     return None
 
 
-# NOTE: the former ``CellSpecificationInput`` DTO has been retired — the ``CellSpecification`` model
+# NOTE: the former ``CellSpecificationInput`` DTO has been retired — the ``CellSpec`` model
 # (battinfo.bundle) now absorbs the flat authoring input shape directly (model_name/specs/notes, a
 # dict manufacturer, flat provenance kwargs, a transient uid), so one model is both the source of
 # truth and the thing callers construct. ``_record_from_cell_spec`` mints the IRI + applies save-time
@@ -164,7 +164,7 @@ def template_cell_spec(
     source_file: str = "template-cell-spec.json",
 ) -> dict[str, Any]:
     """Build a starter canonical cell-spec document for save workflows."""
-    draft = CellSpecification(
+    draft = CellSpec(
         uid=uid,
         model_name=model_name,
         manufacturer=manufacturer,
@@ -262,7 +262,7 @@ def template_cell_instance(
     uid: str | None = TEMPLATE_UID,
 ) -> dict[str, Any]:
     """Build a starter canonical cell-instance document for save workflows."""
-    draft = CellInstance(
+    draft = Cell(
         uid=uid,
         cell_spec_id=cell_spec_id,
         source_type=source_type,
@@ -694,7 +694,7 @@ def _editorial_date_token(value: object) -> str | None:
 
 def _staging_cell_spec_identity(
     source: dict[str, Any] | PathLike,
-    draft: CellSpecification,
+    draft: CellSpec,
 ) -> dict[str, Any]:
     if isinstance(source, (str, Path)):
         payload = _load_json(_as_path(source))
@@ -761,7 +761,7 @@ def _staging_cell_spec_input(
     source: dict[str, Any] | PathLike,
     *,
     uid: str | None = None,
-) -> tuple[CellSpecification, Path | None]:
+) -> tuple[CellSpec, Path | None]:
     source_path: Path | None = None
     if isinstance(source, (str, Path)):
         source_path = _as_path(source)
@@ -780,7 +780,7 @@ def _staging_cell_spec_input(
         manufacturer_obj = product.get("manufacturer")
         manufacturer = manufacturer_obj.get("name") if isinstance(manufacturer_obj, Mapping) else manufacturer_obj
         return (
-            CellSpecification(
+            CellSpec(
                 schema_version=str(record_payload.get("schema_version") or "0.1.0"),
                 id=product.get("id") if isinstance(product.get("id"), str) else None,
                 uid=uid,
@@ -843,7 +843,7 @@ def _staging_cell_spec_input(
     retrieved_at = payload.get("retrieved_at", provenance.get("retrieved_at"))
 
     return (
-        CellSpecification(
+        CellSpec(
             uid=uid,
             manufacturer=manufacturer.strip(),
             model_name=str(model_name).strip(),
@@ -1274,7 +1274,7 @@ def _curated_cell_spec_submission_resource(
         "source_local_id": source_local_id,
         "title": title,
         "semantic_payload": {
-            "@type": "CellSpecification",
+            "@type": "CellSpec",
             "battinfo_records": {"cell_spec": dict(record)},
         },
         "related_resources": [],
@@ -1552,7 +1552,7 @@ def _library_record_from_input(draft: Mapping[str, Any]) -> dict[str, Any]:
 
     Accepts the full specification surface (manufacturer/model/identity + construction,
     property, and the electrode/electrolyte/separator/housing structure). Detailed specs
-    are normally authored via ``cell_description()`` and saved as a ``CellSpecification``
+    are normally authored via ``cell_description()`` and saved as a ``CellSpec``
     bundle; this is the dict/CLI entry point for the same library record.
     """
     draft_id = draft.get("id")
@@ -2376,7 +2376,7 @@ _COMPONENT_SPEC_REF_NAMESPACES = {
 }
 
 
-def _record_from_cell_spec(spec: CellSpecification) -> dict[str, Any]:
+def _record_from_cell_spec(spec: CellSpec) -> dict[str, Any]:
     # Validate component-spec reference IRIs at the input boundary.
     for field_name, namespace in _COMPONENT_SPEC_REF_NAMESPACES.items():
         value = getattr(spec, field_name)
@@ -2478,7 +2478,7 @@ def _identity_minted_uid(entity_kind: str, entity: Any) -> str:
     return stable_uid(seed)
 
 
-def _mint_cell_spec_record(spec: CellSpecification) -> dict[str, Any]:
+def _mint_cell_spec_record(spec: CellSpec) -> dict[str, Any]:
     if spec.id is not None:
         if not CELL_SPEC_IRI_RE.fullmatch(spec.id):
             raise ValueError("cell spec id must match https://w3id.org/battinfo/spec/{uid}.")
@@ -2500,7 +2500,7 @@ def _mint_cell_spec_record(spec: CellSpecification) -> dict[str, Any]:
     return finalized.to_record()
 
 
-def _record_from_cell_instance(instance: CellInstance) -> dict[str, Any]:
+def _record_from_cell_instance(instance: Cell) -> dict[str, Any]:
     if instance.cell_spec_id is None or not CELL_SPEC_IRI_RE.fullmatch(instance.cell_spec_id):
         raise ValueError("cell_spec_id must match https://w3id.org/battinfo/spec/{uid}.")
     for dataset_id in instance.dataset_ids:
@@ -2746,7 +2746,7 @@ def save_record(
 
 
 def save_cell_spec(
-    draft: CellSpecification | dict[str, Any] | PathLike,
+    draft: CellSpec | dict[str, Any] | PathLike,
     *,
     source_root: PathLike = DEFAULT_REGISTRATION_SOURCE_ROOT,
     mode: str = REGISTER_MODE_CREATE_ONLY,
@@ -2767,7 +2767,7 @@ def save_cell_spec(
     re-save is a no-op; a revised datasheet updates the record in place under
     ``mode="upsert"``. See ``save_record`` for the full minting policy.
     """
-    from battinfo.bundle import CellSpecification as CellSpecificationBundle
+    from battinfo.bundle import CellSpec as CellSpecificationBundle
 
     if isinstance(draft, (str, Path)):
         loaded = _load_json(_as_path(draft))
@@ -2819,7 +2819,7 @@ def save_cell_spec(
 
 
 def save_cell_instance(
-    draft: CellInstance | dict[str, Any] | PathLike,
+    draft: Cell | dict[str, Any] | PathLike,
     *,
     source_root: PathLike = DEFAULT_REGISTRATION_SOURCE_ROOT,
     mode: str = REGISTER_MODE_CREATE_ONLY,
@@ -2840,7 +2840,7 @@ def save_cell_instance(
     serial, batch, or name mint randomly so distinct anonymous cells never
     dedup. See ``save_record`` for the full minting policy.
     """
-    from battinfo.bundle import CellInstance as CellInstanceBundle
+    from battinfo.bundle import Cell as CellInstanceBundle
 
     if isinstance(draft, (str, Path)):
         loaded = _load_json(_as_path(draft))
@@ -3191,7 +3191,7 @@ def build_cell_spec_library_rdf(
 
 
 def save_library_cell_spec(
-    draft: "CellSpecification | dict[str, Any] | PathLike",
+    draft: "CellSpec | dict[str, Any] | PathLike",
     *,
     library_root: PathLike = DEFAULT_LIBRARY_CELL_TYPES_DIR,
     package_root: PathLike = DEFAULT_PACKAGED_LIBRARY_CELL_TYPES_DIR,
@@ -3208,7 +3208,7 @@ def save_library_cell_spec(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Save a reusable cell specification into the curated library."""
-    from battinfo.bundle import CellSpecification as CellSpecificationBundle
+    from battinfo.bundle import CellSpec as CellSpecificationBundle
 
     if isinstance(draft, (str, Path)):
         loaded = _load_json(_as_path(draft))

--- a/src/battinfo/authoring.py
+++ b/src/battinfo/authoring.py
@@ -6,7 +6,7 @@ from battinfo.bundle import (
     BillOfMaterials,
     Case,
     CellConstruction,
-    CellSpecification,
+    CellSpec,
     Coating,
     CurrentCollector,
     CurrentCollectorTab,
@@ -497,7 +497,7 @@ def cell_description(
     source: ProvenanceInfo | None = None,
     specification_comment: str | list[str] | None = None,
     comment: str | list[str] | None = None,
-) -> CellSpecification:
+) -> CellSpec:
     """Build a complete cell descriptor specification.
 
     This is the primary authoring entry point for detailed cell descriptions.
@@ -537,7 +537,7 @@ def cell_description(
         else list(specification_comment or [])
     )
     comments = [comment] if isinstance(comment, str) else list(comment or [])
-    return CellSpecification(
+    return CellSpec(
         id=id,
         manufacturer=manufacturer,
         model=model,

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -1265,7 +1265,7 @@ class BundleJsonModel(BaseModel):
         return out_path
 
 
-class CellSpecification(BundleJsonModel):
+class CellSpec(BundleJsonModel):
     # NOTE: This is the merged cell-specification model. It absorbs the former
     # ``CellType`` (authoring API: kwarg-absorbing __init__, _mapping_property
     # descriptors, optional id/name) AND the former datasheet specification model
@@ -1275,7 +1275,7 @@ class CellSpecification(BundleJsonModel):
     # record (``specification``/``property``) formats.
     default_filename: ClassVar[str] = CELL_SPEC_FILENAME
 
-    kind: str = "CellSpecification"
+    kind: str = "CellSpec"
     id: str | None = Field(default=None, description="Canonical IRI for this cell-spec record (https://w3id.org/battinfo/spec/{uid}); minted at save time when omitted.")
     # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
     uid: str | None = Field(default=None, exclude=True, repr=False, description="Transient 16-char Crockford Base32 uid used to mint the canonical IRI when no id is given; never serialized.")
@@ -1298,7 +1298,7 @@ class CellSpecification(BundleJsonModel):
     datasheet_revision: str | None = Field(default=None, description="Revision label of the source datasheet this spec was taken from.")
     cell_specification_id: str | None = Field(default=None, description="IRI of a linked library specification record carrying the detailed datasheet structure.")
     properties: dict[str, Any] = Field(default_factory=dict, description="Quantitative spec properties as name -> {value, unit} quantity objects (authoring alias: specs=; run 'battinfo properties list' for valid names).")
-    # Datasheet structure (merged from the former CellSpecification).
+    # Datasheet structure (merged from the former CellSpec).
     construction: dict[str, Any] = Field(default_factory=dict, description="As-designed construction details (assembly type, layering, stack geometry).")
     positive_electrode: Electrode | None = Field(default=None, description="Inline positive-electrode datasheet structure (coating, current collector, composition).")
     negative_electrode: Electrode | None = Field(default=None, description="Inline negative-electrode datasheet structure (coating, current collector, composition).")
@@ -1517,7 +1517,7 @@ class CellSpecification(BundleJsonModel):
     @classmethod
     def from_cell_specification(
         cls,
-        specification: CellSpecification,
+        specification: CellSpec,
         *,
         id: str | None = None,
         name: str | None = None,
@@ -1542,7 +1542,7 @@ class CellSpecification(BundleJsonModel):
                 citation=_citation_url_value(specification.source.citation),
                 retrieved_at=specification.source.retrieved_at,
             ),
-            comment=["Generated from the linked CellSpecification."],
+            comment=["Generated from the linked CellSpec."],
         )
 
     # ── Draft vs. publish-ready ──────────────────────────────────────────────────
@@ -1576,24 +1576,24 @@ class CellSpecification(BundleJsonModel):
         """True when every field required to publish is set (never raises — for a GUI/CLI check)."""
         return not self.publish_readiness_problems()
 
-    def finalize(self) -> "CellSpecification":
+    def finalize(self) -> "CellSpec":
         """Assert publish-readiness and return self, so ``spec.finalize().to_record()`` reads cleanly.
 
         Raises listing every still-missing field at once. A draft is valid to hold and to persist via
         ``model_dump``; ``finalize()`` is the gate it must pass to become a published record."""
         problems = self.publish_readiness_problems()
         if problems:
-            raise ValueError("CellSpecification is not publish-ready; set: " + ", ".join(problems))
+            raise ValueError("CellSpec is not publish-ready; set: " + ", ".join(problems))
         return self
 
     def to_record(self) -> dict[str, Any]:
         if self.id is None:
             raise ValueError(
-                "CellSpecification has no id yet (it is still a draft). Mint one via publish() or "
+                "CellSpec has no id yet (it is still a draft). Mint one via publish() or "
                 "build_publication_package(); call finalize() to check everything needed to publish."
             )
         if self.name is None:
-            raise ValueError("CellSpecification.name is required before serialization.")
+            raise ValueError("CellSpec.name is required before serialization.")
         record: dict[str, Any] = {
             "schema_version": self.schema_version,
             "cell_spec": {
@@ -1659,7 +1659,7 @@ class CellSpecification(BundleJsonModel):
             record["specification_comment"] = list(self.specification_comment)
         return record_to_snake_aliases(record)
 
-    # ── Datasheet "library" record format (merged from the former CellSpecification) ──
+    # ── Datasheet "library" record format (merged from the former CellSpec) ──
     @classmethod
     def from_path(cls, path: PathLike) -> Self:
         payload = _read_json(_as_path(path))
@@ -1758,16 +1758,16 @@ class CellSpecification(BundleJsonModel):
 
 
 
-class CellInstance(BundleJsonModel):
+class Cell(BundleJsonModel):
     default_filename: ClassVar[str] = CELL_INSTANCE_FILENAME
 
-    kind: str = "CellInstance"
+    kind: str = "Cell"
     id: str | None = Field(default=None, description="Canonical IRI for this physical cell (https://w3id.org/battinfo/cell/{uid}); minted at save time when omitted.")
     # Transient short id used only to mint the canonical IRI when no id is given; never serialized.
     uid: str | None = Field(default=None, exclude=True, repr=False, description="Transient 16-char Crockford Base32 uid used to mint the canonical IRI when no id is given; never serialized.")
     name: str | None = Field(default=None, description="Display name; defaults to the serial number or batch id.")
     cell_spec_id: str | None = Field(default=None, description="IRI of the cell spec this physical cell instantiates (required at save).")
-    cell_spec: CellSpecification | None = Field(default=None, exclude=True, repr=False, description="Linked cell-spec object (alternative to cell_spec_id; may also be passed positionally).")
+    cell_spec: CellSpec | None = Field(default=None, exclude=True, repr=False, description="Linked cell-spec object (alternative to cell_spec_id; may also be passed positionally).")
     serial_number: str | None = Field(default=None, description="Manufacturer or lab serial number of this individual cell.")
     batch_id: str | None = Field(default=None, description="Production or delivery batch identifier.")
     grade: str | None = Field(default=None, description="Sorting/binning grade assigned to this cell (e.g. 'A', 'B').")
@@ -1779,7 +1779,7 @@ class CellInstance(BundleJsonModel):
     source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, retrieved_at=, ...).")
     comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
 
-    def __init__(self, cell_spec: CellSpecification | None = None, /, **data: Any) -> None:
+    def __init__(self, cell_spec: CellSpec | None = None, /, **data: Any) -> None:
         # Absorb the flat authoring/input shape (formerly CellInstanceInput).
         if "notes" in data and "comment" not in data:
             data["comment"] = data.pop("notes")
@@ -1875,9 +1875,9 @@ class CellInstance(BundleJsonModel):
 
     def to_record(self) -> dict[str, Any]:
         if self.id is None:
-            raise ValueError("CellInstance.id is required before serialization. Use battinfo.build_publication_package(...) or battinfo.publish(...) to finalize IDs.")
+            raise ValueError("Cell.id is required before serialization. Use battinfo.build_publication_package(...) or battinfo.publish(...) to finalize IDs.")
         if self.cell_spec_id is None:
-            raise ValueError("CellInstance.cell_spec_id is required before serialization.")
+            raise ValueError("Cell.cell_spec_id is required before serialization.")
         record: dict[str, Any] = {
             "schema_version": self.schema_version,
             "cell_instance": {
@@ -2275,7 +2275,7 @@ class Test(BundleJsonModel):
     protocol_id: str | None = Field(default=None, description="IRI of the test spec this execution followed.")
     protocol_entity: TestSpec | None = Field(default=None, exclude=True, repr=False, description="Linked test-spec object (alternative to protocol_id).")
     cell_instance_id: str | None = Field(default=None, description="IRI of the physical cell under test (authoring alias: cell_id=; required at save).")
-    cell: CellInstance | None = Field(default=None, exclude=True, repr=False, description="Linked cell-instance object (alternative to cell_instance_id; may also be passed positionally).")
+    cell: Cell | None = Field(default=None, exclude=True, repr=False, description="Linked cell-instance object (alternative to cell_instance_id; may also be passed positionally).")
     description: str | None = Field(default=None, description="Free-text description of this execution.")
     status: str | None = Field(default=None, description="Execution status (e.g. 'running', 'completed', 'aborted').")
     protocol: ProtocolInfo = Field(default_factory=ProtocolInfo, description="Name and optional URL of the protocol followed (authoring aliases: protocol_name=, protocol_url=).")
@@ -2288,7 +2288,7 @@ class Test(BundleJsonModel):
     source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, retrieved_at=, ...).")
     comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
 
-    def __init__(self, cell: CellInstance | None = None, /, **data: Any) -> None:
+    def __init__(self, cell: Cell | None = None, /, **data: Any) -> None:
         # Absorb the flat authoring/input shape (formerly TestInput).
         if "cell_id" in data and "cell_instance_id" not in data:
             data["cell_instance_id"] = data.pop("cell_id")
@@ -2515,7 +2515,7 @@ class Dataset(BundleJsonModel):
     related_cell_ids: list[str] = Field(default_factory=list, description="IRIs of additional related cells beyond the primary one.")
     related_test_ids: list[str] = Field(default_factory=list, description="IRIs of additional related tests beyond the primary one.")
     test: Test | None = Field(default=None, exclude=True, repr=False, description="Linked test object (alternative to test_id).")
-    cell: CellInstance | None = Field(default=None, exclude=True, repr=False, description="Linked cell-instance object (alternative to cell_instance_id).")
+    cell: Cell | None = Field(default=None, exclude=True, repr=False, description="Linked cell-instance object (alternative to cell_instance_id).")
     source: ProvenanceInfo = Field(default_factory=ProvenanceInfo, description="Provenance of this record (flat authoring aliases: source_type=, source_url=, retrieved_at=, curated_by=, ...).")
     comment: list[str] = Field(default_factory=list, description="Free-text notes on the record (authoring alias: notes=).")
 
@@ -2919,9 +2919,9 @@ class BattinfoBundle(BundleJsonModel):
 
     kind: str = "BattinfoBundle"
     bundle_name: str | None = None
-    cell_specification: CellSpecification | None = None
-    cell_spec: CellSpecification
-    cell_instance: CellInstance
+    cell_specification: CellSpec | None = None
+    cell_spec: CellSpec
+    cell_instance: Cell
     test: Test
     dataset: Dataset
     comment: list[str] = Field(default_factory=list)
@@ -2964,13 +2964,13 @@ class BattinfoBundle(BundleJsonModel):
         if isinstance(cell_specification_file, str):
             spec_path = root / cell_specification_file
             if spec_path.exists():
-                cell_specification = CellSpecification.from_path(spec_path)
+                cell_specification = CellSpec.from_path(spec_path)
         return cls(
             schema_version=str(manifest.get("schema_version", "1.0.0")),
             bundle_name=manifest.get("bundle_name"),
             cell_specification=cell_specification,
-            cell_spec=CellSpecification.from_path(root / str(manifest.get("cell_spec_file", CELL_SPEC_FILENAME))),
-            cell_instance=CellInstance.from_path(root / str(manifest.get("cell_instance_file", CELL_INSTANCE_FILENAME))),
+            cell_spec=CellSpec.from_path(root / str(manifest.get("cell_spec_file", CELL_SPEC_FILENAME))),
+            cell_instance=Cell.from_path(root / str(manifest.get("cell_instance_file", CELL_INSTANCE_FILENAME))),
             test=Test.from_path(root / str(manifest.get("test_file", TEST_FILENAME))),
             dataset=Dataset.from_path(root / str(manifest.get("dataset_file", DATASET_FILENAME))),
             comment=[str(item) for item in manifest.get("comment", [])] if isinstance(manifest.get("comment"), list) else [],
@@ -3118,7 +3118,7 @@ class BattinfoBundle(BundleJsonModel):
             if "PrismaticBattery" in subclass_ids or _node_has_type(cell_instance_node, "PrismaticBattery") or "PrismaticBattery" in is_desc_types
             else "unknown"
         )
-        cell_spec = CellSpecification(
+        cell_spec = CellSpec(
             id=str(cell_spec_node["@id"]),
             name=str(cell_spec_node.get("schema:name") or f"{manufacturer} {cell_spec_node.get('schema:model') or 'unknown'}"),
             manufacturer=str(manufacturer or "unknown"),
@@ -3158,7 +3158,7 @@ class BattinfoBundle(BundleJsonModel):
                 if isinstance(spec_manufacturer_obj, Mapping)
                 else spec_manufacturer_obj
             )
-            cell_specification = CellSpecification(
+            cell_specification = CellSpec(
                 id=str(cell_specification_node["@id"]),
                 manufacturer=str(spec_manufacturer or manufacturer or "unknown"),
                 model=str(cell_specification_node.get("schema:model") or cell_spec.model),
@@ -3181,7 +3181,7 @@ class BattinfoBundle(BundleJsonModel):
                     comment=source_obj.get("schema:description"),
                 ),
             )
-        cell_instance = CellInstance(
+        cell_instance = Cell(
             id=str(cell_instance_node["@id"]),
             name=str(cell_instance_node.get("schema:name") or cell_instance_node["@id"]),
             cell_spec_id=str(cell_spec_id or cell_spec.id),
@@ -3292,13 +3292,13 @@ class ZenodoDatasetEntry(BaseModel):
     """One test/dataset entry within a ZenodoCellRecord.
 
     cell_instances is empty when the contributing cells are not individually
-    tracked (aggregate records), or contains one or more CellInstance records
+    tracked (aggregate records), or contains one or more Cell records
     when per-cell provenance is available.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    cell_instances: list[CellInstance] = Field(default_factory=list)
+    cell_instances: list[Cell] = Field(default_factory=list)
     test: Test
     dataset: Dataset
 
@@ -3310,15 +3310,15 @@ class ZenodoCellRecord(BaseModel):
     Serialises to / from battinfo.bundle.json — the file that battery-genome's
     Zenodo harvester ingests.  One record covers one manufacturer × cell model
     and may contain multiple (test, dataset) entries, each optionally annotated
-    with one or more CellInstance records.
+    with one or more Cell records.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     schema_version: str = SCHEMA_VERSION
     kind: str = "BattinfoCellRecord"
-    cell_spec: CellSpecification
-    cell_specification: CellSpecification | None = None
+    cell_spec: CellSpec
+    cell_specification: CellSpec | None = None
     datasets: list[ZenodoDatasetEntry]
 
     def to_flat_json(self, *, zenodo_record_url: str | None = None) -> dict[str, Any]:
@@ -3369,12 +3369,12 @@ class ZenodoCellRecord(BaseModel):
         if not isinstance(datasets_raw, list):
             raise ValueError("ZenodoCellRecord must contain a 'datasets' list.")
 
-        cell_specification: CellSpecification | None = None
+        cell_specification: CellSpec | None = None
         spec_raw = data.get("cell_specification")
         if isinstance(spec_raw, Mapping):
-            cell_specification = CellSpecification.from_library_record(spec_raw)
+            cell_specification = CellSpec.from_library_record(spec_raw)
 
-        cell_spec = CellSpecification.from_record(
+        cell_spec = CellSpec.from_record(
             cell_spec_raw,
             cell_specification_id=cell_specification.id if cell_specification is not None else None,
         )
@@ -3393,7 +3393,7 @@ class ZenodoCellRecord(BaseModel):
             if not isinstance(ci_raws, list):
                 raise ValueError(f"datasets[{i}].cell_instances must be a list.")
             entries.append(ZenodoDatasetEntry(
-                cell_instances=[CellInstance.from_record(ci) for ci in ci_raws if isinstance(ci, Mapping)],
+                cell_instances=[Cell.from_record(ci) for ci in ci_raws if isinstance(ci, Mapping)],
                 test=Test.from_record(test_raw),
                 dataset=Dataset.from_record(ds_raw),
             ))
@@ -3415,7 +3415,7 @@ class ZenodoCellRecord(BaseModel):
         cls,
         bundles: list[BattinfoBundle],
         *,
-        cell_specification: CellSpecification | None = None,
+        cell_specification: CellSpec | None = None,
     ) -> "ZenodoCellRecord":
         """Build a ZenodoCellRecord from one or more single-dataset BattinfoBundles.
 
@@ -3441,8 +3441,8 @@ class ZenodoCellRecord(BaseModel):
         )
 
 
-def load_cell_specification(path: PathLike) -> CellSpecification:
-    return CellSpecification.from_path(path)
+def load_cell_specification(path: PathLike) -> CellSpec:
+    return CellSpec.from_path(path)
 
 
 TestProtocol = TestSpec  # backward compat alias
@@ -3456,9 +3456,9 @@ __all__ = [
     "CELL_SPECIFICATION_FILENAME",
     "CELL_SPEC_FILENAME",
     "Coating",
-    "CellInstance",
-    "CellSpecification",
-    "CellSpecification",
+    "Cell",
+    "CellSpec",
+    "CellSpec",
     "ChecksumInfo",
     "CurrentCollector",
     "DATASET_FILENAME",
@@ -3488,3 +3488,10 @@ __all__ = [
     "ZenodoCellRecord",
     "ZenodoDatasetEntry",
 ]
+
+
+# Pre-0.8 long-form names — plain aliases for direct bundle importers; the
+# package-level names warn via battinfo.__getattr__ and are swept per the
+# deprecation policy in CONTRIBUTING.md.
+CellSpecification = CellSpec
+CellInstance = Cell

--- a/src/battinfo/bundle_adapter.py
+++ b/src/battinfo/bundle_adapter.py
@@ -11,13 +11,13 @@ Public API
 ----------
 specs_to_specset(props)         dict[str, Any] → SpecSet
 specset_to_specs(ss)            SpecSet        → dict[str, Any]
-cell_spec_to_schema(ct)         CellSpecification       → generated CellSpecification
-cell_instance_to_schema(ci)     CellInstance   → generated CellInstance
+cell_spec_to_schema(ct)         CellSpec       → generated CellSpec
+cell_instance_to_schema(ci)     Cell   → generated Cell
 test_to_schema(t)               Test           → generated Test
 test_spec_to_schema(ts)         TestSpec       → generated TestSpec
 bundle_to_schema(obj)           any bundle obj → corresponding generated obj
 
-schema_cell_spec_to_record_dict(ct_gen) → record dict accepted by CellSpecification.from_record()
+schema_cell_spec_to_record_dict(ct_gen) → record dict accepted by CellSpec.from_record()
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:
-    from battinfo.bundle import CellInstance, CellSpecification, Test, TestSpec
+    from battinfo.bundle import Cell, CellSpec, Test, TestSpec
     from battinfo.bundle_generated import (
         CellInstance as GenCellInstance,
     )
@@ -132,8 +132,8 @@ def specset_to_specs(specset: "SpecSet | None") -> dict[str, Any]:
 # ── bundle.py → generated ─────────────────────────────────────────────────────
 
 
-def cell_spec_to_schema(ct: "CellSpecification") -> "GenCellSpecification":
-    """Convert a bundle.py CellSpecification to a generated CellSpecification with EMMO IRI annotations."""
+def cell_spec_to_schema(ct: "CellSpec") -> "GenCellSpecification":
+    """Convert a bundle.py CellSpec to a generated CellSpec with EMMO IRI annotations."""
     from battinfo.bundle_generated import (  # noqa: PLC0415
         CellSpecification as GenCellSpecification,
     )
@@ -159,8 +159,8 @@ def cell_spec_to_schema(ct: "CellSpecification") -> "GenCellSpecification":
     )
 
 
-def cell_instance_to_schema(ci: "CellInstance") -> "GenCellInstance":
-    """Convert a bundle.py CellInstance to a generated CellInstance."""
+def cell_instance_to_schema(ci: "Cell") -> "GenCellInstance":
+    """Convert a bundle.py Cell to a generated Cell."""
     from battinfo.bundle_generated import CellInstance as GenCellInstance  # noqa: PLC0415
     return GenCellInstance(
         ci_id=ci.id or "urn:staging:unknown",
@@ -232,14 +232,14 @@ def bundle_to_schema(obj: Any) -> Any:
     Raises TypeError for unknown types.
     """
     from battinfo.bundle import (  # noqa: PLC0415
-        CellInstance,
-        CellSpecification,
+        Cell,
+        CellSpec,
         Test,
         TestSpec,
     )
-    if isinstance(obj, CellSpecification):
+    if isinstance(obj, CellSpec):
         return cell_spec_to_schema(obj)
-    if isinstance(obj, CellInstance):
+    if isinstance(obj, Cell):
         return cell_instance_to_schema(obj)
     if isinstance(obj, Test):
         return test_to_schema(obj)
@@ -252,7 +252,7 @@ def bundle_to_schema(obj: Any) -> Any:
 
 
 def schema_cell_spec_to_record_dict(ct_gen: "GenCellSpecification") -> dict[str, Any]:
-    """Convert a generated CellSpecification to the record dict accepted by CellSpecification.from_record().
+    """Convert a generated CellSpec to the record dict accepted by CellSpec.from_record().
 
     Useful when reading JSON-LD output back into the application layer.
     """

--- a/src/battinfo/cli.py
+++ b/src/battinfo/cli.py
@@ -119,7 +119,7 @@ from battinfo.api import (
 from battinfo.api import (
     validate_staging_datasets as api_validate_staging_datasets,
 )
-from battinfo.bundle import SCHEMA_VERSION, CellInstance, CellSpecification, Dataset, Test, TestSpec
+from battinfo.bundle import SCHEMA_VERSION, Cell, CellSpec, Dataset, Test, TestSpec
 from battinfo.demo import run_demo_pipeline, setup_demo_environment
 from battinfo.entities import ENTITY_KINDS
 from battinfo.ingest import build_ingest_workspace, inspect_ingest_root, publish_ingest_workspace, write_ingest_manifest
@@ -265,11 +265,11 @@ def _render_notebook_recovery(payload: dict[str, Any]) -> None:
             typer.echo(f"- {path}")
 
 
-def _load_cell_spec_input(path: Path) -> CellSpecification:
+def _load_cell_spec_input(path: Path) -> CellSpec:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(payload.get("cell_spec"), dict):
-        return CellSpecification.from_record(payload)
-    return CellSpecification(**payload)
+        return CellSpec.from_record(payload)
+    return CellSpec(**payload)
 
 
 def _init_example_document(profile: str) -> dict[str, Any]:
@@ -1110,7 +1110,8 @@ def template_dataset(
     _emit_table([payload], ["status", "resource", "id", "path"])
 
 
-@template_app.command("test-protocol")
+@template_app.command("test-spec")
+@template_app.command("test-protocol", hidden=True)  # pre-0.8 name
 def template_test_spec(
     name: str = typer.Option("Example Test Protocol", help="Human-readable protocol name."),
     kind: str = typer.Option("other", help="Test kind."),
@@ -1611,7 +1612,8 @@ def query_datasets(
     _emit_table(rows, ["id", "title", "format", "license", "source_type", "access_url"])
 
 
-@query_app.command("test-protocol")
+@query_app.command("test-spec")
+@query_app.command("test-protocol", hidden=True)  # pre-0.8 name
 def query_test_specs(
     id: str | None = typer.Option(None, help="Filter by canonical test-protocol IRI."),
     kind: str | None = typer.Option(None, help="Filter by protocol kind."),
@@ -1877,7 +1879,7 @@ def save_cell_spec(
     policy_name = _check_validation_policy(validation_policy)
     try:
         if input_path is not None:
-            draft_obj: CellSpecification | dict[str, Any] | Path = input_path
+            draft_obj: CellSpec | dict[str, Any] | Path = input_path
         else:
             if not manufacturer or not model_name:
                 raise ValueError("--manufacturer and --model-name are required when --input is not provided.")
@@ -1887,7 +1889,7 @@ def save_cell_spec(
                 if not isinstance(loaded_specs, dict):
                     raise ValueError("--specs must point to a JSON object.")
                 specs = loaded_specs
-            draft_obj = CellSpecification(
+            draft_obj = CellSpec(
                 uid=uid,
                 model_name=model_name,
                 manufacturer=manufacturer,
@@ -1951,11 +1953,11 @@ def save_cell_instance(
     policy_name = _check_validation_policy(validation_policy)
     try:
         if input_path is not None:
-            draft_obj: CellInstance | dict[str, Any] | Path = input_path
+            draft_obj: Cell | dict[str, Any] | Path = input_path
         else:
             if not cell_spec_id:
                 raise ValueError("--cell-spec-id is required when --input is not provided.")
-            draft_obj = CellInstance(
+            draft_obj = Cell(
                 uid=uid,
                 cell_spec_id=cell_spec_id,
                 serial_number=serial_number,
@@ -2059,7 +2061,8 @@ def save_dataset(
     _emit_table([payload], ["status", "entity_type", "id", "path", "mode", "published"])
 
 
-@save_app.command("test-protocol")
+@save_app.command("test-spec")
+@save_app.command("test-protocol", hidden=True)  # pre-0.8 name
 def save_test_spec(
     input_path: Path | None = typer.Option(
         None, "--input", exists=True, file_okay=True, dir_okay=False, readable=True, help="Draft or canonical JSON."
@@ -2598,7 +2601,7 @@ def publish_cell_spec(
                 raise typer.BadParameter(
                     "Provide --input or all of --manufacturer, --model, --cell-format, and --chemistry."
                 )
-            cell_spec = CellSpecification(
+            cell_spec = CellSpec(
                 manufacturer=manufacturer.strip(),
                 model=model.strip(),
                 format=cell_format.strip(),

--- a/src/battinfo/contribution.py
+++ b/src/battinfo/contribution.py
@@ -1040,23 +1040,23 @@ def _test_kind_from_path(path: Path, subdir_name: str = "") -> str:
 
 
 def _load_cell_spec_for_batch(cell_spec_iri: str) -> tuple[Any, Any]:
-    """Return (CellSpecification, CellSpecification | None) for a cell-spec IRI.
+    """Return (CellSpec, CellSpec | None) for a cell-spec IRI.
 
     Searches the packaged library first, then the local workspace library.
-    Falls back to a minimal CellSpecification carrying only the IRI.
+    Falls back to a minimal CellSpec carrying only the IRI.
     """
     from battinfo.api import DEFAULT_LIBRARY_CELL_TYPES_DIR, query_library_cell_specs
-    from battinfo.bundle import CellSpecification
+    from battinfo.bundle import CellSpec
     from battinfo.publication import DEFAULT_CR2032_LIBRARY_SPEC
 
     packaged_lib = DEFAULT_CR2032_LIBRARY_SPEC.parent
     for directory in (packaged_lib, DEFAULT_LIBRARY_CELL_TYPES_DIR):
         results = query_library_cell_specs(id=cell_spec_iri, directory=directory)
         if results:
-            spec = CellSpecification.from_library_record(results[0]["record"])
-            ct = CellSpecification.from_cell_specification(spec, id=cell_spec_iri)
+            spec = CellSpec.from_library_record(results[0]["record"])
+            ct = CellSpec.from_cell_specification(spec, id=cell_spec_iri)
             return ct, spec
-    return CellSpecification(id=cell_spec_iri), None
+    return CellSpec(id=cell_spec_iri), None
 
 
 def package_batch(
@@ -1091,7 +1091,7 @@ def package_batch(
         ``cell_count``, ``entry_count``.
     """
     from battinfo.bundle import (
-        CellInstance,
+        Cell,
         Dataset,
         ProvenanceInfo,
         Test,
@@ -1141,7 +1141,7 @@ def package_batch(
             (cell_dir / CONTRIBUTION_MANIFEST).read_text(encoding="utf-8")
         ) or {}
 
-        raw_ci = CellInstance(
+        raw_ci = Cell(
             id=cell_manifest.get("cell_iri") or None,
             cell_spec_id=cell_spec.id,
             name=cell_manifest.get("cell_name"),

--- a/src/battinfo/interop/battery_data_commons.py
+++ b/src/battinfo/interop/battery_data_commons.py
@@ -43,7 +43,7 @@ from battinfo.api import (
     _validate_canonical_record,
     create_material_spec,
 )
-from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
+from battinfo.bundle import BatteryTestType, Cell, CellSpec, Dataset, Test
 from battinfo.interop._common import load_json_source
 
 PathLike = str | Path
@@ -239,7 +239,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     if source_meta.get("owner"):
         notes.append(f"dataset owner: {source_meta['owner']}")
 
-    cell_spec = _check(_record_from_cell_spec(CellSpecification(
+    cell_spec = _check(_record_from_cell_spec(CellSpec(
         uid=_uid("bdc", "cell-spec", bdc_id),
         model_name=_clean(overview.get("battery_model")) or bdc_id,
         manufacturer={"type": "Organization", "name": _clean(overview.get("manufacturer")) or "Unknown"},
@@ -257,7 +257,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
     )))
     cell_spec_id = cell_spec["cell_spec"]["id"]
 
-    cell_instance = _check(_record_from_cell_instance(CellInstance(
+    cell_instance = _check(_record_from_cell_instance(Cell(
         uid=_uid("bdc", "cell-instance", bdc_id),
         cell_spec_id=cell_spec_id,
         serial_number=bdc_id,

--- a/src/battinfo/interop/bpx.py
+++ b/src/battinfo/interop/bpx.py
@@ -471,7 +471,7 @@ def to_bpx(
     ----------
     source:
         A BattINFO cell-spec record dict (``{"cell_spec": ..., "properties":
-        ...}``), a :class:`~battinfo.bundle.CellSpecification` (anything exposing
+        ...}``), a :class:`~battinfo.bundle.CellSpec` (anything exposing
         ``to_record()``), or a bare properties mapping.
     cell_instance:
         Optional cell-instance record or object; its serial number / id is
@@ -609,7 +609,7 @@ def _coerce_cell_spec(source: Any) -> tuple[dict[str, Any], dict[str, Any]]:
         # A bare properties mapping (key → {value, unit}).
         return {}, dict(source)
     raise TypeError(
-        "to_bpx expects a cell-spec record dict, a CellSpecification-like object with "
+        "to_bpx expects a cell-spec record dict, a CellSpec-like object with "
         f"to_record(), or a properties mapping; got {type(source).__name__}."
     )
 

--- a/src/battinfo/interop/converter.py
+++ b/src/battinfo/interop/converter.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
-from battinfo.bundle import SCHEMA_VERSION, CellInstance, CellSpecification, ProvenanceInfo, Test, TestSpec
+from battinfo.bundle import SCHEMA_VERSION, Cell, CellSpec, ProvenanceInfo, Test, TestSpec
 from battinfo.interop._common import load_json_source
 from battinfo.interop.protocols import _num
 
@@ -140,7 +140,7 @@ PROPERTY_TYPE_MAP = {
 
 @dataclass(slots=True)
 class ConverterImportResult:
-    specification: CellSpecification
+    specification: CellSpec
     record: dict[str, Any]
     warnings: list[str]
     test_specs: list[dict[str, Any]] = field(default_factory=list)
@@ -149,9 +149,9 @@ class ConverterImportResult:
 
 @dataclass(slots=True)
 class ConverterImportPackage:
-    specification: CellSpecification
-    cell_spec: CellSpecification
-    cell_instance: CellInstance | None
+    specification: CellSpec
+    cell_spec: CellSpec
+    cell_instance: Cell | None
     test_specs: list[TestSpec] = field(default_factory=list)
     tests: list[Test] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
@@ -364,7 +364,7 @@ def import_converter_jsonld_record(
             fragments.append(f"coin-schema={converter_schema_version}")
         source_comment = f"{source_comment} {'; '.join(fragments)}"
 
-    specification = CellSpecification(
+    specification = CellSpec(
         schema_version=schema_version,
         id=spec_id,
         manufacturer=imported_manufacturer,
@@ -412,7 +412,7 @@ def import_converter_jsonld_record(
         warnings=warnings,
     )
 
-    result_specification = CellSpecification.from_library_record(record)
+    result_specification = CellSpec.from_library_record(record)
     if validate:
         # Match the other interop importers: schema-validate the emitted cell-spec so a malformed
         # import fails loudly here, not silently downstream. `to_record()` is the canonical
@@ -451,19 +451,19 @@ def import_converter_package(
         validate=validate,
     )
     specification = imported.specification
-    cell_spec = CellSpecification.from_cell_specification(specification)
+    cell_spec = CellSpec.from_cell_specification(specification)
     if cell_spec.source.type not in {"datasheet", "label", "catalog", "manual", "other"}:
         cell_spec.source.type = "other"
         existing = list(cell_spec.comment)
         existing.append("Source type normalized from converter-jsonld during converter package import.")
         cell_spec.comment = existing
 
-    cell_instance: CellInstance | None = None
+    cell_instance: Cell | None = None
     instances = imported.record.get("instances")
     if isinstance(instances, list) and instances:
         first = instances[0]
         if isinstance(first, Mapping):
-            cell_instance = CellInstance(
+            cell_instance = Cell(
                 schema_version=schema_version,
                 id=first.get("id"),
                 name=first.get("name"),

--- a/src/battinfo/interop/discovery.py
+++ b/src/battinfo/interop/discovery.py
@@ -51,7 +51,7 @@ from battinfo.api import (
     create_component_spec,
     create_material_spec,
 )
-from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Dataset, Test
+from battinfo.bundle import BatteryTestType, Cell, CellSpec, Dataset, Test
 from battinfo.interop._common import load_json_source
 from battinfo.interop.protocols import _num
 
@@ -291,7 +291,7 @@ class _Builder:
                  test_name: str | None = None, test_description: str | None = None,
                  dataset_file: str | None = None) -> DiscoveryCell:
         seed = refcode or cell_id
-        cell_spec = self._check(_record_from_cell_spec(CellSpecification(
+        cell_spec = self._check(_record_from_cell_spec(CellSpec(
             uid=_uid("discovery", "cell-spec", seed),
             model_name=model_name,
             manufacturer={"type": "Organization", "name": manufacturer},
@@ -309,7 +309,7 @@ class _Builder:
         )))
         cell_spec_id = cell_spec["cell_spec"]["id"]
 
-        cell_instance = self._check(_record_from_cell_instance(CellInstance(
+        cell_instance = self._check(_record_from_cell_instance(Cell(
             uid=_uid("discovery", "cell-instance", seed),
             cell_spec_id=cell_spec_id,
             serial_number=cell_id,

--- a/src/battinfo/interop/solid_state_db.py
+++ b/src/battinfo/interop/solid_state_db.py
@@ -49,7 +49,7 @@ from battinfo.api import (
     _record_from_test,
     _validate_canonical_record,
 )
-from battinfo.bundle import BatteryTestType, CellInstance, CellSpecification, Test
+from battinfo.bundle import BatteryTestType, Cell, CellSpec, Test
 
 PathLike = str | Path
 
@@ -277,7 +277,7 @@ def from_solid_state_db_row(
         notes.append(f"reported in {journal} ({_clean(row.get('Publication_date')) or 'n.d.'})")
 
     cell_uid = _uid_from_seed(seed, "cell-spec")
-    cell_spec = _record_from_cell_spec(CellSpecification(
+    cell_spec = _record_from_cell_spec(CellSpec(
         uid=cell_uid,
         model_name=model_name,
         manufacturer={"type": "Organization", "name": manufacturer},
@@ -292,7 +292,7 @@ def from_solid_state_db_row(
     ))
     cell_spec_id = cell_spec["cell_spec"]["id"]
 
-    cell_instance = _record_from_cell_instance(CellInstance(
+    cell_instance = _record_from_cell_instance(Cell(
         uid=_uid_from_seed(seed, "cell-instance"),
         cell_spec_id=cell_spec_id,
         source_type="lab",

--- a/src/battinfo/jsonld.py
+++ b/src/battinfo/jsonld.py
@@ -300,7 +300,7 @@ def cell_instance_to_jsonld(record: dict) -> dict:
 
     node: dict = {
         "@context": _CONTEXT_INLINE,
-        "@type":    "https://w3id.org/battinfo/CellInstance",
+        "@type":    "https://w3id.org/battinfo/Cell",
         "@id":      ci.get("id", ""),
         "schema:serialNumber": ci.get("serial_number"),
     }

--- a/src/battinfo/local_workspace.py
+++ b/src/battinfo/local_workspace.py
@@ -15,8 +15,8 @@ from battinfo._jsonio import write_json as _write_json
 from battinfo._workspace import Workspace
 from battinfo.bundle import (
     BattinfoBundle,
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     ChecksumInfo,
     Dataset,
     ProtocolInfo,
@@ -560,8 +560,8 @@ class LocalWorkspace:
 
     def capture(
         self,
-        cell_design: CellSpecification,
-        cell: CellInstance,
+        cell_design: CellSpec,
+        cell: Cell,
         test: Test,
         dataset: Dataset,
         *,
@@ -641,8 +641,8 @@ class LocalWorkspace:
         title: str,
         registry: RegistryTarget | Mapping[str, Any],
         publisher_id: str | None = None,
-        cell_design: CellSpecification,
-        cell: CellInstance,
+        cell_design: CellSpec,
+        cell: Cell,
         test: Test,
         dataset: Dataset,
         description: str | None = None,
@@ -834,7 +834,7 @@ class LocalWorkspace:
         dataset_path = None
         if distribution.path is not None:
             dataset_path = str((self.root / distribution.path).resolve())
-        cell_design = CellSpecification(
+        cell_design = CellSpec(
             id=cell_doc.cell_spec.id,
             manufacturer=cell_doc.cell_spec.manufacturer,
             model=cell_doc.cell_spec.model,
@@ -848,7 +848,7 @@ class LocalWorkspace:
             source=cell_doc.cell_spec.provenance.model_copy(deep=True),
             comment=list(cell_doc.cell_spec.comment),
         )
-        cell = CellInstance(
+        cell = Cell(
             id=cell_doc.cell.id,
             name=cell_doc.cell.name,
             cell_spec=cell_design,
@@ -977,8 +977,8 @@ class LocalWorkspace:
             raise ValueError("Submission bundle must include a cell_spec record, either as a resource or nested in the cell resource.")
         return BattinfoBundle(
             bundle_name=bundle_name,
-            cell_spec=CellSpecification.from_record(dict(cell_spec_record)),
-            cell_instance=CellInstance.from_record(cell_payload["cell"]),
+            cell_spec=CellSpec.from_record(dict(cell_spec_record)),
+            cell_instance=Cell.from_record(cell_payload["cell"]),
             test=Test.from_record(test_payload["test"]),
             dataset=Dataset.from_record(dataset_payload["dataset"]),
         )
@@ -1249,7 +1249,7 @@ class LocalWorkspace:
             if checksum_algorithm == "sha256":
                 checksum_value = _sha256(distribution_path)
 
-        cell_spec = CellSpecification(
+        cell_spec = CellSpec(
             id=cell_doc.cell_spec.id,
             manufacturer=cell_doc.cell_spec.manufacturer,
             model=cell_doc.cell_spec.model,
@@ -1263,7 +1263,7 @@ class LocalWorkspace:
             source=cell_doc.cell_spec.provenance.model_copy(deep=True),
             comment=list(cell_doc.cell_spec.comment),
         )
-        cell = CellInstance(
+        cell = Cell(
             id=cell_doc.cell.id,
             name=cell_doc.cell.name,
             cell_spec=cell_spec,

--- a/src/battinfo/publication.py
+++ b/src/battinfo/publication.py
@@ -19,8 +19,8 @@ from battinfo._jsonio import write_json as _write_json
 from battinfo.bundle import (
     ZENODO_CELL_RECORD_FILENAME,
     BattinfoBundle,
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     Dataset,
     ProtocolInfo,
     ProvenanceInfo,
@@ -1182,7 +1182,7 @@ def _test_jsonld_node(test_record: Mapping[str, Any], dataset_id: str) -> dict[s
     return _without_none(node)
 
 
-def _cell_instance_summary_node(cell_instance_record: Mapping[str, Any], label: str, cell_spec: CellSpecification) -> dict[str, Any]:
+def _cell_instance_summary_node(cell_instance_record: Mapping[str, Any], label: str, cell_spec: CellSpec) -> dict[str, Any]:
     inst = cell_instance_record["cell_instance"]
     type_list = ["BatteryCell", "schema:IndividualProduct"]
     subclass_term = CELL_SUBCLASS_MAP.get(cell_spec.format)
@@ -1265,7 +1265,7 @@ def _cell_spec_property_node(name: str, quantity: Any) -> dict[str, Any] | None:
     return node
 
 
-def _cell_spec_jsonld_node(cell_spec: CellSpecification, *, cell_specification: CellSpecification | None = None) -> dict[str, Any]:
+def _cell_spec_jsonld_node(cell_spec: CellSpec, *, cell_specification: CellSpec | None = None) -> dict[str, Any]:
     physical_types: list[str] = ["BatteryCell"]
     subclass_term = CELL_SUBCLASS_MAP.get(cell_spec.format)
     if subclass_term is not None:
@@ -1314,7 +1314,7 @@ def _cell_spec_jsonld_node(cell_spec: CellSpecification, *, cell_specification: 
     return _without_none(node)
 
 
-def _cell_specification_jsonld_node(cell_specification: CellSpecification, *, cell_spec: CellSpecification) -> dict[str, Any]:
+def _cell_specification_jsonld_node(cell_specification: CellSpec, *, cell_spec: CellSpec) -> dict[str, Any]:
     descriptions = list(cell_specification.specification_comment) + [
         comment for comment in cell_specification.comment if comment not in cell_specification.specification_comment
     ]
@@ -1355,8 +1355,8 @@ def _cell_specification_jsonld_node(cell_specification: CellSpecification, *, ce
 
 def _publication_graph(
     *,
-    cell_spec: CellSpecification,
-    cell_specification: CellSpecification | None,
+    cell_spec: CellSpec,
+    cell_specification: CellSpec | None,
     cell_instance_record: dict[str, Any],
     test_record: dict[str, Any],
     dataset_record: dict[str, Any],
@@ -1499,11 +1499,11 @@ def _publication_graph(
 
 
 def _normalize_cell_specification(
-    source: CellSpecification | Mapping[str, Any] | PathLike,
+    source: CellSpec | Mapping[str, Any] | PathLike,
     *,
     datasheet_path: Path | None = None,
-) -> CellSpecification:
-    if isinstance(source, CellSpecification):
+) -> CellSpec:
+    if isinstance(source, CellSpec):
         spec = source.model_copy(deep=True)
     else:
         payload = _load_json(_as_path(source)) if isinstance(source, (str, Path)) else dict(source)
@@ -1511,12 +1511,12 @@ def _normalize_cell_specification(
             result = validate_json(payload, profile="cell-spec")
             if not result.ok:
                 raise ValueError(f"cell specification validation failed: {'; '.join(result.errors)}")
-            spec = CellSpecification.from_library_record(payload)
+            spec = CellSpec.from_library_record(payload)
         elif isinstance(payload.get("specification"), Mapping):
             # Internal specification-format record — bypass cell-spec schema validation.
-            spec = CellSpecification.from_library_record(payload)
+            spec = CellSpec.from_library_record(payload)
         else:
-            spec = CellSpecification.from_json(payload)
+            spec = CellSpec.from_json(payload)
     if datasheet_path is not None:
         spec.source = spec.source.model_copy(
             update={
@@ -1531,17 +1531,17 @@ def _normalize_cell_specification(
     return spec
 
 
-def _normalize_cell_spec(source: CellSpecification | Mapping[str, Any] | PathLike) -> CellSpecification:
-    if isinstance(source, CellSpecification):
+def _normalize_cell_spec(source: CellSpec | Mapping[str, Any] | PathLike) -> CellSpec:
+    if isinstance(source, CellSpec):
         return source.model_copy(deep=True)
     payload = _load_json(_as_path(source)) if isinstance(source, (str, Path)) else dict(source)
     if isinstance(payload.get("cell_spec"), Mapping):
-        return CellSpecification.from_record(payload)
-    return CellSpecification.from_json(payload)
+        return CellSpec.from_record(payload)
+    return CellSpec.from_json(payload)
 
 
-def _build_cell_spec_from_specification(cell_specification: CellSpecification) -> CellSpecification:
-    return CellSpecification(
+def _build_cell_spec_from_specification(cell_specification: CellSpec) -> CellSpec:
+    return CellSpec(
         id=_cell_spec_iri(cell_specification.id),
         name=f"{cell_specification.manufacturer} {cell_specification.model}",
         manufacturer=cell_specification.manufacturer,
@@ -1563,15 +1563,15 @@ def _build_cell_spec_from_specification(cell_specification: CellSpecification) -
             workflow_version=cell_specification.source.workflow_version,
             comment=cell_specification.source.comment,
         ),
-        comment=["Generated from the linked CellSpecification for publication packaging."],
+        comment=["Generated from the linked CellSpec for publication packaging."],
     )
 
 
 def derive_cell_spec(
-    source: CellSpecification | Mapping[str, Any] | PathLike,
+    source: CellSpec | Mapping[str, Any] | PathLike,
     *,
     datasheet_path: PathLike | None = None,
-) -> CellSpecification:
+) -> CellSpec:
     datasheet = _as_path(datasheet_path) if datasheet_path is not None else None
     normalized = _normalize_cell_specification(source, datasheet_path=datasheet)
     return _finalize_cell_spec(
@@ -1581,10 +1581,10 @@ def derive_cell_spec(
 
 
 def _finalize_cell_spec(
-    cell_spec: CellSpecification,
+    cell_spec: CellSpec,
     *,
-    cell_specification: CellSpecification | None = None,
-) -> CellSpecification:
+    cell_specification: CellSpec | None = None,
+) -> CellSpec:
     finalized = cell_spec.model_copy(deep=True)
     if finalized.id is None:
         finalized.id = (
@@ -1613,12 +1613,12 @@ def _finalize_cell_spec(
 
 
 def _finalize_cell_instance(
-    cell_instance: CellInstance,
+    cell_instance: Cell,
     *,
-    cell_spec: CellSpecification,
+    cell_spec: CellSpec,
     dataset_dir: Path,
     dataset_id: str | None = None,
-) -> CellInstance:
+) -> Cell:
     finalized = cell_instance.model_copy(deep=True, update={"cell_spec": None})
     if finalized.cell_spec_id is None:
         finalized.cell_spec_id = cell_spec.id
@@ -1651,7 +1651,7 @@ def _finalize_cell_instance(
 def _finalize_test(
     test: Test,
     *,
-    cell_instance: CellInstance,
+    cell_instance: Cell,
     dataset_dir: Path,
     dataset_id: str | None = None,
 ) -> Test:
@@ -1688,7 +1688,7 @@ def _finalize_test(
 def _finalize_dataset(
     dataset: Dataset,
     *,
-    cell_instance: CellInstance,
+    cell_instance: Cell,
     test: Test,
     dataset_dir: Path,
 ) -> Dataset:
@@ -1729,11 +1729,11 @@ def _finalize_dataset(
 
 def _finalize_publication_bundle(
     *,
-    cell_spec: CellSpecification,
-    cell_instance: CellInstance,
+    cell_spec: CellSpec,
+    cell_instance: Cell,
     test: Test,
     dataset: Dataset,
-    cell_specification: CellSpecification | None = None,
+    cell_specification: CellSpec | None = None,
 ) -> tuple[BattinfoBundle, Path]:
     dataset_dir = _resolve_dataset_dir(dataset)
     finalized_cell_spec = _finalize_cell_spec(cell_spec, cell_specification=cell_specification)
@@ -1772,11 +1772,11 @@ def _finalize_publication_bundle(
 
 def publish(
     *,
-    cell_spec: CellSpecification,
-    cell_instance: CellInstance,
+    cell_spec: CellSpec,
+    cell_instance: Cell,
     test: Test,
     dataset: Dataset,
-    cell_specification: CellSpecification | Mapping[str, Any] | PathLike | None = None,
+    cell_specification: CellSpec | Mapping[str, Any] | PathLike | None = None,
     datasheet_path: PathLike | None = None,
     publish_filename: str = DEFAULT_PUBLISH_FILENAME,
     html_filename: str = "index.html",
@@ -1898,11 +1898,11 @@ def publish(
 
 def build_publication_package(
     *,
-    cell_spec: CellSpecification,
-    cell_instance: CellInstance,
+    cell_spec: CellSpec,
+    cell_instance: Cell,
     test: Test,
     dataset: Dataset,
-    cell_specification: CellSpecification | Mapping[str, Any] | PathLike | None = None,
+    cell_specification: CellSpec | Mapping[str, Any] | PathLike | None = None,
     datasheet_path: PathLike | None = None,
     publish_filename: str = DEFAULT_PUBLISH_FILENAME,
     html_filename: str = "index.html",
@@ -1945,8 +1945,8 @@ def publish_dataset_metadata(
     *,
     dataset_dirs: list[PathLike],
     staging_root: PathLike,
-    cell_spec: CellSpecification | Mapping[str, Any] | PathLike | None = None,
-    cell_specification: CellSpecification | Mapping[str, Any] | PathLike | None = None,
+    cell_spec: CellSpec | Mapping[str, Any] | PathLike | None = None,
+    cell_specification: CellSpec | Mapping[str, Any] | PathLike | None = None,
     datasheet_path: PathLike | None = None,
     test_kind: str = "other",
     protocol_name: str | None = None,
@@ -2032,7 +2032,7 @@ def publish_dataset_metadata(
 
         retrieved_at = _now_unix()
         source = ProvenanceInfo(type="measurement", url=dataset_dir.resolve().as_uri(), retrieved_at=retrieved_at)
-        cell_instance = CellInstance(
+        cell_instance = Cell(
             name=instance_name,
             cell_spec=normalized_cell_spec,
             serial_number=serial_number,

--- a/src/battinfo/workspace_state.py
+++ b/src/battinfo/workspace_state.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from battinfo._jsonio import read_json as _read_json
 from battinfo._jsonio import write_json as _write_json
 from battinfo._workspace import Workspace
-from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test
+from battinfo.bundle import Cell, CellSpec, Dataset, Test
 from battinfo.local_workspace import (
     BattinfoSubmission,
     SubmissionDistribution,
@@ -26,7 +26,7 @@ from battinfo.local_workspace import (
 from battinfo.validate.record import validate_record
 
 PathLike = str | Path
-WorkspaceTarget = CellSpecification | CellInstance | Test | Dataset
+WorkspaceTarget = CellSpec | Cell | Test | Dataset
 WORKSPACE_STATE_SCHEMA_VERSION = "0.1.0"
 WORKSPACE_STATE_FILENAME = "battinfo-authoring-workspace.json"
 
@@ -211,11 +211,11 @@ class WorkspaceStateStore:
         return self.workspace.root
 
     @property
-    def cell_specs(self) -> list[CellSpecification]:
+    def cell_specs(self) -> list[CellSpec]:
         return self.workspace.cell_specs
 
     @property
-    def cells(self) -> list[CellInstance]:
+    def cells(self) -> list[Cell]:
         return self.workspace.cells
 
     @property
@@ -227,20 +227,20 @@ class WorkspaceStateStore:
         return self.workspace.datasets
 
     @property
-    def descriptions(self) -> list[CellSpecification]:
+    def descriptions(self) -> list[CellSpec]:
         return self.workspace.descriptions
 
     def add(self, *objects: Any) -> "WorkspaceStateStore":
         self.workspace.add(*objects)
         return self
 
-    def describe_cell(self, **kwargs: Any) -> CellSpecification:
+    def describe_cell(self, **kwargs: Any) -> CellSpec:
         return self.workspace.describe_cell(**kwargs)
 
-    def cell_spec(self, **kwargs: Any) -> CellSpecification:
+    def cell_spec(self, **kwargs: Any) -> CellSpec:
         return self.workspace.cell_spec(**kwargs)
 
-    def cell(self, *args: Any, **kwargs: Any) -> CellInstance:
+    def cell(self, *args: Any, **kwargs: Any) -> Cell:
         return self.workspace.cell(*args, **kwargs)
 
     def test(self, *args: Any, **kwargs: Any) -> Test:
@@ -513,13 +513,13 @@ class WorkspaceStateStore:
         dataset_records = cls._load_records(root_path / paths.datasets)
         artifact_map = {entry.dataset_id: root_path / entry.path for entry in manifest.dataset_artifacts}
 
-        cell_specs = [CellSpecification.from_record(record) for record in cell_spec_records]
+        cell_specs = [CellSpec.from_record(record) for record in cell_spec_records]
         cell_spec_by_id = {item.id: item for item in cell_specs if item.id is not None}
 
-        cells: list[CellInstance] = []
-        cell_by_id: dict[str, CellInstance] = {}
+        cells: list[Cell] = []
+        cell_by_id: dict[str, Cell] = {}
         for record in cell_records:
-            cell = CellInstance.from_record(record)
+            cell = Cell.from_record(record)
             if cell.cell_spec_id is not None:
                 cell.cell_spec = cell_spec_by_id.get(cell.cell_spec_id)
             cells.append(cell)
@@ -782,7 +782,7 @@ class WorkspaceStateStore:
             source_local_id=self._source_local_id("cell_spec", record),
             title=self._cell_spec_title(record),
             semantic_payload={
-                "@type": "CellSpecification",
+                "@type": "CellSpec",
                 "battinfo_records": {"cell_spec": record},
             },
         )
@@ -964,10 +964,10 @@ class WorkspaceStateStore:
         cell_local_ids: dict[str, str],
         test_local_ids: dict[str, str],
     ) -> SubmissionResource:
-        if isinstance(target, CellSpecification):
+        if isinstance(target, CellSpec):
             record = self._find_record("cell_specs", target.id, cell_spec_by_id.values())
             return self._cell_spec_resource(record)
-        if isinstance(target, CellInstance):
+        if isinstance(target, Cell):
             record = self._find_record("cells", target.id, cell_records)
             return self._cell_resource(record, cell_spec_by_id)
         if isinstance(target, Test):
@@ -976,7 +976,7 @@ class WorkspaceStateStore:
         if isinstance(target, Dataset):
             record = self._find_record("dataset", target.id, dataset_records)
             return self._dataset_resource(record, artifact_map, cell_titles, test_titles, cell_local_ids, test_local_ids)
-        raise TypeError("Workspace.bundle_workspace() target must be a CellSpecification, CellInstance, Test, or Dataset.")
+        raise TypeError("Workspace.bundle_workspace() target must be a CellSpec, Cell, Test, or Dataset.")
 
     def _resource_artifacts(
         self,

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -948,7 +948,7 @@ class AuthoringWorkspace:
         # identity into every other workspace in the process); _credential()
         # consults this first, then the environment.
         self._session_credentials: dict[str, str] = {}
-        # name -> CellInstance, keyed by short_id for test matching
+        # name -> Cell, keyed by short_id for test matching
         self._cells_by_short_id: dict[str, Any] = {}
         # in-memory search cache; populated lazily from registry API or local index
         self._search_cache: list[dict] | None = None
@@ -1968,7 +1968,7 @@ class AuthoringWorkspace:
             ws.add("test", type="capacity_check", cell="FAC-001",
                    data="data/FAC-001.csv", instrument="Maccor 4200")
 
-        ``cell`` accepts a serial, IRI, ``CellInstance``, or search result, and is
+        ``cell`` accepts a serial, IRI, ``Cell``, or search result, and is
         resolved in this session, locally, then in the registry (referenced if it
         already exists).  ``data`` is a path or list of paths.  ``type`` is the test
         type (``"cycling"``, ``"capacity_check"``, …); ``kind`` is accepted as an alias.
@@ -2267,7 +2267,7 @@ class AuthoringWorkspace:
             ws.save()
             ws.submit()
         """
-        from battinfo.bundle import CellInstance
+        from battinfo.bundle import Cell
 
         ci_dir = self._records_root / "examples" / "cell-instance"
         if not ci_dir.exists():
@@ -2279,7 +2279,7 @@ class AuthoringWorkspace:
             try:
                 raw = json.loads(src.read_text(encoding="utf-8"))
                 ci = raw.get("cell_instance", {})
-                cell = CellInstance(
+                cell = Cell(
                     id=ci.get("id"),
                     cell_spec_id=ci.get("cell_spec_id"),
                     name=ci.get("name"),
@@ -2509,11 +2509,11 @@ class AuthoringWorkspace:
                 dataset_node = node
 
         # ── 5. Import cell specs ───────────────────────────────────────────────
-        spec_objects: dict[str, Any] = {}   # IRI → CellSpecification
+        spec_objects: dict[str, Any] = {}   # IRI → CellSpec
         for iri, node in sorted(spec_nodes_by_iri.items()):
             # Skip typed stubs for externally-defined specs (no descriptive body):
             # they only assert @type + a pointer to where the real spec lives, so
-            # there is nothing to reconstruct a CellSpecification from — and doing so would
+            # there is nothing to reconstruct a CellSpec from — and doing so would
             # mint an empty spec that shadows the authoritative remote one.
             if not node.get("hasProperty") and not node.get("isDescriptionFor"):
                 continue
@@ -4652,9 +4652,9 @@ class AuthoringWorkspace:
         # NOT across runs (those are distinct measurements on different cells).
         #
         # Provenance chain: Distribution ──wasGeneratedBy──> BatteryTest (processed)
-        #                   BatteryTest  ──hasTestObject──>  CellInstance
+        #                   BatteryTest  ──hasTestObject──>  Cell
         #                   BatteryTest  ──prov:used──>      TestSpec (plan)
-        #                   CellInstance ──hasDescription──> CellSpec
+        #                   Cell ──hasDescription──> CellSpec
         # A "raw"-role distribution is the test's INPUT (prov:used), not output, so
         # it is not tagged wasGeneratedBy; it carries a description for provenance.
         dataset_member_nodes: list[dict] = []
@@ -5593,8 +5593,8 @@ class AuthoringWorkspace:
         The cell is added to the matching index but NOT to the save set, so it is
         never re-saved or re-submitted — downstream tests just record its IRI.
         """
-        from battinfo.bundle import CellInstance  # noqa: PLC0415
-        cell = CellInstance(
+        from battinfo.bundle import Cell  # noqa: PLC0415
+        cell = Cell(
             id=result.get("id"),
             cell_spec_id=result.get("cell_spec_id"),
             name=result.get("name"),
@@ -5610,15 +5610,15 @@ class AuthoringWorkspace:
         return cell
 
     def _reference_spec(self, result: dict) -> Any:
-        """Build a referenced CellSpecification reusing its existing IRI (NOT queued to publish)."""
-        from battinfo.bundle import CellSpecification, ProvenanceInfo  # noqa: PLC0415
+        """Build a referenced CellSpec reusing its existing IRI (NOT queued to publish)."""
+        from battinfo.bundle import CellSpec, ProvenanceInfo  # noqa: PLC0415
         record = self._fetch_cell_spec_record(result) if result.get("source") == "api" else result.get("_record", {})
         product = record.get("cell_spec", {}) or {}
         specs_raw = record.get("properties", {}) or {}
         specs = {k: v for k, v in specs_raw.items() if isinstance(v, dict) and v.get("value") is not None}
         mfr = product.get("manufacturer") or {}
         mfr_name = mfr.get("name", "") if isinstance(mfr, dict) else str(mfr)
-        ct = CellSpecification(
+        ct = CellSpec(
             manufacturer=mfr_name or result.get("manufacturer", ""),
             model=product.get("model", "") or result.get("model", ""),
             format=product.get("cell_format") or product.get("format") or "",
@@ -5651,7 +5651,7 @@ class AuthoringWorkspace:
         return (payload.get("battinfo_records") or {}).get("cell_spec") or payload
 
     def _coerce_cell_spec_arg(self, spec: Any) -> Any:
-        """Accept a ``ws.search()`` hit, a ``CellSpecification``, or an authoring dict for ``spec=``.
+        """Accept a ``ws.search()`` hit, a ``CellSpec``, or an authoring dict for ``spec=``.
 
         Search hits carry index metadata (``_canonical_id``, ``type``, ``source``),
         not authoring fields — feeding one straight into the model trips the
@@ -5659,13 +5659,13 @@ class AuthoringWorkspace:
         existing IRI, never re-published); pass everything else to the model,
         whose validation errors teach.
         """
-        from battinfo.bundle import CellSpecification  # noqa: PLC0415
+        from battinfo.bundle import CellSpec  # noqa: PLC0415
 
         if isinstance(spec, dict):
             if "_canonical_id" in spec or "type" in spec:
                 return self._reference_spec(dict(spec))
-            spec = CellSpecification(**spec)  # authoring dict — model errors teach
-        if isinstance(spec, CellSpecification):
+            spec = CellSpec(**spec)  # authoring dict — model errors teach
+        if isinstance(spec, CellSpec):
             # A NEW spec (no id yet) must join the save set, or the instances
             # would reference a spec that never gets saved and fail at save
             # time with an obscure error. IRI is minted at ws.save().
@@ -5674,7 +5674,7 @@ class AuthoringWorkspace:
             return spec
         if isinstance(spec, str):
             raise TypeError(
-                f"spec= takes a ws.search() hit or a battinfo.CellSpecification, not the string {spec!r}. "
+                f"spec= takes a ws.search() hit or a battinfo.CellSpec, not the string {spec!r}. "
                 f"Try: spec = ws.search({spec!r})[0]"
             )
         return spec
@@ -5977,11 +5977,11 @@ class AuthoringWorkspace:
     def _resolve_cell(self, ref: Any) -> Any:
         """Resolve a cell reference: this session, then local index, then the registry.
 
-        Accepts a ``CellInstance``, a search result, a serial / short ID, or an IRI.
+        Accepts a ``Cell``, a search result, a serial / short ID, or an IRI.
         An instance found only in the registry is referenced (not re-published).
         """
-        from battinfo.bundle import CellInstance  # noqa: PLC0415
-        if isinstance(ref, CellInstance):
+        from battinfo.bundle import Cell  # noqa: PLC0415
+        if isinstance(ref, Cell):
             return ref
         if isinstance(ref, dict):  # a search result
             return self.load(ref)
@@ -6001,7 +6001,7 @@ class AuthoringWorkspace:
                 f"Could not resolve cell {ref!r} in this session, locally, or the registry. "
                 "Create it with ws.add('cell', ...), or check the serial."
             )
-        raise TypeError("cell= must be a serial, IRI, CellInstance, or search result.")
+        raise TypeError("cell= must be a serial, IRI, Cell, or search result.")
 
     def _add_tests_by_filename(
         self,
@@ -6221,7 +6221,7 @@ def _cell_spec_submission_payload(
             "source_local_id": source_local_id,
             "title": title,
             "semantic_payload": {
-                "@type": "CellSpecification",
+                "@type": "CellSpec",
                 "battinfo_records": {"cell_spec": record},
             },
             "related_resources": related_resources or [],
@@ -6272,7 +6272,7 @@ def _cell_instance_submission_payload(
             })
 
     semantic_payload: dict = {
-        "@type": "CellInstance",
+        "@type": "Cell",
         "battinfo_records": {
             "cell": record,
             **({"cell_spec": spec_record} if spec_record else {}),

--- a/tests/installed_smoke.py
+++ b/tests/installed_smoke.py
@@ -38,14 +38,14 @@ def main() -> None:
         raw_file.parent.mkdir(parents=True, exist_ok=True)
         raw_file.write_text("time,voltage\n0,3.0\n", encoding="utf-8")
 
-        cell_spec = battinfo.CellSpecification(
+        cell_spec = battinfo.CellSpec(
             manufacturer="Energizer",
             model="CR2032",
             format="coin",
             chemistry="Li-primary",
             size_code="R2032",
         )
-        cell = battinfo.CellInstance(cell_spec=cell_spec, serial_number="energizer-cr2032-001")
+        cell = battinfo.Cell(cell_spec=cell_spec, serial_number="energizer-cr2032-001")
         test = battinfo.Test(
             cell=cell,
             kind="capacity_check",

--- a/tests/test_acceptance_workflows.py
+++ b/tests/test_acceptance_workflows.py
@@ -17,9 +17,9 @@ sys.path.insert(0, str(ROOT / "src"))
 
 # ── Golden path 1: the quickstart product surface (author -> publish -> inspect) ──
 def test_quickstart_product_publish(tmp_path: Path) -> None:
-    from battinfo import CellSpecification, publish
+    from battinfo import CellSpec, publish
 
-    cell_spec = CellSpecification(
+    cell_spec = CellSpec(
         manufacturer="Panasonic", model="NCR18650B", format="cylindrical", chemistry="Li-ion",
         size_code="R18650",
         nominal_capacity={"value": 3.4, "unit": "Ah"},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,7 +44,7 @@ from battinfo.api import (
     template_test_spec_draft,
     validate_staging_cell_spec,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test, TestSpec
+from battinfo.bundle import Cell, CellSpec, Dataset, Test, TestSpec
 from battinfo.validate import validate_references_report
 
 
@@ -592,7 +592,7 @@ def test_promote_staging_cell_spec_preserves_double_hyphen_record_id(tmp_path: P
 
 def test_save_test_protocol_and_test_with_protocol_reference(tmp_path: Path) -> None:
     cell_spec = save_cell_spec(
-        CellSpecification(
+        CellSpec(
             uid="7d9k2m4p8t3x6nq5",
             manufacturer="A123",
             model_name="ANR26650M1-B",
@@ -604,7 +604,7 @@ def test_save_test_protocol_and_test_with_protocol_reference(tmp_path: Path) -> 
         mode="upsert",
     )
     cell = save_cell_instance(
-        CellInstance(
+        Cell(
             uid="3m6k9t2p7x4h9nq8",
             cell_spec_id=cell_spec["id"],
         ),
@@ -803,7 +803,7 @@ def test_save_resource_drafts_and_duplicate_policy(tmp_path: Path) -> None:
     source_root = tmp_path / "examples"
 
     cell_spec_payload = save_cell_spec(
-        CellSpecification(
+        CellSpec(
             uid="3m6k9t2p7x4h9nq8",
             model_name="MN1500",
             manufacturer="Duracell",
@@ -817,7 +817,7 @@ def test_save_resource_drafts_and_duplicate_policy(tmp_path: Path) -> None:
     assert cell_spec_payload["id"].startswith("https://w3id.org/battinfo/spec/")
 
     exists_payload = save_cell_spec(
-        CellSpecification(
+        CellSpec(
             uid="3m6k9t2p7x4h9nq8",
             model_name="MN1500",
             manufacturer="Duracell",
@@ -831,7 +831,7 @@ def test_save_resource_drafts_and_duplicate_policy(tmp_path: Path) -> None:
     assert exists_payload["status"] == "exists"
 
     cell_instance_payload = save_cell_instance(
-        CellInstance(
+        Cell(
             uid="1f8r6v2k9p4m3t7x",
             cell_spec_id=cell_spec_payload["id"],
             serial_number="LAB-001",
@@ -911,7 +911,7 @@ def test_save_record_accepts_canonical_records_and_paths(tmp_path: Path) -> None
 def test_save_cell_instance_missing_reference_is_deferred_until_set_validation(tmp_path: Path) -> None:
     source_root = tmp_path / "examples"
     payload = save_cell_instance(
-        CellInstance(
+        Cell(
             uid="eysh4h5sk4bxzkgg",
             cell_spec_id="https://w3id.org/battinfo/spec/pvn1-43h7-rm3e-mjqq",
             dataset_id="https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x",

--- a/tests/test_authoring.py
+++ b/tests/test_authoring.py
@@ -28,7 +28,7 @@ from battinfo.authoring import (
 from battinfo.bundle import (
     BillOfMaterials,
     CellConstruction,
-    CellSpecification,
+    CellSpec,
     Electrode,
     Electrolyte,
     MaterialComponent,
@@ -368,7 +368,7 @@ _CELL_ID = "https://w3id.org/battinfo/cell/1234-5678-abcd-efgh"
 
 
 class TestCellDescription:
-    def _minimal(self) -> CellSpecification:
+    def _minimal(self) -> CellSpec:
         return cell_description(
             id=_CELL_ID,
             manufacturer="Acme",
@@ -379,7 +379,7 @@ class TestCellDescription:
 
     def test_returns_cell_specification(self):
         spec = self._minimal()
-        assert isinstance(spec, CellSpecification)
+        assert isinstance(spec, CellSpec)
 
     def test_required_fields_set(self):
         spec = self._minimal()

--- a/tests/test_bpx_export.py
+++ b/tests/test_bpx_export.py
@@ -102,9 +102,9 @@ def test_cell_instance_reference_in_header(a123_record):
 
 
 def test_accepts_cellspecification_object():
-    from battinfo import CellSpecification
+    from battinfo import CellSpec
 
-    ct = CellSpecification.from_record(json.loads(A123.read_text(encoding="utf-8")))
+    ct = CellSpec.from_record(json.loads(A123.read_text(encoding="utf-8")))
     result = to_bpx(ct)
     assert result.bpx["Parameterisation"]["Cell"]["Nominal cell capacity [A.h]"] == pytest.approx(2.5)
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -12,9 +12,9 @@ sys.path.insert(0, str(ROOT / "src"))
 from battinfo import (  # noqa: E402
     BattinfoBundle,
     BillOfMaterials,
+    Cell,
     CellConstruction,
-    CellInstance,
-    CellSpecification,
+    CellSpec,
     Coating,
     CurrentCollector,
     Dataset,
@@ -38,7 +38,7 @@ from battinfo.bundle import ProtocolInfo, ProvenanceInfo  # noqa: E402
 
 
 def test_bundle_round_trip_and_save(tmp_path: Path) -> None:
-    specification = CellSpecification(
+    specification = CellSpec(
         id="https://w3id.org/battinfo/spec/7r2m-4q8v-k6nt-c3pj",
         manufacturer="Energizer",
         model="CR2032",
@@ -57,7 +57,7 @@ def test_bundle_round_trip_and_save(tmp_path: Path) -> None:
         ),
         comment=["Example bundle specification."],
     )
-    cell_spec = CellSpecification(
+    cell_spec = CellSpec(
         id="https://w3id.org/battinfo/spec/7r2m-4q8v-k6nt-c3pj",
         name="Energizer CR2032",
         manufacturer="Energizer",
@@ -87,7 +87,7 @@ def test_bundle_round_trip_and_save(tmp_path: Path) -> None:
             retrieved_at=1771804800,
         ),
     )
-    cell_instance = CellInstance(
+    cell_instance = Cell(
         id="https://w3id.org/battinfo/cell/69ca-scxq-6w58-e9tc",
         name="energizer-cr2032-202602-dtjrga",
         cell_spec_id=cell_spec.id,
@@ -387,7 +387,7 @@ def test_derive_cell_spec_from_library_record_mapping() -> None:
 
 
 def test_cell_specification_accepts_nested_objects() -> None:
-    spec = CellSpecification(
+    spec = CellSpec(
         id="https://w3id.org/battinfo/spec/9qfb-4wrn-ynwc-ayjw",
         manufacturer="A123",
         model="ANR26650M1-B",
@@ -445,7 +445,7 @@ def test_cell_specification_accepts_nested_objects() -> None:
 
 
 def test_cell_specification_accepts_human_first_helper_objects() -> None:
-    spec = CellSpecification(
+    spec = CellSpec(
         id="https://w3id.org/battinfo/cell/4f2m-8k7p-1t9x-6q3r",
         manufacturer="ExampleLab",
         model="POUCH-ML-NMC-042",

--- a/tests/test_cell_fleet.py
+++ b/tests/test_cell_fleet.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import battinfo as bi
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellSpec
 from battinfo.transform.json_to_jsonld import to_jsonld
 from battinfo.validate.record import validate_record
 
@@ -64,7 +64,7 @@ def test_nmc811_chain_resolves_end_to_end():
 
 def test_missing_component_reference_is_flagged(tmp_path):
     from battinfo import api
-    rec = api._record_from_cell_spec(CellSpecification(
+    rec = api._record_from_cell_spec(CellSpec(
         uid="cmiss123456789ab", model_name="X", manufacturer="Y", format="coin", chemistry="Li-ion",
         electrolyte_spec_id="https://w3id.org/battinfo/electrolyte-spec/0000-0000-0000-0000"))
     result = validate_record(rec, source_root=tmp_path)

--- a/tests/test_cell_spec_input_routing.py
+++ b/tests/test_cell_spec_input_routing.py
@@ -1,5 +1,5 @@
 """PR B (step A): the cell-spec save path builds its canonical record THROUGH the one
-model (CellSpecification.to_record), not a parallel hand-assembled dict. These pin that the routed
+model (CellSpec.to_record), not a parallel hand-assembled dict. These pin that the routed
 builder preserves everything the input carries — including product_type, which the old hand-builder
 silently dropped — and still derives the id/short_id/identifier the same way."""
 from __future__ import annotations
@@ -12,11 +12,11 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo import validate_record
 from battinfo.api import _record_from_cell_spec
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellSpec
 
 
 def test_routed_builder_preserves_all_fields_and_validates() -> None:
-    rec = _record_from_cell_spec(CellSpecification(
+    rec = _record_from_cell_spec(CellSpec(
         uid="1c4m-7p9q-2k6t-8v3r", model_name="CR2032",
         manufacturer={"name": "Energizer", "id": "https://w3id.org/battinfo/organization/1111-2222-3333-4444"},
         format="coin", chemistry="Li-primary", product_type="commercial", size_code="R2032",
@@ -32,7 +32,7 @@ def test_routed_builder_preserves_all_fields_and_validates() -> None:
 
 
 def test_routed_builder_mints_id_short_id_and_identifier_from_uid() -> None:
-    rec = _record_from_cell_spec(CellSpecification(
+    rec = _record_from_cell_spec(CellSpec(
         uid="1c4m-7p9q-2k6t-8v3r", model_name="X", manufacturer="Acme", format="coin", chemistry="Li-ion",
     ))
     cs = rec["cell_spec"]

--- a/tests/test_core_workflow.py
+++ b/tests/test_core_workflow.py
@@ -15,7 +15,7 @@ from battinfo.api import (
     save_dataset,
     save_test,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test
+from battinfo.bundle import Cell, CellSpec, Dataset, Test
 
 
 def test_core_workflow_end_to_end(tmp_path: Path) -> None:
@@ -24,7 +24,7 @@ def test_core_workflow_end_to_end(tmp_path: Path) -> None:
     index_path = tmp_path / ".battinfo" / "index.json"
 
     cell_spec = save_cell_spec(
-        CellSpecification(
+        CellSpec(
             uid="3m6k9t2p7x4h9nq8",
             model_name="MN1500",
             manufacturer="Duracell",
@@ -36,7 +36,7 @@ def test_core_workflow_end_to_end(tmp_path: Path) -> None:
         validation_policy="strict",
     )
     cell_instance = save_cell_instance(
-        CellInstance(
+        Cell(
             uid="1f8r6v2k9p4m3t7x",
             cell_spec_id=cell_spec["id"],
             serial_number="SN-001",

--- a/tests/test_cr2032_dataset_publication_script.py
+++ b/tests/test_cr2032_dataset_publication_script.py
@@ -10,8 +10,8 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo import (
     BattinfoBundle,
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     Dataset,
     Test,
     load_publication,
@@ -194,7 +194,7 @@ def test_publish_dataset_metadata_with_cell_spec_only(tmp_path: Path) -> None:
     raw.parent.mkdir(parents=True)
     raw.write_text("time,voltage\n0,3.7\n", encoding="utf-8")
 
-    cell_spec = CellSpecification(
+    cell_spec = CellSpec(
         id="https://w3id.org/battinfo/spec/1234-5678-9abc-def0",
         name="ExampleCell 21700-A",
         manufacturer="ExampleCell",
@@ -241,7 +241,7 @@ def test_publish_object_first_api(tmp_path: Path) -> None:
     raw.parent.mkdir(parents=True)
     raw.write_text("time,voltage\n0,3.0\n", encoding="utf-8")
 
-    cell_spec = CellSpecification(
+    cell_spec = CellSpec(
         manufacturer="Energizer",
         model="CR2032",
         format="coin",
@@ -249,7 +249,7 @@ def test_publish_object_first_api(tmp_path: Path) -> None:
         size_code="R2032",
         properties={"nominal_voltage": {"value": 3.0, "unit": "V"}},
     )
-    cell = CellInstance(
+    cell = Cell(
         cell_spec=cell_spec,
         serial_number="energizer-cr2032-202602-dtjrga",
     )

--- a/tests/test_deprecation_shims.py
+++ b/tests/test_deprecation_shims.py
@@ -17,8 +17,8 @@ sys.path.insert(0, str(ROOT / "src"))
 import battinfo  # noqa: E402
 
 ALIASES = {
-    "CellSpecificationInput": battinfo.CellSpecification,
-    "CellInstanceInput": battinfo.CellInstance,
+    "CellSpecificationInput": battinfo.CellSpec,
+    "CellInstanceInput": battinfo.Cell,
     "TestInput": battinfo.Test,
     "DatasetInput": battinfo.Dataset,
     "TestSpecInput": battinfo.TestSpec,

--- a/tests/test_draft_finalize.py
+++ b/tests/test_draft_finalize.py
@@ -1,6 +1,6 @@
 """PR D: draft vs. publish-ready.
 
-The CellSpecification model is tolerant to construct (a half-filled spec is a valid draft — this is
+The CellSpec model is tolerant to construct (a half-filled spec is a valid draft — this is
 what lets importers build it from arbitrary data and a GUI hold work-in-progress). Publish-readiness
 is a POLICY applied at finalize()/is_publishable(), not baked into the field types. These tests pin
 that separation, which is the foundation for folding the strict input DTOs onto the one model."""
@@ -14,11 +14,11 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellSpec
 
 
 def test_draft_constructs_and_is_not_publishable() -> None:
-    draft = CellSpecification(manufacturer="Acme")  # half-filled, no id
+    draft = CellSpec(manufacturer="Acme")  # half-filled, no id
     assert draft.is_publishable() is False
     problems = draft.publish_readiness_problems()
     # every unset required field is reported at once (manufacturer IS set, so it is not listed)
@@ -28,7 +28,7 @@ def test_draft_constructs_and_is_not_publishable() -> None:
 
 
 def test_finalize_raises_listing_all_missing_fields() -> None:
-    draft = CellSpecification(manufacturer="Acme")
+    draft = CellSpec(manufacturer="Acme")
     with pytest.raises(ValueError, match="not publish-ready") as exc:
         draft.finalize()
     msg = str(exc.value)
@@ -36,7 +36,7 @@ def test_finalize_raises_listing_all_missing_fields() -> None:
 
 
 def test_complete_spec_is_publishable_and_finalize_returns_self() -> None:
-    spec = CellSpecification(
+    spec = CellSpec(
         id="https://w3id.org/battinfo/spec/aaaa-bbbb-cccc-dddd", name="Acme X",
         manufacturer="Acme", model="X", format="coin", chemistry="Li-ion",
     )
@@ -48,7 +48,7 @@ def test_complete_spec_is_publishable_and_finalize_returns_self() -> None:
 def test_tolerant_import_is_serializable_but_flagged_unpublishable() -> None:
     # A record imported with an unknown chemistry (tolerant construction) must still serialize — so
     # import->save round-trips — while is_publishable() flags it for the author to complete.
-    imported = CellSpecification(
+    imported = CellSpec(
         id="https://w3id.org/battinfo/spec/bbbb-cccc-dddd-eeee", name="Imported",
         manufacturer="X", model="Y", format="coin",  # chemistry defaults to "unknown"
     )
@@ -58,6 +58,6 @@ def test_tolerant_import_is_serializable_but_flagged_unpublishable() -> None:
 
 
 def test_to_record_on_a_draft_raises_a_clear_draft_error() -> None:
-    draft = CellSpecification(manufacturer="Acme", model="X", format="coin", chemistry="Li-ion")
+    draft = CellSpec(manufacturer="Acme", model="X", format="coin", chemistry="Li-ion")
     with pytest.raises(ValueError, match="draft"):
         draft.to_record()  # no id yet

--- a/tests/test_field_descriptions.py
+++ b/tests/test_field_descriptions.py
@@ -14,15 +14,15 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.bundle import (
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     Dataset,
     ProvenanceInfo,
     Test,
     TestSpec,
 )
 
-MODELS = [CellSpecification, CellInstance, Test, TestSpec, Dataset, ProvenanceInfo]
+MODELS = [CellSpec, Cell, Test, TestSpec, Dataset, ProvenanceInfo]
 
 # Structural fields shared via BundleJsonModel — not part of the authoring vocabulary.
 STRUCTURAL = {"kind", "schema_version"}

--- a/tests/test_friendly_errors.py
+++ b/tests/test_friendly_errors.py
@@ -16,7 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.api import _validate_canonical_record
-from battinfo.bundle import CellSpecification, Dataset, Test
+from battinfo.bundle import CellSpec, Dataset, Test
 
 SPEC_IRI = "https://w3id.org/battinfo/spec/aaaa-aaaa-aaaa-aaaa"
 
@@ -78,12 +78,12 @@ def test_required_error_path_names_the_missing_field() -> None:
 
 def test_kwarg_typo_gets_a_did_you_mean() -> None:
     with pytest.raises(TypeError, match=r"manufacture=.*did you mean manufacturer=\?"):
-        CellSpecification(manufacture="Acme", model_name="X", chemistry="LFP", format="cylindrical")
+        CellSpec(manufacture="Acme", model_name="X", chemistry="LFP", format="cylindrical")
 
 
 def test_spec_property_typo_gets_a_did_you_mean() -> None:
     with pytest.raises(TypeError, match=r"did you mean nominal_capacity=\?"):
-        CellSpecification(
+        CellSpec(
             manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
             nominal_capacit={"value": 2.0, "unit": "Ah"},
         )

--- a/tests/test_housing_engineering.py
+++ b/tests/test_housing_engineering.py
@@ -13,7 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from battinfo import CellSpecification  # noqa: E402
+from battinfo import CellSpec  # noqa: E402
 from battinfo.authoring import (  # noqa: E402
     bom,
     case,
@@ -31,7 +31,7 @@ from battinfo.authoring import (  # noqa: E402
 from battinfo.transform.json_to_jsonld import to_jsonld  # noqa: E402
 
 
-def _battery_node(spec: CellSpecification) -> dict:
+def _battery_node(spec: CellSpec) -> dict:
     """Export a spec to validated domain-battery JSON-LD and return the battery node."""
     spec_dict = spec.to_json()
     if "properties" in spec_dict and "property" not in spec_dict:
@@ -85,7 +85,7 @@ def _prismatic_spec(housing_model=None, construction_model=None):
 
 def test_housing_round_trips_through_library_record() -> None:
     spec = _prismatic_spec(housing_model=_prismatic_housing())
-    restored = CellSpecification.from_library_record(spec.to_library_record())
+    restored = CellSpec.from_library_record(spec.to_library_record())
 
     assert restored.housing is not None
     assert restored.housing.case.material == "Aluminium"
@@ -143,7 +143,7 @@ def test_electrode_tab_round_trips_and_emits() -> None:
             tab=tab(material="Aluminium", width={"value": 50, "unit": "mm"}, thickness={"value": 0.65, "unit": "mm"}),
         ),
     )
-    restored = CellSpecification.from_library_record(spec.to_library_record())
+    restored = CellSpec.from_library_record(spec.to_library_record())
     assert restored.positive_electrode.tab.material == "Aluminium"
     assert restored.positive_electrode.tab.property["width"]["value"] == 50
 
@@ -225,7 +225,7 @@ def test_legacy_coin_hardware_record_loads_into_housing() -> None:
         },
         "provenance": {},
     }
-    spec = CellSpecification.from_library_record(record)
+    spec = CellSpec.from_library_record(record)
     assert spec.housing is not None
     assert spec.housing.case.material == "Stainless steel"
     # On re-serialization the on-disk key is `housing`, not the retired `coin_hardware`.

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -9,7 +9,7 @@ sys.path.insert(0, str(ROOT / "src"))
 from battinfo import (  # noqa: E402
     BatteryTestType,
     Cell,
-    CellSpecification,
+    CellSpec,
     Dataset,
     TableColumn,
     TableSchema,
@@ -84,7 +84,7 @@ def test_infer_variable_measured_from_columns_and_metadata() -> None:
 
 
 def test_dataset_with_tabular_data_populates_variables_and_csvw() -> None:
-    cell_spec = CellSpecification(
+    cell_spec = CellSpec(
         manufacturer="A123",
         model="ANR26650M1-B",
         format="cylindrical",

--- a/tests/test_model_input_coercion.py
+++ b/tests/test_model_input_coercion.py
@@ -1,4 +1,4 @@
-"""Step B (foundation): the CellSpecification model accepts the flat authoring/input shape directly
+"""Step B (foundation): the CellSpec model accepts the flat authoring/input shape directly
 (the fields the separate CellSpecificationInput DTO used to carry), so one model can be both the
 source of truth and the thing importers/CLI/tests construct. This is what makes retiring the DTO
 possible; the retirement + caller repoint follows."""
@@ -10,11 +10,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellSpec
 
 
 def test_model_absorbs_flat_authoring_input() -> None:
-    spec = CellSpecification(
+    spec = CellSpec(
         uid="1c4m-7p9q-2k6t-8v3r",
         model_name="CR2032",  # -> model
         manufacturer={"type": "Organization", "name": "Energizer",
@@ -35,7 +35,7 @@ def test_model_absorbs_flat_authoring_input() -> None:
 
 
 def test_uid_is_transient_and_not_serialized() -> None:
-    spec = CellSpecification(uid="1c4m-7p9q-2k6t-8v3r", manufacturer="A", model="M",
+    spec = CellSpec(uid="1c4m-7p9q-2k6t-8v3r", manufacturer="A", model="M",
                              format="coin", chemistry="Li-ion")
     assert spec.uid == "1c4m-7p9q-2k6t-8v3r"
     assert "uid" not in spec.model_dump()  # excluded from serialization

--- a/tests/test_no_silent_drops.py
+++ b/tests/test_no_silent_drops.py
@@ -24,7 +24,7 @@ from battinfo.api import (
     _record_from_test,
     _record_from_test_protocol,
 )
-from battinfo.bundle import CellInstance, CellSpecification, Dataset, Test, TestSpec
+from battinfo.bundle import Cell, CellSpec, Dataset, Test, TestSpec
 
 UID = "ffffffffffffffff"
 SPEC_IRI = "https://w3id.org/battinfo/spec/aaaa-aaaa-aaaa-aaaa"
@@ -41,14 +41,14 @@ PROVENANCE_KWARGS = dict(
 
 def test_specs_non_mapping_raises_with_the_fix() -> None:
     with pytest.raises(TypeError, match="specs= must be a mapping"):
-        CellSpecification(
+        CellSpec(
             manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
             specs=[("nominal_capacity", 2.5)],
         )
 
 
 def test_specs_mapping_still_accepted() -> None:
-    spec = CellSpecification(
+    spec = CellSpec(
         manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
         specs={"nominal_capacity": {"value": 2.5, "unit": "Ah"}},
     )
@@ -70,18 +70,18 @@ def _assert_provenance_survives(record: dict, model_cls, prov_key: str = "proven
 
 
 def test_cell_spec_provenance_round_trip() -> None:
-    record = _record_from_cell_spec(CellSpecification(
+    record = _record_from_cell_spec(CellSpec(
         manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
         uid=UID, **PROVENANCE_KWARGS,
     ))
-    _assert_provenance_survives(record, CellSpecification)
+    _assert_provenance_survives(record, CellSpec)
 
 
 def test_cell_instance_provenance_round_trip() -> None:
-    record = _record_from_cell_instance(CellInstance(
+    record = _record_from_cell_instance(Cell(
         uid=UID, cell_spec_id=SPEC_IRI, **PROVENANCE_KWARGS,
     ))
-    _assert_provenance_survives(record, CellInstance)
+    _assert_provenance_survives(record, Cell)
 
 
 def test_test_provenance_round_trip() -> None:
@@ -99,33 +99,33 @@ def test_test_spec_provenance_round_trip() -> None:
 
 
 def test_cell_instance_conflicting_spec_references_raise() -> None:
-    spec = CellSpecification(
+    spec = CellSpec(
         id=SPEC_IRI, manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
     )
     other = "https://w3id.org/battinfo/spec/cccc-cccc-cccc-cccc"
     with pytest.raises(ValueError, match="Conflicting cell spec references"):
-        CellInstance(spec, cell_spec_id=other)
+        Cell(spec, cell_spec_id=other)
 
 
 def test_cell_instance_positional_spec_with_matching_id_is_kept() -> None:
-    spec = CellSpecification(
+    spec = CellSpec(
         id=SPEC_IRI, manufacturer="Acme", model_name="X", chemistry="LFP", format="cylindrical",
     )
     # Previously the positional object was silently discarded whenever cell_spec_id= was given.
-    instance = CellInstance(spec, cell_spec_id=SPEC_IRI)
+    instance = Cell(spec, cell_spec_id=SPEC_IRI)
     assert instance.cell_spec is spec
     assert instance.cell_spec_id == SPEC_IRI
 
 
 def test_test_conflicting_cell_references_raise() -> None:
-    cell = CellInstance(id=CELL_IRI, cell_spec_id=SPEC_IRI)
+    cell = Cell(id=CELL_IRI, cell_spec_id=SPEC_IRI)
     other = "https://w3id.org/battinfo/cell/dddd-dddd-dddd-dddd"
     with pytest.raises(ValueError, match="Conflicting cell references"):
         Test(cell, cell_id=other, name="T", kind="cycling")
 
 
 def test_test_positional_cell_with_matching_id_is_kept() -> None:
-    cell = CellInstance(id=CELL_IRI, cell_spec_id=SPEC_IRI)
+    cell = Cell(id=CELL_IRI, cell_spec_id=SPEC_IRI)
     test = Test(cell, cell_id=CELL_IRI, name="T", kind="cycling")
     assert test.cell is cell
     assert test.cell_instance_id == CELL_IRI

--- a/tests/test_notebook_hygiene.py
+++ b/tests/test_notebook_hygiene.py
@@ -1,0 +1,25 @@
+"""Committed guide notebooks must not leak the executing machine's paths."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Windows user-profile paths and unix home dirs — none belong in committed output.
+_LOCAL_PATH = re.compile(r"[A-Za-z]:[\/]Users[\/]|/home/|/Users/")
+
+
+def test_no_machine_local_paths_in_committed_outputs() -> None:
+    offenders: list[str] = []
+    for notebook in sorted((ROOT / "docs" / "guides").glob("*.ipynb")):
+        nb = json.loads(notebook.read_text(encoding="utf-8"))
+        for index, cell in enumerate(nb.get("cells", [])):
+            blob = json.dumps(cell.get("outputs", []))
+            if _LOCAL_PATH.search(blob):
+                offenders.append(f"{notebook.name} cell {index}")
+    assert not offenders, (
+        "machine-local paths leaked into committed notebook outputs — re-run "
+        "`uv run python scripts/execute_guides.py`:\n" + "\n".join(offenders)
+    )

--- a/tests/test_phase0_record_fixes.py
+++ b/tests/test_phase0_record_fixes.py
@@ -18,8 +18,8 @@ from battinfo.api import (
     _record_from_test_protocol,
 )
 from battinfo.bundle import (
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     Dataset,
     ProvenanceInfo,
     Test,
@@ -121,7 +121,7 @@ def test_explicit_source_citation_wins_over_flat_kwarg() -> None:
 
 
 def test_expires_at_converts_like_manufactured_at() -> None:
-    instance = CellInstance(
+    instance = Cell(
         cell_spec_id=SPEC_IRI, manufactured_at="2024-01-01", expires_at="2030-01-01", uid=UID
     )
     record = _record_from_cell_instance(instance)
@@ -130,18 +130,18 @@ def test_expires_at_converts_like_manufactured_at() -> None:
 
 
 def test_expires_at_garbage_raises() -> None:
-    instance = CellInstance(cell_spec_id=SPEC_IRI, expires_at="not a date", uid=UID)
+    instance = Cell(cell_spec_id=SPEC_IRI, expires_at="not a date", uid=UID)
     with pytest.raises(ValueError, match="expires_at"):
         _record_from_cell_instance(instance)
 
 
 def test_retrieved_at_iso_string_converts_on_every_builder() -> None:
     spec_rec = _record_from_cell_spec(
-        CellSpecification(manufacturer="ACME", model="X1", retrieved_at="2024-01-01", uid=UID)
+        CellSpec(manufacturer="ACME", model="X1", retrieved_at="2024-01-01", uid=UID)
     )
     assert spec_rec["provenance"]["retrieved_at"] == JAN_2024
     inst_rec = _record_from_cell_instance(
-        CellInstance(cell_spec_id=SPEC_IRI, retrieved_at="2024-01-01", uid=UID)
+        Cell(cell_spec_id=SPEC_IRI, retrieved_at="2024-01-01", uid=UID)
     )
     assert inst_rec["provenance"]["retrieved_at"] == JAN_2024
     test_rec = _record_from_test(
@@ -162,11 +162,11 @@ def test_retrieved_at_epoch_zero_is_preserved() -> None:
 
 
 def test_retrieved_at_garbage_raises_instead_of_becoming_now() -> None:
-    spec = CellSpecification(manufacturer="ACME", model="X1", retrieved_at="not a date", uid=UID)
+    spec = CellSpec(manufacturer="ACME", model="X1", retrieved_at="not a date", uid=UID)
     with pytest.raises(ValueError, match="retrieved_at"):
         _record_from_cell_spec(spec)
 
 
 def test_retrieved_at_absent_still_defaults_to_now() -> None:
-    record = _record_from_cell_spec(CellSpecification(manufacturer="ACME", model="X1", uid=UID))
+    record = _record_from_cell_spec(CellSpec(manufacturer="ACME", model="X1", uid=UID))
     assert isinstance(record["provenance"]["retrieved_at"], int)

--- a/tests/test_provenance_stamping.py
+++ b/tests/test_provenance_stamping.py
@@ -15,11 +15,11 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 import battinfo  # noqa: E402
-from battinfo.bundle import CellSpecification, stamp_provenance  # noqa: E402
+from battinfo.bundle import CellSpec, stamp_provenance  # noqa: E402
 
 
-def _spec() -> CellSpecification:
-    return CellSpecification(
+def _spec() -> CellSpec:
+    return CellSpec(
         id="https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
         manufacturer="Energizer",
         model="CR2032",
@@ -37,13 +37,13 @@ def test_to_record_stamps_current_version() -> None:
 def test_explicit_version_is_preserved_through_round_trip() -> None:
     record = _spec().to_record()
     record["provenance"]["battinfo_version"] = "0.0.1"
-    reread = CellSpecification.from_record(record)
+    reread = CellSpec.from_record(record)
     assert reread.to_record()["provenance"]["battinfo_version"] == "0.0.1"
 
 
 def test_round_trip_is_a_fixed_point() -> None:
     first = _spec().to_record()
-    second = CellSpecification.from_record(first).to_record()
+    second = CellSpec.from_record(first).to_record()
     assert first["provenance"] == second["provenance"]
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -11,12 +11,12 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 publish_module = importlib.import_module("battinfo._publish")
-from battinfo import CellSpecification, PublishResult, publish
+from battinfo import CellSpec, PublishResult, publish
 from battinfo.api import publish_record, save_record
 
 
-def _sample_cell_spec() -> CellSpecification:
-    return CellSpecification(
+def _sample_cell_spec() -> CellSpec:
+    return CellSpec(
         manufacturer="Google",
         model="G20M7",
         format="pouch",

--- a/tests/test_quickstart_recipe.py
+++ b/tests/test_quickstart_recipe.py
@@ -35,7 +35,7 @@ def ws(tmp_path: Path) -> AuthoringWorkspace:
     )
     # Offline search falls back to a local battinfo-records clone; fabricate a
     # one-record clone so the search->add seam runs with zero network.
-    record = battinfo.CellSpecification(
+    record = battinfo.CellSpec(
         id="https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
         manufacturer="Molicel",
         model="INR21700-P45B",
@@ -107,7 +107,7 @@ def test_add_with_string_spec_teaches_the_fix(ws: AuthoringWorkspace) -> None:
 
 
 def test_add_still_accepts_a_cell_specification(ws: AuthoringWorkspace) -> None:
-    spec = battinfo.CellSpecification(
+    spec = battinfo.CellSpec(
         manufacturer="Acme", model="QS-1", format="coin", chemistry="Li-ion"
     )
     cells = ws.add("cell", spec=spec, serial_numbers=["ACME-1"])
@@ -139,9 +139,9 @@ def test_user_facing_prints_are_console_safe() -> None:
 
 
 def test_new_spec_passed_to_add_joins_the_save_set(ws: AuthoringWorkspace, tmp_path: Path) -> None:
-    # A CellSpecification without an id handed to add() must be saved and
+    # A CellSpec without an id handed to add() must be saved and
     # minted with the instances — not left as an orphan that fails at save.
-    spec = battinfo.CellSpecification(
+    spec = battinfo.CellSpec(
         manufacturer="Molicel", model="INR21700-P45B", format="cylindrical", chemistry="Li-ion"
     )
     cells = ws.add("cell", spec=spec, serial_numbers=["NEW-1"])

--- a/tests/test_record_roundtrip.py
+++ b/tests/test_record_roundtrip.py
@@ -1,6 +1,6 @@
 """Phase 1a: the canonical record serialization must be LOSSLESS.
 
-Previously CellSpecification.to_record() dropped the entire datasheet structure (electrodes,
+Previously CellSpec.to_record() dropped the entire datasheet structure (electrodes,
 electrolyte, separator, housing, construction) — the "electrode-drop" data-loss bug: authoring a
 rich cell spec and saving it silently discarded the structure on disk. These tests pin that
 to_record()/from_record() now round-trip the full structure and that the emitted record still
@@ -17,7 +17,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo import validate_record
-from battinfo.bundle import CellSpecification
+from battinfo.bundle import CellSpec
 
 _STRUCTURE = ("positive_electrode", "negative_electrode", "electrolyte", "separator", "housing")
 _DETAILED = sorted((ROOT / "src/battinfo/data/examples/cell-spec/research").glob("*detailed*.json"))
@@ -25,7 +25,7 @@ _DETAILED = sorted((ROOT / "src/battinfo/data/examples/cell-spec/research").glob
 
 @pytest.mark.parametrize("path", _DETAILED, ids=lambda p: p.name)
 def test_canonical_roundtrip_is_lossless_and_valid(path: Path) -> None:
-    spec = CellSpecification.from_path(path)  # auto-detects canonical vs library
+    spec = CellSpec.from_path(path)  # auto-detects canonical vs library
     rec1 = spec.to_record()
 
     # Every structure component the spec carries must survive serialization (not be dropped).
@@ -40,7 +40,7 @@ def test_canonical_roundtrip_is_lossless_and_valid(path: Path) -> None:
     assert report.ok, f"{path.name}: {[i.message for i in report.errors][:3]}"
 
     # from_record → to_record is idempotent (no drift, no loss) at the record level.
-    rec2 = CellSpecification.from_record(rec1).to_record()
+    rec2 = CellSpec.from_record(rec1).to_record()
     assert rec1 == rec2, f"{path.name}: canonical round-trip is not idempotent"
 
 
@@ -56,7 +56,7 @@ def test_detailed_fixtures_actually_carry_structure() -> None:
 def test_inline_component_schema_reconciled_with_model() -> None:
     # The inline datasheet structure is strictly validated. Pins the component-schema reconciliation:
     # a material component carrying molecular_formula, and a current_collector with no name, are both
-    # valid — the CellSpecification models allow them, and the schemas now match the models.
+    # valid — the CellSpec models allow them, and the schemas now match the models.
     base = json.loads(
         next(p for p in _DETAILED if "cell_spec" in json.loads(p.read_text(encoding="utf-8"))).read_text(
             encoding="utf-8"
@@ -74,9 +74,9 @@ def test_manufacturer_id_provenance_and_component_refs_round_trip() -> None:
     # PR A: complete the model. Three fields the canonical record supports but the model used to drop
     # on save — the manufacturer organization id, the extra provenance fields the converter populates,
     # and the standalone component-spec references — must now survive to_record/from_record losslessly.
-    from battinfo.bundle import CellSpecification, ProvenanceInfo
+    from battinfo.bundle import CellSpec, ProvenanceInfo
 
-    spec = CellSpecification(
+    spec = CellSpec(
         id="https://w3id.org/battinfo/spec/aaaa-bbbb-cccc-dddd",
         name="Acme X", manufacturer="Acme", model="X", format="coin", chemistry="Li-ion",
         size_code="R2032",
@@ -100,7 +100,7 @@ def test_manufacturer_id_provenance_and_component_refs_round_trip() -> None:
 
     assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
 
-    back = CellSpecification.from_record(rec)
+    back = CellSpec.from_record(rec)
     assert back.manufacturer_id == spec.manufacturer_id
     assert back.positive_electrode_spec_id == spec.positive_electrode_spec_id
     assert back.electrolyte_spec_id == spec.electrolyte_spec_id
@@ -114,13 +114,13 @@ def test_electrode_drop_regression() -> None:
     rich = next(
         p for p in _DETAILED if "positive_electrode" in json.loads(p.read_text(encoding="utf-8"))
     )
-    spec = CellSpecification.from_path(rich)
+    spec = CellSpec.from_path(rich)
     assert spec.positive_electrode is not None and spec.electrolyte is not None  # fixture sanity
 
     rec = spec.to_record()
     assert "positive_electrode" in rec and "electrolyte" in rec  # not dropped on save
 
-    reloaded = CellSpecification.from_record(rec)
+    reloaded = CellSpec.from_record(rec)
     assert reloaded.positive_electrode is not None  # not dropped on load
     # byte-lossless on the electrode subtree
     src = json.loads(rich.read_text(encoding="utf-8"))

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -15,8 +15,8 @@ SPEC COVERAGE (report only) — which SpecSet schema fields lack a direct
   failure, since schema can legitimately contain EU-regulation fields that
   aren't in the authoring API yet.
 
-ADAPTER ROUNDTRIP (fail) — CellSpecification → generated CellSpecification → record dict →
-  CellSpecification must preserve identity for all non-None fields.
+ADAPTER ROUNDTRIP (fail) — CellSpec → generated CellSpec → record dict →
+  CellSpec must preserve identity for all non-None fields.
 """
 
 from __future__ import annotations
@@ -163,10 +163,10 @@ def test_bundle_authoring_fields_report_schema_gaps() -> None:
 # ── ADAPTER ROUNDTRIP ─────────────────────────────────────────────────────────
 
 def test_adapter_cell_spec_to_schema_basic() -> None:
-    from battinfo.bundle import CellSpecification
+    from battinfo.bundle import CellSpec
     from battinfo.bundle_adapter import cell_spec_to_schema
 
-    ct = CellSpecification(
+    ct = CellSpec(
         manufacturer="Panasonic",
         model="NCR18650B",
         format="cylindrical",
@@ -185,10 +185,10 @@ def test_adapter_cell_spec_to_schema_basic() -> None:
 
 
 def test_adapter_cell_spec_roundtrip() -> None:
-    from battinfo.bundle import CellSpecification
+    from battinfo.bundle import CellSpec
     from battinfo.bundle_adapter import cell_spec_to_schema, schema_cell_spec_to_record_dict
 
-    ct = CellSpecification(
+    ct = CellSpec(
         id="https://w3id.org/battinfo/spec/abc123",
         manufacturer="Samsung SDI",
         model="INR21700-50E",
@@ -200,7 +200,7 @@ def test_adapter_cell_spec_roundtrip() -> None:
     )
     gen = cell_spec_to_schema(ct)
     record = schema_cell_spec_to_record_dict(gen)
-    ct2 = CellSpecification.from_record(record)
+    ct2 = CellSpec.from_record(record)
 
     assert ct2.manufacturer == ct.manufacturer
     assert ct2.model == ct.model
@@ -211,12 +211,12 @@ def test_adapter_cell_spec_roundtrip() -> None:
 
 
 def test_adapter_spec_value_coercion_in_cell_spec() -> None:
-    """SpecValue objects passed to CellSpecification should be coerced to dicts."""
-    from battinfo.bundle import CellSpecification
+    """SpecValue objects passed to CellSpec should be coerced to dicts."""
+    from battinfo.bundle import CellSpec
     from battinfo.bundle_generated import SpecValue
 
     sv = SpecValue(sv_value=2.5, sv_unit="Ah")
-    ct = CellSpecification(
+    ct = CellSpec(
         manufacturer="A123",
         model="ANR26650M1B",
         format="cylindrical",
@@ -231,10 +231,10 @@ def test_adapter_spec_value_coercion_in_cell_spec() -> None:
 
 def test_adapter_spec_value_via_mapping_property() -> None:
     """Setting a _mapping_property with a SpecValue should coerce to dict."""
-    from battinfo.bundle import CellSpecification
+    from battinfo.bundle import CellSpec
     from battinfo.bundle_generated import SpecValue
 
-    ct = CellSpecification(manufacturer="A123", model="X", format="cylindrical", chemistry="li-ion")
+    ct = CellSpec(manufacturer="A123", model="X", format="cylindrical", chemistry="li-ion")
     ct.nominal_capacity = SpecValue(sv_value=3.0, sv_unit="Ah")
     assert ct.nominal_capacity == {"value": 3.0, "unit": "Ah"}
 
@@ -259,10 +259,10 @@ def test_adapter_specset_roundtrip() -> None:
 
 
 def test_adapter_bundle_to_schema_dispatcher() -> None:
-    from battinfo.bundle import CellInstance, CellSpecification, Test, TestSpec
+    from battinfo.bundle import Cell, CellSpec, Test, TestSpec
     from battinfo.bundle_adapter import bundle_to_schema
     from battinfo.bundle_generated import (
-        CellInstance as GenCI,
+        CellInstance as GenCI,  # generated layer keeps the LinkML names
     )
     from battinfo.bundle_generated import (
         CellSpecification as GenCT,
@@ -274,10 +274,10 @@ def test_adapter_bundle_to_schema_dispatcher() -> None:
         TestSpec as GenTS,
     )
 
-    ct = CellSpecification(manufacturer="X", model="Y", format="pouch", chemistry="nmc")
+    ct = CellSpec(manufacturer="X", model="Y", format="pouch", chemistry="nmc")
     assert isinstance(bundle_to_schema(ct), GenCT)
 
-    ci = CellInstance(
+    ci = Cell(
         cell_spec_id="https://w3id.org/battinfo/spec/abc",
         serial_number="SN-001",
     )

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -14,7 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from battinfo.api import template_material_spec
-from battinfo.bundle import SCHEMA_VERSION, CellSpecification, Dataset, ProvenanceInfo
+from battinfo.bundle import SCHEMA_VERSION, CellSpec, Dataset, ProvenanceInfo
 
 
 def test_schema_version_value() -> None:
@@ -22,7 +22,7 @@ def test_schema_version_value() -> None:
 
 
 def test_bundle_models_default_to_the_constant() -> None:
-    spec = CellSpecification(manufacturer="Acme", model_name="X1", chemistry="LFP", format="cylindrical")
+    spec = CellSpec(manufacturer="Acme", model_name="X1", chemistry="LFP", format="cylindrical")
     assert spec.schema_version == SCHEMA_VERSION
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12,7 +12,7 @@ from battinfo import (
     BatteryCellSpecification,
     BatteryTestType,
     Cell,
-    CellSpecification,
+    CellSpec,
     Dataset,
     Test,
     Workspace,
@@ -493,7 +493,7 @@ def test_workspace_add_supports_object_style_authoring_and_dataset_infers_cell_f
     dataset_file.parent.mkdir(parents=True, exist_ok=True)
     dataset_file.write_text("cycle,capacity_ah\n0,2.50\n1,2.48\n", encoding="utf-8")
 
-    cell_spec = CellSpecification()
+    cell_spec = CellSpec()
     cell_spec.manufacturer = "A123"
     cell_spec.model = "ANR26650M1-B"
     cell_spec.format = "cylindrical"

--- a/tests/test_zenodo_cell_record.py
+++ b/tests/test_zenodo_cell_record.py
@@ -11,8 +11,8 @@ import pytest
 
 from battinfo import (
     BattinfoBundle,
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     Dataset,
     Test,
     ZenodoCellRecord,
@@ -36,8 +36,8 @@ DATASET_ID = "https://w3id.org/battinfo/dataset/gj1y-pn2n-t5pm-gs9c"
 DATASET_ID_2 = "https://w3id.org/battinfo/dataset/eeee-ffff-gggg-hhhh"
 
 
-def _make_cell_spec() -> CellSpecification:
-    return CellSpecification(
+def _make_cell_spec() -> CellSpec:
+    return CellSpec(
         id=CELL_SPEC_ID,
         manufacturer="Energizer",
         model="CR2032",
@@ -50,8 +50,8 @@ def _make_cell_spec() -> CellSpecification:
     )
 
 
-def _make_cell_spec() -> CellSpecification:
-    return CellSpecification(
+def _make_cell_spec() -> CellSpec:
+    return CellSpec(
         id=CELL_TYPE_ID,
         name="Energizer CR2032",
         manufacturer="Energizer",
@@ -66,8 +66,8 @@ def _make_cell_spec() -> CellSpecification:
 def _make_cell_instance(
     instance_id: str = CELL_INSTANCE_ID,
     serial: str = "sn-001",
-) -> CellInstance:
-    return CellInstance(
+) -> Cell:
+    return Cell(
         id=instance_id,
         name=serial,
         cell_spec_id=CELL_TYPE_ID,
@@ -79,7 +79,7 @@ def _make_cell_instance(
 def _make_dataset_entry(
     test_id: str = TEST_ID,
     dataset_id: str = DATASET_ID,
-    cell_instances: list[CellInstance] | None = None,
+    cell_instances: list[Cell] | None = None,
 ) -> ZenodoDatasetEntry:
     test = Test(
         id=test_id,

--- a/tests/test_zenodo_upload.py
+++ b/tests/test_zenodo_upload.py
@@ -18,8 +18,8 @@ sys.path.insert(0, str(ROOT / "src"))
 import pytest
 
 from battinfo import (
-    CellInstance,
-    CellSpecification,
+    Cell,
+    CellSpec,
     Dataset,
     Test,
     ZenodoCellRecord,
@@ -119,7 +119,7 @@ CREATORS = [{"name": "Clark, Simon", "affiliation": "SINTEF"}]
 
 
 def _make_record(n: int = 2) -> ZenodoCellRecord:
-    ct = CellSpecification(
+    ct = CellSpec(
         id=CELL_TYPE_ID,
         name="Energizer CR2032",
         manufacturer="Energizer",
@@ -137,7 +137,7 @@ def _make_record(n: int = 2) -> ZenodoCellRecord:
         ci_id = f"https://w3id.org/battinfo/cell/ci-{idx}"
         test_id = f"https://w3id.org/battinfo/test/t-{idx}"
         ds_id = f"https://w3id.org/battinfo/dataset/d-{idx}"
-        ci = CellInstance(id=ci_id, name=f"sn-{idx}", cell_spec_id=CELL_TYPE_ID,
+        ci = Cell(id=ci_id, name=f"sn-{idx}", cell_spec_id=CELL_TYPE_ID,
                           serial_number=f"sn-{idx}", source=ProvenanceInfo(type="measurement"))
         test = Test(id=test_id, name=f"test {idx}", test_kind="capacity_check",
                     cell_instance_id=ci_id, source=ProvenanceInfo(type="measurement"))

--- a/web/app/convert/page.tsx
+++ b/web/app/convert/page.tsx
@@ -26,15 +26,15 @@ function FormatTable({
   caption: string;
 }) {
   return (
-    <div className="overflow-x-auto rounded-xl border border-slate-200">
+    <div className="overflow-x-auto rounded-xl border border-border">
       <table className="w-full text-left text-sm">
-        <thead className="bg-slate-50 text-xs uppercase tracking-wider text-ink-faint">
+        <thead className="bg-paper text-xs uppercase tracking-wider text-ink-faint">
           <tr>
             <th className="px-4 py-3 w-28">Extension</th>
             <th className="px-4 py-3">{caption}</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-slate-100">
+        <tbody className="divide-y divide-border">
           {rows.map((row) => (
             <tr key={row.ext + row.source} className="bg-white">
               <td className="px-4 py-2.5 font-mono text-xs text-ink">{row.ext}</td>
@@ -101,7 +101,7 @@ export default function ConvertPage() {
         </div>
       </section>
 
-      <section className="mt-14 rounded-2xl border border-slate-200 bg-slate-50 p-6">
+      <section className="mt-14 rounded-2xl border border-border bg-surface p-6">
         <h2 className="text-lg font-semibold text-ink">What you get back</h2>
         <p className="mt-2 max-w-prose text-sm leading-relaxed text-ink-muted">
           <span className="font-mono text-xs">bdf/*.bdf.csv</span> — cycle, step,

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -167,7 +167,7 @@ export default function DocsPage() {
               href={s.href}
               target="_blank"
               rel="noreferrer"
-              className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 transition hover:border-brand-300"
+              className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3 transition hover:border-brand-300"
             >
               <span className="text-sm font-semibold text-ink">{s.name}</span>
               <span className="text-xs text-ink-faint">{s.role}</span>
@@ -177,7 +177,7 @@ export default function DocsPage() {
       </section>
 
       {/* Relationship to EMMO */}
-      <section className="mt-20 rounded-2xl border border-slate-200 bg-slate-50 p-8">
+      <section className="mt-20 rounded-2xl border border-border bg-surface p-8">
         <SectionHeading kicker="Scope" title="BattINFO and the ontology" />
         <div className="mt-4 max-w-prose space-y-3 text-sm leading-relaxed text-ink-muted">
           <p>

--- a/web/app/federation/page.tsx
+++ b/web/app/federation/page.tsx
@@ -43,7 +43,7 @@ export default function FederationPage() {
   return (
     <>
       {/* Hero */}
-      <section className="border-b border-slate-200 bg-gradient-to-b from-brand-50/60 to-white">
+      <section className="border-b border-border bg-gradient-to-b from-brand-50/60 to-white">
         <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6 sm:py-24">
           <span className="inline-flex items-center gap-2 rounded-full border border-brand-200 bg-white px-3 py-1 text-xs font-medium text-brand-700">
             <span className="h-1.5 w-1.5 rounded-full bg-volt-500" />
@@ -102,7 +102,7 @@ export default function FederationPage() {
       </section>
 
       {/* BattINFO as the backbone */}
-      <section className="border-y border-slate-200 bg-slate-50">
+      <section className="border-y border-border bg-surface">
         <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6">
           <SectionHeading
             kicker="The backbone"
@@ -195,7 +195,7 @@ export default function FederationPage() {
       </section>
 
       {/* CTA */}
-      <section className="border-t border-slate-200 bg-brand-950">
+      <section className="border-t border-border bg-brand-950">
         <div className="mx-auto max-w-6xl px-4 py-16 text-center sm:px-6">
           <h2 className="text-2xl font-semibold tracking-tight text-white">
             Join the federation.

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -18,7 +18,7 @@ export default function HomePage() {
   return (
     <>
       {/* Hero */}
-      <section className="relative overflow-hidden border-b border-slate-200 bg-gradient-to-b from-brand-50/60 to-white">
+      <section className="relative overflow-hidden border-b border-border bg-gradient-to-b from-brand-50/60 to-white">
         <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6 sm:py-28">
           <div className="grid items-center gap-12 lg:grid-cols-2">
             <div>
@@ -44,7 +44,7 @@ export default function HomePage() {
                 </Link>
                 <Link
                   href="/validate"
-                  className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
+                  className="rounded-lg border border-border bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-tint"
                 >
                   Validate a record
                 </Link>
@@ -69,7 +69,7 @@ export default function HomePage() {
       </section>
 
       {/* Standards strip — "we build on accepted foundations" */}
-      <section className="border-b border-slate-200 bg-white">
+      <section className="border-b border-border bg-white">
         <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
           <p className="text-center text-xs font-semibold uppercase tracking-wider text-ink-faint">
             Built on open, accepted standards
@@ -111,7 +111,7 @@ export default function HomePage() {
       </section>
 
       {/* How it works — the four-verb pipeline */}
-      <section className="border-t border-slate-200 mx-auto max-w-6xl px-4 py-20 sm:px-6">
+      <section className="border-t border-border mx-auto max-w-6xl px-4 py-20 sm:px-6">
         <SectionHeading
           kicker="How it works"
           title="From datasheet to machine-readable Linked Data — in four steps."
@@ -134,7 +134,7 @@ export default function HomePage() {
       </section>
 
       {/* Features */}
-      <section className="border-y border-slate-200 bg-slate-50">
+      <section className="border-y border-border bg-surface">
         <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6">
           <SectionHeading
             kicker="What BattINFO does"
@@ -175,7 +175,7 @@ export default function HomePage() {
       </section>
 
       {/* Record model */}
-      <section className="border-y border-slate-200 bg-slate-50">
+      <section className="border-y border-border bg-surface">
         <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6">
           <SectionHeading
             kicker="One coherent model"
@@ -221,7 +221,7 @@ export default function HomePage() {
       </section>
 
       {/* Principles */}
-      <section className="border-y border-slate-200 bg-slate-50">
+      <section className="border-y border-border bg-surface">
         <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6">
           <SectionHeading
             kicker="Principles"
@@ -242,7 +242,7 @@ export default function HomePage() {
       </section>
 
       {/* CTA */}
-      <section className="border-t border-slate-200 bg-brand-950">
+      <section className="border-t border-border bg-brand-950">
         <div className="mx-auto max-w-6xl px-4 py-16 text-center sm:px-6">
           <h2 className="text-2xl font-semibold tracking-tight text-white">Build on the battery genome.</h2>
           <p className="mx-auto mt-3 max-w-xl text-sm text-brand-100">

--- a/web/app/properties/page.tsx
+++ b/web/app/properties/page.tsx
@@ -53,23 +53,23 @@ export default function PropertiesPage() {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search properties and units — try “capacity”, “Wh”, or “impedance”…"
-        className="mt-8 w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30"
+        className="mt-8 w-full rounded-xl border border-border px-4 py-3 text-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30"
       />
 
       <section className="mt-10">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-faint">
           Properties ({properties.length})
         </h2>
-        <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200">
+        <div className="mt-3 overflow-x-auto rounded-xl border border-border">
           <table className="w-full text-left text-sm">
-            <thead className="bg-slate-50 text-xs uppercase tracking-wider text-ink-faint">
+            <thead className="bg-paper text-xs uppercase tracking-wider text-ink-faint">
               <tr>
                 <th className="px-4 py-3">You write</th>
                 <th className="px-4 py-3">EMMO class</th>
                 <th className="px-4 py-3">IRI</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">
+            <tbody className="divide-y divide-border">
               {properties.map((p) => (
                 <tr key={p.key} className="bg-white">
                   <td className="px-4 py-2.5 font-mono text-xs text-ink">{p.key}</td>
@@ -95,16 +95,16 @@ export default function PropertiesPage() {
         <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-faint">
           Units ({units.length})
         </h2>
-        <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200">
+        <div className="mt-3 overflow-x-auto rounded-xl border border-border">
           <table className="w-full text-left text-sm">
-            <thead className="bg-slate-50 text-xs uppercase tracking-wider text-ink-faint">
+            <thead className="bg-paper text-xs uppercase tracking-wider text-ink-faint">
               <tr>
                 <th className="px-4 py-3">You write</th>
                 <th className="px-4 py-3">EMMO unit</th>
                 <th className="px-4 py-3">IRI</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">
+            <tbody className="divide-y divide-border">
               {units.map((u) => (
                 <tr key={u.symbol} className="bg-white">
                   <td className="px-4 py-2.5 font-mono text-xs text-ink">{u.symbol}</td>
@@ -126,7 +126,7 @@ export default function PropertiesPage() {
         </div>
       </section>
 
-      <section className="mt-12 rounded-2xl border border-slate-200 bg-white p-6">
+      <section className="mt-12 rounded-2xl border border-border bg-white p-6">
         <h2 className="text-lg font-semibold text-ink">Use them in a record</h2>
         <p className="mt-2 max-w-prose text-sm text-ink-muted">
           Any property above can go straight into a cell spec —{" "}

--- a/web/app/publish/page.tsx
+++ b/web/app/publish/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 export default function PublishPage() {
   return (
     <>
-      <section className="border-b border-slate-200 bg-gradient-to-b from-brand-50/60 to-white">
+      <section className="border-b border-border bg-gradient-to-b from-brand-50/60 to-white">
         <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6">
           <SectionHeading
             kicker="The procedure"
@@ -33,7 +33,7 @@ export default function PublishPage() {
             validated records with permanent identifiers, a DOI you can put in a
             paper, and data the whole field can find and read.
           </p>
-          <div className="mt-6 rounded-lg border border-slate-200 bg-white px-4 py-3">
+          <div className="mt-6 rounded-lg border border-border bg-white px-4 py-3">
             <p className="font-mono text-sm text-brand-700">
               raw files → BDF tables → {provenanceChain} → JSON-LD → DOI + registry
             </p>
@@ -53,7 +53,7 @@ export default function PublishPage() {
                   {i + 1}
                 </span>
                 <h2 className="text-xl font-semibold text-ink">{stage.stage}</h2>
-                <code className="ml-1 hidden rounded bg-slate-100 px-2 py-0.5 text-xs text-brand-700 sm:inline">
+                <code className="ml-1 hidden rounded bg-tint px-2 py-0.5 text-xs text-brand-700 sm:inline">
                   {stage.verb}
                 </code>
               </div>
@@ -77,7 +77,7 @@ export default function PublishPage() {
         </ol>
       </section>
 
-      <section className="border-t border-slate-200 bg-slate-50">
+      <section className="border-t border-border bg-surface">
         <div className="mx-auto max-w-4xl px-4 py-14 sm:px-6">
           <SectionHeading kicker="Before you publish" title="Check your record here, in the browser." />
           <p className="mt-4 max-w-prose text-sm leading-relaxed text-ink-muted">
@@ -94,7 +94,7 @@ export default function PublishPage() {
             </Link>
             <Link
               href="/examples"
-              className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
+              className="rounded-lg border border-border bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-tint"
             >
               See a worked example
             </Link>
@@ -115,7 +115,7 @@ export default function PublishPage() {
             href={site.reference}
             target="_blank"
             rel="noreferrer"
-            className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
+            className="rounded-lg border border-border bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-tint"
           >
             Developer reference →
           </a>
@@ -123,7 +123,7 @@ export default function PublishPage() {
             href={site.genome}
             target="_blank"
             rel="noreferrer"
-            className="rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-slate-50"
+            className="rounded-lg border border-border bg-white px-5 py-3 text-sm font-semibold text-ink transition hover:bg-tint"
           >
             See published data on Battery Genome →
           </a>

--- a/web/app/validate/page.tsx
+++ b/web/app/validate/page.tsx
@@ -29,10 +29,10 @@ const BROKEN_SAMPLE = JSON.stringify(
 function IssueRow({ issue }: { issue: Issue }) {
   const isError = issue.severity === "error";
   return (
-    <li className="flex items-start gap-3 rounded-lg border border-slate-200 bg-white p-3">
+    <li className="flex items-start gap-3 rounded-lg border border-border bg-white p-3">
       <span
         className={`mt-0.5 rounded px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase ${
-          isError ? "bg-red-100 text-red-700" : "bg-amber-100 text-amber-700"
+          isError ? "bg-error-tint text-error" : "bg-warning-tint text-warning"
         }`}
       >
         {issue.severity}
@@ -83,7 +83,7 @@ export default function ValidatePage() {
             domain-battery {site.versions.domainBattery} · {site.versions.schema}
           </span>
         </div>
-        <p className="mt-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-ink-muted">
+        <p className="mt-3 rounded-lg border border-border bg-surface px-4 py-3 text-sm text-ink-muted">
           This is the structural layer. The Python package additionally runs
           semantic rules, SHACL shapes, and referential-integrity checks that
           need your full record set — run those locally before publishing.
@@ -131,7 +131,7 @@ export default function ValidatePage() {
             }}
             onDragOver={(e) => e.preventDefault()}
             spellCheck={false}
-            className="h-[28rem] w-full resize-none rounded-xl border border-slate-300 bg-slate-950 p-4 font-mono text-sm text-slate-100 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30"
+            className="h-[28rem] w-full resize-none rounded-xl border border-border bg-ink-deep p-4 font-mono text-sm text-paper focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30"
           />
           <button
             onClick={() => run()}
@@ -144,17 +144,17 @@ export default function ValidatePage() {
         <div>
           <h2 className="mb-2 text-sm font-semibold uppercase tracking-wider text-ink-faint">Result</h2>
           {!result ? (
-            <div className="flex h-[28rem] items-center justify-center rounded-xl border border-dashed border-slate-300 bg-slate-50 text-sm text-ink-faint">
+            <div className="flex h-[28rem] items-center justify-center rounded-xl border border-dashed border-border bg-surface text-sm text-ink-faint">
               Run validation to see results.
             </div>
           ) : (
             <div className="space-y-4">
               <div
                 className={`rounded-xl border p-4 ${
-                  result.ok ? "border-volt-200 bg-volt-50" : "border-red-200 bg-red-50"
+                  result.ok ? "border-volt-200 bg-volt-50" : "border-error/30 bg-error-tint"
                 }`}
               >
-                <p className={`text-sm font-semibold ${result.ok ? "text-volt-700" : "text-red-700"}`}>
+                <p className={`text-sm font-semibold ${result.ok ? "text-volt-700" : "text-error"}`}>
                   {result.ok ? "Valid against the canonical schema" : "Validation failed"}
                 </p>
                 <p className="mt-1 text-xs text-ink-muted">
@@ -170,7 +170,7 @@ export default function ValidatePage() {
 
               {errors.length > 0 && (
                 <div>
-                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-red-600">
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-error">
                     Errors
                   </h3>
                   <ul className="space-y-2">
@@ -182,7 +182,7 @@ export default function ValidatePage() {
               )}
               {warnings.length > 0 && (
                 <div>
-                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-amber-600">
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-warning">
                     Warnings
                   </h3>
                   <ul className="space-y-2">
@@ -198,14 +198,14 @@ export default function ValidatePage() {
       </div>
 
       {/* Reproduce canonically */}
-      <section className="mt-12 rounded-2xl border border-slate-200 bg-white p-6">
+      <section className="mt-12 rounded-2xl border border-border bg-white p-6">
         <h2 className="text-lg font-semibold text-ink">The full verdict, locally</h2>
         <p className="mt-2 max-w-prose text-sm text-ink-muted">
           For the authoritative check — schema, references, semantics, and
           publication policies — run the same record through the CLI:
         </p>
-        <pre className="mt-4 overflow-x-auto rounded-lg bg-slate-950 p-4 text-sm">
-          <code className="font-mono text-slate-100">{`battinfo validate my-record.json --policy strict --format json`}</code>
+        <pre className="mt-4 overflow-x-auto rounded-lg bg-ink-deep p-4 text-sm">
+          <code className="font-mono text-paper">{`battinfo validate my-record.json --policy strict --format json`}</code>
         </pre>
         <div className="mt-4 flex flex-wrap gap-4 text-sm">
           <Link href="/publish" className="font-semibold text-brand-600 hover:text-brand-700">

--- a/web/components/code-block.tsx
+++ b/web/components/code-block.tsx
@@ -22,20 +22,20 @@ export function CodeBlock({ code, language, label }: CodeBlockProps) {
   }
 
   return (
-    <div className="group relative overflow-hidden rounded-xl border border-slate-200 bg-slate-950">
+    <div className="group relative overflow-hidden rounded-xl border border-border bg-ink-deep">
       <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
-        <span className="font-mono text-xs uppercase tracking-wider text-slate-400">
+        <span className="font-mono text-xs uppercase tracking-wider text-paper/60">
           {label ?? language ?? "code"}
         </span>
         <button
           onClick={copy}
-          className="rounded-md px-2 py-1 text-xs font-medium text-slate-300 transition hover:bg-white/10 hover:text-white"
+          className="rounded-md px-2 py-1 text-xs font-medium text-paper/70 transition hover:bg-white/10 hover:text-white"
         >
           {copied ? "Copied" : "Copy"}
         </button>
       </div>
       <pre className="overflow-x-auto p-4 text-sm leading-relaxed">
-        <code className="font-mono text-slate-100">{code}</code>
+        <code className="font-mono text-paper">{code}</code>
       </pre>
     </div>
   );

--- a/web/components/site-footer.tsx
+++ b/web/components/site-footer.tsx
@@ -3,7 +3,7 @@ import { footerNav, site } from "@/lib/site";
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-slate-200 bg-slate-50">
+    <footer className="border-t border-border bg-surface">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
         <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
           <div className="col-span-2 md:col-span-1">
@@ -41,7 +41,7 @@ export function SiteFooter() {
           ))}
         </div>
 
-        <div className="mt-10 flex flex-col gap-2 border-t border-slate-200 pt-6 text-xs text-ink-faint sm:flex-row sm:items-center sm:justify-between">
+        <div className="mt-10 flex flex-col gap-2 border-t border-border pt-6 text-xs text-ink-faint sm:flex-row sm:items-center sm:justify-between">
           <p>{site.license}</p>
           <p>
             IRIs resolve via{" "}

--- a/web/components/site-header.tsx
+++ b/web/components/site-header.tsx
@@ -3,15 +3,12 @@ import { primaryNav, site } from "@/lib/site";
 
 export function SiteHeader() {
   return (
-    <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/80 backdrop-blur">
+    <header className="sticky top-0 z-40 border-b border-border bg-white/80 backdrop-blur">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
-        <Link href="/" className="flex items-center gap-2.5">
-          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-600 font-mono text-sm font-bold text-white">
-            Bi
-          </span>
-          <span className="text-lg font-semibold tracking-tight text-ink">
-            Batt<span className="text-brand-600">INFO</span>
-          </span>
+        <Link href="/" className="flex items-center">
+          {/* Canonical horizontal lockup from the brand pack (brand/assets/logo). */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/brand/logo-horizontal.svg" alt="BattINFO" className="h-7 w-auto" />
         </Link>
 
         <nav className="flex items-center gap-1 sm:gap-2">
@@ -19,7 +16,7 @@ export function SiteHeader() {
             <Link
               key={item.href}
               href={item.href}
-              className="rounded-md px-3 py-2 text-sm font-medium text-ink-muted transition hover:bg-slate-100 hover:text-ink"
+              className="rounded-md px-3 py-2 text-sm font-medium text-ink-muted transition hover:bg-tint hover:text-ink"
             >
               {item.label}
             </Link>

--- a/web/lib/examples.ts
+++ b/web/lib/examples.ts
@@ -36,10 +36,10 @@ export const heroSnippet = `{
   "nominal_voltage":  { "value": 3.3, "unit": "V" }
 }`;
 
-export const quickstartPython = `from battinfo import CellSpecification, publish
+export const quickstartPython = `from battinfo import CellSpec, publish
 
 result = publish(
-    CellSpecification(
+    CellSpec(
         manufacturer="A123",
         model="ANR26650M1-B",
         cell_format="cylindrical",

--- a/web/public/brand/logo-horizontal.svg
+++ b/web/public/brand/logo-horizontal.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="470" height="112" viewBox="0 0 470 112" fill="none" role="img" aria-label="BattINFO logo">
+  
+  
+  <rect x="38" y="6" width="24" height="11" rx="3.5" fill="#102A43"></rect>
+  <rect x="19" y="17" width="62" height="86" rx="13" fill="none" stroke="#102A43" stroke-width="6.5"></rect>
+  <line x1="56" y1="41" x2="65" y2="74" stroke="#12A394" stroke-width="6" stroke-linecap="round"></line>
+  <line x1="65" y1="74" x2="33" y2="65" stroke="#12A394" stroke-width="6" stroke-linecap="round"></line>
+  <line x1="33" y1="65" x2="56" y2="41" stroke="#12A394" stroke-width="6" stroke-linecap="round"></line>
+  <circle cx="56" cy="41" r="7.5" fill="#12A394"></circle>
+  <circle cx="65" cy="74" r="7.5" fill="#12A394"></circle>
+  <circle cx="33" cy="65" r="7.5" fill="#12A394"></circle>
+  
+  <text class="wm" x="108" y="80"><tspan fill="#102A43">Batt</tspan><tspan fill="#12A394">INFO</tspan></text>
+</svg>

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -50,7 +50,12 @@ const config: Config = {
           DEFAULT: "#102a43", // Ink — primary text, headers
           muted: "#5a6570", // Muted — secondary text, captions
           faint: "#8a877e", // tertiary labels / eyebrows
+          deep: "#0a1b2c", // Ink active — dark code surfaces
         },
+        // Semantic states from brand/tokens.css — all AA-verified on white.
+        error: { DEFAULT: "#c8372d", tint: "#fbe7e4" },
+        warning: { DEFAULT: "#946007", tint: "#fbf0da" },
+        info: { DEFAULT: "#2563b8", tint: "#e5eefa" },
         // Brand neutrals & surfaces (from brand/tokens.css).
         paper: "#f3f2ee", // page background
         surface: "#ffffff", // cards


### PR DESCRIPTION
The record classes mixed long and short forms (CellSpecification vs TestSpec), and the "Instance" in CellInstance was redundant. This settles on one scheme before the 0.8 release: **CellSpec, Cell, TestSpec, Test, Dataset** — applied across the package, tests, docs, notebooks, and website.

- **No breakage**: `CellSpecification` and `CellInstance` keep working — as   silent aliases from `battinfo.bundle`, and with a `DeprecationWarning` naming   the replacement at the package level (removed one release after 0.8, per the   deprecation policy).
- **Data contract untouched**: JSON record keys (`cell_spec`, `cell_instance`),   IRIs, and schemas do not change. This renames the Python surface only.
- Same convention elsewhere: `properties=` is now the documented keyword for spec properties (`specs=` remains a quiet alias), and the CLI uses `test-spec` command names (`test-protocol` still works, hidden).
- Guide notebooks are now executed via a script that scrubs machine-local paths from committed outputs, with a test that keeps them clean.

1291 tests pass; web build, schema-agreement check, and strict docs build all green.
