### PR TITLE
One submission envelope; salts are materials

### DIFF
--- a/src/battinfo/api.py
+++ b/src/battinfo/api.py
@@ -1263,6 +1263,70 @@ def _curated_cell_spec_title(record: Mapping[str, Any]) -> str:
     return str(product.get("name") or f"{manufacturer or 'Battery'} {product.get('model') or 'Cell'}").strip()
 
 
+def build_submission_envelope(
+    *,
+    resource_type: str,
+    records: Mapping[str, Mapping[str, Any]],
+    rdf_type: str | None,
+    workspace_id: str,
+    publisher_id: str,
+    source_version: str,
+    source_local_id: str,
+    title: str,
+    publication_mode: str,
+    source_system: str,
+    workflow_name: str,
+    related_resources: Sequence[dict[str, Any]] | None = None,
+    distributions: Sequence[dict[str, Any]] | None = None,
+    preview: dict[str, Any] | None = None,
+    workspace: dict[str, Any] | None = None,
+    validation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """The ONE submission-envelope builder (beta-hardening 4.3).
+
+    Every path that talks to the registry — the authoring workspace, the
+    curated editorial pipeline, and anything future — builds its envelope
+    here, so the shape can never fork again. Callers differ only in the
+    fields that SHOULD differ: publication mode, provenance system/workflow,
+    the embedded records, and the validation verdict.
+    """
+    generated_at = _now_iso()
+    semantic_payload: dict[str, Any] = {}
+    if rdf_type:
+        semantic_payload["@type"] = rdf_type
+    semantic_payload["battinfo_records"] = {k: dict(v) for k, v in records.items()}
+    if preview:
+        semantic_payload["preview"] = preview
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "BattinfoSubmission",
+        "submission_mode": "resource",
+        "generated_at": generated_at,
+        "workspace_id": workspace_id,
+        "publisher_id": publisher_id,
+        "source_version": source_version,
+        "title": title,
+        "publication_intent": {"mode": publication_mode},
+        "provenance": {
+            "source_system": source_system,
+            "workflow_name": workflow_name,
+            "generated_at": generated_at,
+        },
+        "release": {"version": source_version},
+        "workspace": workspace,
+        "resource": {
+            "resource_type": resource_type,
+            "source_local_id": source_local_id,
+            "title": title,
+            "semantic_payload": semantic_payload,
+            "related_resources": list(related_resources or []),
+            "distributions": list(distributions or []),
+        },
+        "artifacts": [],
+        "validation": validation or {"ok": True, "errors": [], "policy": "default"},
+    }
+
+
 def _curated_cell_spec_submission_resource(
     *,
     record: Mapping[str, Any],
@@ -1305,7 +1369,6 @@ def build_curated_cell_spec_submission(
         raise ValueError(f"curated cell-spec validation failed: {'; '.join(validation.errors)}")
 
     resolved_title = title or _curated_cell_spec_title(record)
-    generated_at = _now_iso()
     workspace: dict[str, Any] | None = None
     if source_path is not None:
         workspace = {
@@ -1315,35 +1378,25 @@ def build_curated_cell_spec_submission(
             }
         }
 
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "kind": "BattinfoSubmission",
-        "submission_mode": "resource",
-        "generated_at": generated_at,
-        "workspace_id": workspace_id,
-        "publisher_id": publisher_id,
-        "source_version": source_version,
-        "title": resolved_title,
-        "publication_intent": {"mode": publication_mode},
-        "provenance": {
-            "source_system": source_system,
-            "workflow_name": workflow_name,
-            "generated_at": generated_at,
-        },
-        "release": {"version": source_version},
-        "workspace": workspace,
-        "resource": _curated_cell_spec_submission_resource(
-            record=record,
-            source_local_id=resolved_source_local_id,
-            title=resolved_title,
-        ),
-        "artifacts": [],
-        "validation": {
+    return build_submission_envelope(
+        resource_type="cell_spec",
+        records={"cell_spec": record},
+        rdf_type="CellSpec",
+        workspace_id=workspace_id,
+        publisher_id=publisher_id,
+        source_version=source_version,
+        source_local_id=resolved_source_local_id,
+        title=resolved_title,
+        publication_mode=publication_mode,
+        source_system=source_system,
+        workflow_name=workflow_name,
+        workspace=workspace,
+        validation={
             "ok": validation.ok,
             "errors": list(validation.errors),
             "policy": validation.policy,
         },
-    }
+    )
 
 
 class RegistryError(RuntimeError):

--- a/src/battinfo/authoring.py
+++ b/src/battinfo/authoring.py
@@ -302,7 +302,7 @@ def electrolyte_recipe(
     *,
     family: str,
     solvents: str | MaterialComponent | Sequence[str | MaterialComponent] | None = None,
-    salt: str | Salt | None = None,
+    salt: str | Salt | MaterialComponent | None = None,
     salt_concentration: dict[str, Any] | None = None,
     additives: str | MaterialComponent | Sequence[str | MaterialComponent] | None = None,
     properties: PropertySet | None = None,
@@ -316,9 +316,12 @@ def electrolyte_recipe(
             ``"solid"``, ``"gel"``, ``"hybrid"``, or ``"unknown"``.
         solvents: Solvent component(s) — name string(s) or :class:`MaterialComponent`
             objects.  Use :func:`material` to attach volume-fraction properties.
-        salt: Salt name string or pre-built :class:`Salt` object.
-        salt_concentration: Concentration quantity dict, e.g.
-            ``{"value": 1.0, "unit": "mol/L"}``.  Only used when ``salt`` is a string.
+        salt: The salt, in the SAME form as a solvent entry — a
+            :func:`material` component carrying its properties inline, e.g.
+            ``salt=material("LiPF6", concentration={"value": 1.0, "unit": "mol/L"})``
+            — or a bare name string, or a pre-built :class:`Salt`.
+        salt_concentration: Concentration quantity dict; only used when ``salt``
+            is a bare string (the ``material(...)`` form carries it inline).
         additives: Optional electrolyte additive(s).
         properties: Bulk electrolyte properties (ionic conductivity, viscosity, etc.).
         solvent_comment: Free-text note about the solvent mixture.
@@ -326,6 +329,24 @@ def electrolyte_recipe(
     """
     if isinstance(salt, Salt):
         salt_obj = salt
+    elif isinstance(salt, MaterialComponent):
+        # Salts are materials like any other component; accept the same
+        # material(...) form as solvents. molecular_formula has no home on a
+        # salt record (use cation=/anion= on Salt) — refuse rather than drop.
+        if salt.molecular_formula is not None:
+            raise ValueError(
+                "salt components do not carry molecular_formula — build a "
+                "Salt(name=..., cation=..., anion=...) instead."
+            )
+        salt_obj = Salt(
+            name=salt.name,
+            material_spec_id=salt.material_spec_id,
+            manufacturer=salt.manufacturer,
+            supplier=salt.supplier,
+            product_id=salt.product_id,
+            property=salt.property,
+            comment=salt.comment,
+        )
     elif isinstance(salt, str):
         salt_properties = PropertySet()
         if salt_concentration is not None:

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -1050,6 +1050,7 @@ class Salt(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
+    material_spec_id: str | None = Field(default=None, description="Optional canonical IRI of a standalone material-spec for the salt — the same MaterialSpec -> Material link every other component material carries.")
     cation: str | None = None
     anion: str | None = None
     manufacturer: str | None = None

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -6189,6 +6189,19 @@ def _now_iso() -> str:
     return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
+def _authoring_envelope(**kwargs) -> dict:
+    """All authoring-workspace submissions share ONE envelope core (api.py, 4.3);
+    only the staged mode and authoring provenance identify this path."""
+    from battinfo.api import build_submission_envelope  # noqa: PLC0415
+
+    return build_submission_envelope(
+        publication_mode=STAGED_PUBLICATION_MODE,
+        source_system="battinfo-authoring",
+        workflow_name="authoring-workspace-submission",
+        **kwargs,
+    )
+
+
 def _cell_spec_submission_payload(
     record: dict,
     *,
@@ -6199,37 +6212,17 @@ def _cell_spec_submission_payload(
     title: str,
     related_resources: list[dict] | None = None,
 ) -> dict:
-    return {
-        "schema_version": "0.1.0",
-        "kind": "BattinfoSubmission",
-        "submission_mode": "resource",
-        "generated_at": _now_iso(),
-        "workspace_id": wid,
-        "publisher_id": pid,
-        "source_version": ver,
-        "title": title,
-        "publication_intent": {"mode": STAGED_PUBLICATION_MODE},
-        "provenance": {
-            "source_system": "battinfo-authoring",
-            "workflow_name": "authoring-workspace-submission",
-            "generated_at": _now_iso(),
-        },
-        "release": {"version": ver},
-        "workspace": None,
-        "resource": {
-            "resource_type": "cell_spec",
-            "source_local_id": source_local_id,
-            "title": title,
-            "semantic_payload": {
-                "@type": "CellSpec",
-                "battinfo_records": {"cell_spec": record},
-            },
-            "related_resources": related_resources or [],
-            "distributions": [],
-        },
-        "artifacts": [],
-        "validation": {"ok": True, "errors": [], "policy": "default"},
-    }
+    return _authoring_envelope(
+        resource_type="cell_spec",
+        records={"cell_spec": record},
+        rdf_type="CellSpec",
+        workspace_id=wid,
+        publisher_id=pid,
+        source_version=ver,
+        source_local_id=source_local_id,
+        title=title,
+        related_resources=related_resources,
+    )
 
 
 def _find_spec_record(cell_spec_dir: Path, cell_spec_id: str) -> dict | None:
@@ -6271,44 +6264,18 @@ def _cell_instance_submission_payload(
                 "canonical_iri": cell_spec_id,
             })
 
-    semantic_payload: dict = {
-        "@type": "Cell",
-        "battinfo_records": {
-            "cell": record,
-            **({"cell_spec": spec_record} if spec_record else {}),
-        },
-    }
-    if preview:
-        semantic_payload["preview"] = preview
-
-    return {
-        "schema_version": "0.1.0",
-        "kind": "BattinfoSubmission",
-        "submission_mode": "resource",
-        "generated_at": _now_iso(),
-        "workspace_id": wid,
-        "publisher_id": pid,
-        "source_version": ver,
-        "title": title,
-        "publication_intent": {"mode": STAGED_PUBLICATION_MODE},
-        "provenance": {
-            "source_system": "battinfo-authoring",
-            "workflow_name": "authoring-workspace-submission",
-            "generated_at": _now_iso(),
-        },
-        "release": {"version": ver},
-        "workspace": None,
-        "resource": {
-            "resource_type": "cell",
-            "source_local_id": source_local_id,
-            "title": title,
-            "semantic_payload": semantic_payload,
-            "related_resources": related,
-            "distributions": [],
-        },
-        "artifacts": [],
-        "validation": {"ok": True, "errors": [], "policy": "default"},
-    }
+    return _authoring_envelope(
+        resource_type="cell",
+        records={"cell": record, **({"cell_spec": spec_record} if spec_record else {})},
+        rdf_type="Cell",
+        workspace_id=wid,
+        publisher_id=pid,
+        source_version=ver,
+        source_local_id=source_local_id,
+        title=title,
+        related_resources=related,
+        preview=preview,
+    )
 
 
 def _build_dataset_distributions(ds: dict) -> tuple[list[dict], list[dict]]:
@@ -6366,40 +6333,19 @@ def _simple_submission_payload(
                 "resource_type": "cell",
                 "canonical_iri": related_cell_id,
             })
-    semantic_payload: dict = {
-        "@type": rdf_type,
-        "battinfo_records": {record_key: record},
-    }
-    if preview:
-        semantic_payload["preview"] = preview
-    return {
-        "schema_version": "0.1.0",
-        "kind": "BattinfoSubmission",
-        "submission_mode": "resource",
-        "generated_at": _now_iso(),
-        "workspace_id": wid,
-        "publisher_id": pid,
-        "source_version": ver,
-        "title": title,
-        "publication_intent": {"mode": STAGED_PUBLICATION_MODE},
-        "provenance": {
-            "source_system": "battinfo-authoring",
-            "workflow_name": "authoring-workspace-submission",
-            "generated_at": _now_iso(),
-        },
-        "release": {"version": ver},
-        "workspace": None,
-        "resource": {
-            "resource_type": resource_type,
-            "source_local_id": source_local_id,
-            "title": title,
-            "semantic_payload": semantic_payload,
-            "related_resources": related,
-            "distributions": distributions or [],
-        },
-        "artifacts": [],
-        "validation": {"ok": True, "errors": [], "policy": "default"},
-    }
+    return _authoring_envelope(
+        resource_type=resource_type,
+        records={record_key: record},
+        rdf_type=rdf_type,
+        workspace_id=wid,
+        publisher_id=pid,
+        source_version=ver,
+        source_local_id=source_local_id,
+        title=title,
+        related_resources=related,
+        distributions=distributions,
+        preview=preview,
+    )
 
 
 def _lift_funding_to_provenance(payload: dict) -> None:

--- a/tests/test_salt_as_material.py
+++ b/tests/test_salt_as_material.py
@@ -1,0 +1,48 @@
+"""Salts are materials: electrolyte_recipe accepts the same material() form as solvents."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.authoring import electrolyte_recipe, material  # noqa: E402
+from battinfo.bundle import Salt  # noqa: E402
+
+
+def test_salt_accepts_the_material_component_form() -> None:
+    e = electrolyte_recipe(
+        family="organic",
+        solvents=[material("EC", volume_fraction={"value": 50, "unit": "%"})],
+        salt=material("LiPF6", concentration={"value": 1.0, "unit": "mol/L"}),
+    )
+    assert isinstance(e.salt, Salt)
+    assert e.salt.name == "LiPF6"
+    assert e.salt.property["concentration"] == {"value": 1.0, "unit": "mol/L"}
+
+
+def test_salt_material_keeps_its_materialspec_link() -> None:
+    spec_iri = "https://w3id.org/battinfo/material-spec/7d9k-2m4p-8t3x-6nq5"
+    component = material("LiPF6", concentration={"value": 1.0, "unit": "mol/L"})
+    component.material_spec_id = spec_iri
+    e = electrolyte_recipe(family="organic", salt=component)
+    assert e.salt is not None and e.salt.material_spec_id == spec_iri, (
+        "the MaterialSpec -> Material link must survive — salts are materials too"
+    )
+
+
+def test_salt_with_molecular_formula_refuses_instead_of_dropping() -> None:
+    component = material("LiPF6")
+    component.molecular_formula = "LiPF6"
+    with pytest.raises(ValueError, match="cation="):
+        electrolyte_recipe(family="organic", salt=component)
+
+
+def test_string_salt_with_concentration_still_works() -> None:
+    e = electrolyte_recipe(
+        family="organic", salt="LiPF6", salt_concentration={"value": 1.0, "unit": "mol/L"}
+    )
+    assert e.salt is not None and e.salt.name == "LiPF6"

--- a/tests/test_submission_envelope.py
+++ b/tests/test_submission_envelope.py
@@ -1,0 +1,63 @@
+"""Every registry submission path builds its envelope in ONE place (4.3).
+
+The authoring workspace and the curated editorial pipeline used to parallel-
+build their envelopes in ws.py and api.py; they forked (envelope version,
+payload shape) without anyone noticing. Both now delegate to
+api.build_submission_envelope — this test pins that the two paths differ ONLY
+in the fields that should differ.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api import build_curated_cell_spec_submission  # noqa: E402
+from battinfo.bundle import SCHEMA_VERSION  # noqa: E402
+from battinfo.ws import _cell_spec_submission_payload  # noqa: E402
+
+RECORD_FILE = ROOT / "examples" / "cell-spec" / "A123__ANR26650M1-B.json"
+
+# Fields that legitimately differ between the authoring and curated paths.
+INTENDED_DIFFERENCES = {"publication_intent", "provenance", "validation", "workspace", "generated_at"}
+
+
+def _normalise(payload: dict) -> dict:
+    return {k: v for k, v in payload.items() if k not in INTENDED_DIFFERENCES}
+
+
+def test_authoring_and_curated_envelopes_share_one_shape() -> None:
+    record = json.loads(RECORD_FILE.read_text(encoding="utf-8"))
+
+    authoring = _cell_spec_submission_payload(
+        record, wid="w", pid="p", ver="v1",
+        source_local_id="a123-anr26650m1-b", title="A123 ANR26650M1-B",
+    )
+    curated = build_curated_cell_spec_submission(
+        RECORD_FILE, workspace_id="w", publisher_id="p", source_version="v1",
+        source_local_id="a123-anr26650m1-b", title="A123 ANR26650M1-B",
+    )
+
+    assert set(authoring) == set(curated), "envelope key sets forked"
+    assert _normalise(authoring) == _normalise(curated), (
+        "the two submission paths produced different envelopes outside the "
+        f"intended fields {sorted(INTENDED_DIFFERENCES)}"
+    )
+    # The intended differences say what they should say.
+    assert authoring["publication_intent"]["mode"] == "staged-publication"
+    assert curated["publication_intent"]["mode"] == "canonical-publication"
+    assert authoring["provenance"]["source_system"] == "battinfo-authoring"
+    assert curated["provenance"]["source_system"] == "battinfo-records"
+
+
+def test_envelope_version_is_the_single_constant() -> None:
+    record = json.loads(RECORD_FILE.read_text(encoding="utf-8"))
+    payload = _cell_spec_submission_payload(
+        record, wid="w", pid="p", ver="v1", source_local_id="x", title="t",
+    )
+    assert payload["schema_version"] == SCHEMA_VERSION, (
+        "the authoring envelope hardcoded 0.1.0 for months — it must track SCHEMA_VERSION"
+    )


### PR DESCRIPTION
- The authoring workspace and the curated pipeline parallel-built their   registry submission envelopes and had forked (the authoring path hardcoded  envelope schema_version 0.1.0 and a placeholder validation block). Both now   delegate to one builder, api.build_submission_envelope; a test pins the two   paths to a single shape so they can't fork again.
- electrolyte_recipe(salt=...) accepts the same material() component form as   solvents — concentration and the MaterialSpec link travel inline (Salt gains the material_spec_id field the JSON schema always allowed). Unsupported fields are refused with a teaching error, never dropped silently.

1296 tests pass; ruff + mypy clean. No schema changes.