### PR TITLE
one tutorial story, Diátaxis structure, two-line notebook bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ docs/_build
 # Editor
 .vscode/
 catalog-v001.xml
+
+# Guide-notebook scratch outputs (created when running docs/guides/*.ipynb)
+docs/guides/_scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **The tutorials tell one story on the modern API.** Tutorial 3 (linked
+  records) is rewritten on `battinfo.workspace()` — cells, a draft-file test
+  spec with PyBaMM steps, a test with data, save, validation, a publication
+  preview, and guarded publishing; the deprecated engine no longer appears in
+  any notebook. Tutorial 2 sheds the material-level walkthrough that
+  duplicated Tutorial 5 step-for-step and instead teaches the
+  spec-and-instance model for materials (salts as `material(...)`, lifting
+  components to standalone material specs). Tutorial 5 gains that lifting as
+  a step of its own and now publishes the descriptor record directly.
+- **Notebook bootstrap is two lines.** Notebooks run from their own folder
+  (as nbmake/nbconvert always did) and write to a gitignored
+  `docs/guides/_scratch/` directory — the cwd-detection/chdir preamble and
+  `.battinfo/notebooks/` are gone.
+- **Docs follow Diátaxis.** "Guides" are now *Tutorials* (learning-oriented,
+  ordered, with a what-you-learn/time table); *How-to guides* state that they
+  are task recipes; the landing page links the four quadrants explicitly.
+  `getting-started` and `python-api` are rewritten around `workspace()` and
+  the models (the engine appears only as an "advanced: internal" note), and
+  the test-protocol semantic-depth essay moved from Tutorial 3 into the
+  `test-specs` explanation page.
+- `ws.convert()` without the BDF converter now points at
+  `pip install "battinfo[processing]"`; README/QUICKSTART/getting-started
+  document the extras.
+
+### Fixed
+
+- **`ws.preview_jsonld()` crashed on any workspace whose cells carry a
+  production date**: records store `manufactured_at` as a Unix timestamp, but
+  the publication assembler assumed a string (`AttributeError: 'int' object
+  has no attribute 'strip'`). Timestamps now become UTC `xsd:date` values.
+- **The gold-standard JSON-LD check rejected the library's own test-spec
+  method graphs** (8 errors for `IterativeWorkflow`, `VoltageHold`,
+  `Duration`, ...): the validator's allowed term set now includes the
+  test-method vocabulary the emitter draws from the bundled context, with a
+  can't-drift regression test.
+- Two self-contradicting docstrings: `ws.add`'s example used
+  `production_date="2026-01"` (a value it rejects — full dates required) and
+  `construction()` suggested `layering="jelly-roll"` (not in the schema enum).
+
+
 ### Fixed
 
 - **Unit mappings corrected at the source** (`unit_map.curated.json` + packaged copy):

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,6 +24,9 @@ If in doubt, start with `battinfo.workspace(".")` — it wraps everything else. 
 pip install battinfo
 ```
 
+> Converting raw cycler files (`ws.convert()`) needs the BDF converter:
+> `pip install "battinfo[processing]"`.
+
 ---
 
 ## 1. Create your first cell-spec record
@@ -91,7 +94,7 @@ print(jsonld["schema:size"])     # R18650
 
 BattINFO automatically stacks EMMO types based on the cell's format and chemistry. A cylindrical Li-ion cell is simultaneously `BatteryCell`, `CylindricalBattery`, and `LithiumIonBattery` — no manual annotation needed.
 
-The resolver JSON-LD is the lightweight document served at the cell's IRI. The full EMMO-aligned publication package — with `hasProperty` nodes for each quantitative specification — is produced by `workspace.build_publication_package()` (see [Guide 3](docs/guides/03-linked-records.ipynb)).
+The resolver JSON-LD is the lightweight document served at the cell's IRI. The full EMMO-aligned publication package — with `hasProperty` nodes for each quantitative specification — is produced when you publish (see [Tutorial 3](docs/guides/03-linked-records.ipynb)).
 
 ---
 
@@ -126,13 +129,13 @@ In four steps you have:
 
 ## Next steps
 
-The guide notebooks in `docs/guides/` continue the walkthrough interactively. Open them from the repo root with the `.venv` kernel selected.
+The tutorial notebooks in `docs/guides/` continue the walkthrough interactively. Each notebook runs from its own folder and writes only to a throwaway `_scratch/` directory next to it.
 
 | Notebook | What you'll learn |
 |---|---|
-| [01 — Concepts](docs/guides/01-concepts.ipynb) | The data model, record types, and how IRIs work |
-| [02 — First cell spec](docs/guides/02-first-cell-type.ipynb) | Full cell-spec authoring: specs, provenance, CLI and Python paths |
-| [03 — Linked records](docs/guides/03-linked-records.ipynb) | Cell instance → test → dataset provenance chain |
-| [04 — Semantic layer](docs/guides/04-semantic-layer.ipynb) | JSON-LD, EMMO alignment, validation, and RDF queries |
-| [05 — Descriptors](docs/guides/05-descriptors.ipynb) | Deep cell descriptors: electrodes, electrolyte, separator |
-| [06 — Publish your data](docs/guides/06-publish-your-data.ipynb) | End to end: raw cycler CSV → validated records → DOI + registry |
+| [1 — Concepts](docs/guides/01-concepts.ipynb) | The record model, IRIs, and the semantic layer |
+| [2 — Describing a cell](docs/guides/02-first-cell-type.ipynb) | Author and publish a cell spec, with a taste of material-level depth |
+| [3 — Linked records](docs/guides/03-linked-records.ipynb) | Cells, test specs, tests, and datasets with the workspace |
+| [4 — Semantic layer](docs/guides/04-semantic-layer.ipynb) | JSON-LD anatomy, EMMO type stacking, RDF and SPARQL |
+| [5 — Cell descriptors](docs/guides/05-descriptors.ipynb) | Research-grade composition: materials, BOMs, electrodes, electrolyte |
+| [6 — Publish your first dataset](docs/guides/06-publish-your-data.ipynb) | End to end: raw cycler CSV → validated records → DOI + registry |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and resolvable through persistent `https://w3id.org/battinfo/` identifiers.
 
 [**Quickstart**](QUICKSTART.md) ·
 [**Documentation**](docs/index.md) ·
-[**Guide notebooks**](#guide-notebooks) ·
+[**Tutorials**](#tutorials) ·
 [**Contributing**](#contributing) ·
 [**Cite**](#citation)
 
@@ -57,7 +57,7 @@ queryable with SPARQL, and Battery Pass-compatible out of the box.
 - [Why BattINFO](#why-battinfo)
 - [Installation](#installation)
 - [Quickstart](#quickstart)
-- [Guide notebooks](#guide-notebooks)
+- [Tutorials](#tutorials)
 - [What BattINFO does](#what-battinfo-does)
 - [Semantic foundation](#semantic-foundation)
 - [Project status](#project-status)
@@ -85,9 +85,10 @@ Requires **Python 3.11+**.
 pip install battinfo
 ```
 
-Optional extras: `battinfo[storage]` (S3), `battinfo[processing]` (data
-analysis), `battinfo[docs]` (Sphinx), and `battinfo[dev]` (full test/lint/build
-toolchain).
+Optional extras: `battinfo[processing]` (cycler-file conversion via `ws.convert()`
++ plotting), `battinfo[tabular]` (CSV/Parquet/XLSX readers), `battinfo[publish]`
+(RO-Crate validation), `battinfo[storage]` (S3), `battinfo[docs]` (Sphinx), and
+`battinfo[dev]` (full test/lint/build toolchain).
 
 **Developing on BattINFO?** This repo uses [uv](https://docs.astral.sh/uv/):
 
@@ -135,19 +136,20 @@ maps the three entry points (workspace, models + `publish`, `battinfo.Workspace`
 
 **→ Read the [full quickstart](QUICKSTART.md) and the [documentation index](docs/index.md).**
 
-## Guide notebooks
+## Tutorials
 
-Interactive Jupyter notebooks in [`docs/guides/`](docs/guides/) — open from the
-repo root with the `.venv` kernel.
+Six tutorial notebooks in [`docs/guides/`](docs/guides/) — one story, from the
+record model to a published dataset. Each runs from its own folder and writes
+only to a throwaway `_scratch/` directory next to it.
 
-| Notebook | What you'll learn |
+| Tutorial | What you'll learn |
 |---|---|
-| [01 — Concepts](docs/guides/01-concepts.ipynb) | Data model, record types, IRIs, and the semantic layer |
-| [02 — First cell spec](docs/guides/02-first-cell-type.ipynb) | Materials → components → cell spec → publish |
-| [03 — Linked records](docs/guides/03-linked-records.ipynb) | Cell instance → test → dataset → registry submission |
-| [04 — Semantic layer](docs/guides/04-semantic-layer.ipynb) | JSON-LD anatomy, EMMO type stacking, RDF and SPARQL |
-| [05 — Descriptors](docs/guides/05-descriptors.ipynb) | Research-grade descriptors: electrodes, electrolyte, separator |
-| [06 — Publish your data](docs/guides/06-publish-your-data.ipynb) | End to end: raw cycler CSV → validated records → DOI + registry |
+| [1 — Concepts](docs/guides/01-concepts.ipynb) | The record model, IRIs, and the semantic layer |
+| [2 — Describing a cell](docs/guides/02-first-cell-type.ipynb) | Author and publish a cell spec, with a taste of material-level depth |
+| [3 — Linked records](docs/guides/03-linked-records.ipynb) | Cells, test specs, tests, and datasets with the workspace |
+| [4 — Semantic layer](docs/guides/04-semantic-layer.ipynb) | JSON-LD anatomy, EMMO type stacking, RDF and SPARQL |
+| [5 — Cell descriptors](docs/guides/05-descriptors.ipynb) | Research-grade composition: materials, BOMs, electrodes, electrolyte |
+| [6 — Publish your first dataset](docs/guides/06-publish-your-data.ipynb) | End to end: raw cycler CSV → validated records → DOI + registry |
 
 ## What BattINFO does
 

--- a/docs/guides/01-concepts.ipynb
+++ b/docs/guides/01-concepts.ipynb
@@ -12,6 +12,8 @@
     "\n",
     "This guide explains the data model, record types, and the semantic layer.\n",
     "\n",
+    "*Already have cycler data on disk? Jump straight to [Guide 6 — Publish your first dataset](06-publish-your-data.ipynb) and come back here for the concepts.*\n",
+    "\n",
     "**Estimated time:** 10 minutes"
    ]
   },
@@ -21,35 +23,21 @@
    "id": "d1bde660",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:35.174572Z",
-     "iopub.status.busy": "2026-07-06T20:02:35.173557Z",
-     "iopub.status.idle": "2026-07-06T20:02:35.181967Z",
-     "shell.execute_reply": "2026-07-06T20:02:35.181967Z"
+     "iopub.execute_input": "2026-07-07T08:09:11.910576Z",
+     "iopub.status.busy": "2026-07-07T08:09:11.910576Z",
+     "iopub.status.idle": "2026-07-07T08:09:11.931728Z",
+     "shell.execute_reply": "2026-07-07T08:09:11.929712Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running from the repo root.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os, json, warnings\n",
+    "import json\n",
     "from pathlib import Path\n",
     "\n",
-    "_here = Path.cwd()\n",
-    "if (_here / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here\n",
-    "elif (_here.parent.parent / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here.parent.parent\n",
-    "    os.chdir(REPO)\n",
-    "else:\n",
-    "    REPO = _here\n",
-    "\n",
-    "print(\"Running from the repo root.\")"
+    "# This notebook runs from its own folder (docs/guides). Everything it\n",
+    "# writes lands in a throwaway scratch folder next to it.\n",
+    "SCRATCH = Path(\"_scratch/guide-01\").resolve()\n",
+    "SCRATCH.mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
@@ -92,10 +80,10 @@
    "id": "af9f7f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:35.181967Z",
-     "iopub.status.busy": "2026-07-06T20:02:35.181967Z",
-     "iopub.status.idle": "2026-07-06T20:02:35.193775Z",
-     "shell.execute_reply": "2026-07-06T20:02:35.193775Z"
+     "iopub.execute_input": "2026-07-07T08:09:11.942767Z",
+     "iopub.status.busy": "2026-07-07T08:09:11.940785Z",
+     "iopub.status.idle": "2026-07-07T08:09:11.958126Z",
+     "shell.execute_reply": "2026-07-07T08:09:11.958126Z"
     }
    },
    "outputs": [
@@ -113,7 +101,8 @@
    "source": [
     "# Load the canonical A123 cell-spec record that ships with the repo\n",
     "a123 = json.loads(\n",
-    "    (REPO / \"examples/cell-spec/A123__ANR26650M1-B.json\").read_text(encoding=\"utf-8\")\n",
+    "    # Repo files sit two levels up from this notebook.\n",
+    "    Path(\"../../examples/cell-spec/A123__ANR26650M1-B.json\").read_text(encoding=\"utf-8\")\n",
     ")\n",
     "\n",
     "# Top-level structure\n",
@@ -126,10 +115,10 @@
    "id": "2876af4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:35.193775Z",
-     "iopub.status.busy": "2026-07-06T20:02:35.193775Z",
-     "iopub.status.idle": "2026-07-06T20:02:35.201411Z",
-     "shell.execute_reply": "2026-07-06T20:02:35.201411Z"
+     "iopub.execute_input": "2026-07-07T08:09:11.958126Z",
+     "iopub.status.busy": "2026-07-07T08:09:11.958126Z",
+     "iopub.status.idle": "2026-07-07T08:09:11.973220Z",
+     "shell.execute_reply": "2026-07-07T08:09:11.973220Z"
     }
    },
    "outputs": [
@@ -172,10 +161,10 @@
    "id": "8d47a257",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:35.203996Z",
-     "iopub.status.busy": "2026-07-06T20:02:35.203996Z",
-     "iopub.status.idle": "2026-07-06T20:02:35.210863Z",
-     "shell.execute_reply": "2026-07-06T20:02:35.210347Z"
+     "iopub.execute_input": "2026-07-07T08:09:11.973220Z",
+     "iopub.status.busy": "2026-07-07T08:09:11.973220Z",
+     "iopub.status.idle": "2026-07-07T08:09:11.990070Z",
+     "shell.execute_reply": "2026-07-07T08:09:11.989061Z"
     }
    },
    "outputs": [
@@ -312,10 +301,10 @@
    "id": "e85e0b8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:35.212243Z",
-     "iopub.status.busy": "2026-07-06T20:02:35.212243Z",
-     "iopub.status.idle": "2026-07-06T20:02:35.217196Z",
-     "shell.execute_reply": "2026-07-06T20:02:35.217196Z"
+     "iopub.execute_input": "2026-07-07T08:09:11.996714Z",
+     "iopub.status.busy": "2026-07-07T08:09:11.995712Z",
+     "iopub.status.idle": "2026-07-07T08:09:12.008667Z",
+     "shell.execute_reply": "2026-07-07T08:09:12.006652Z"
     }
    },
    "outputs": [
@@ -365,10 +354,10 @@
    "id": "e670cfbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:35.220257Z",
-     "iopub.status.busy": "2026-07-06T20:02:35.217196Z",
-     "iopub.status.idle": "2026-07-06T20:02:37.020874Z",
-     "shell.execute_reply": "2026-07-06T20:02:37.019845Z"
+     "iopub.execute_input": "2026-07-07T08:09:12.013167Z",
+     "iopub.status.busy": "2026-07-07T08:09:12.011660Z",
+     "iopub.status.idle": "2026-07-07T08:09:13.730557Z",
+     "shell.execute_reply": "2026-07-07T08:09:13.729543Z"
     }
    },
    "outputs": [
@@ -396,7 +385,7 @@
     "    },\n",
     ")\n",
     "\n",
-    "result = publish(cell_spec, destination=\"local\", root=REPO / \".battinfo/notebooks/guide-01\")\n",
+    "result = publish(cell_spec, destination=\"local\", root=SCRATCH)\n",
     "print(\"IRI:\", result.canonical_iri)"
    ]
   },
@@ -406,10 +395,10 @@
    "id": "0f9bd621",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:37.023310Z",
-     "iopub.status.busy": "2026-07-06T20:02:37.023310Z",
-     "iopub.status.idle": "2026-07-06T20:02:37.164183Z",
-     "shell.execute_reply": "2026-07-06T20:02:37.164183Z"
+     "iopub.execute_input": "2026-07-07T08:09:13.740730Z",
+     "iopub.status.busy": "2026-07-07T08:09:13.738717Z",
+     "iopub.status.idle": "2026-07-07T08:09:14.803463Z",
+     "shell.execute_reply": "2026-07-07T08:09:14.800436Z"
     }
    },
    "outputs": [
@@ -426,7 +415,7 @@
     "\n",
     "output = publish_record(\n",
     "    result.debug_paths[\"canonical_record_path\"],\n",
-    "    target_root=REPO / \".battinfo/notebooks/guide-01-jsonld\",\n",
+    "    target_root=SCRATCH / \"resolver\",\n",
     ")\n",
     "jsonld = json.loads(\n",
     "    Path(output[\"output_dir\"], \"index.jsonld\").read_text(encoding=\"utf-8\")\n",
@@ -442,10 +431,10 @@
    "id": "50971f8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:37.168799Z",
-     "iopub.status.busy": "2026-07-06T20:02:37.168799Z",
-     "iopub.status.idle": "2026-07-06T20:02:37.176879Z",
-     "shell.execute_reply": "2026-07-06T20:02:37.175869Z"
+     "iopub.execute_input": "2026-07-07T08:09:14.813044Z",
+     "iopub.status.busy": "2026-07-07T08:09:14.811448Z",
+     "iopub.status.idle": "2026-07-07T08:09:14.827108Z",
+     "shell.execute_reply": "2026-07-07T08:09:14.825073Z"
     }
    },
    "outputs": [
@@ -454,8 +443,8 @@
      "output_type": "stream",
      "text": [
       "Properties:\n",
-      "  NominalCapacity: None  [AmpereHour]\n",
-      "  NominalVoltage: None  [Volt]\n"
+      "  NominalCapacity: 2.5  [AmpereHour]\n",
+      "  NominalVoltage: 3.3  [Volt]\n"
      ]
     }
    ],
@@ -464,7 +453,7 @@
     "print(\"Properties:\")\n",
     "for prop in jsonld.get(\"hasProperty\", []):\n",
     "    class_name = prop[\"@type\"][0] if isinstance(prop[\"@type\"], list) else prop[\"@type\"]\n",
-    "    value = prop.get(\"hasNumericalPart\", {}).get(\"hasNumericalValue\")\n",
+    "    value = prop.get(\"hasNumericalPart\", {}).get(\"hasNumberValue\")\n",
     "    unit  = prop.get(\"hasMeasurementUnit\", \"\").split(\"#\")[-1]\n",
     "    print(f\"  {class_name}: {value}  [{unit}]\")"
    ]
@@ -485,10 +474,10 @@
    "id": "4bb41daf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:37.180420Z",
-     "iopub.status.busy": "2026-07-06T20:02:37.179876Z",
-     "iopub.status.idle": "2026-07-06T20:02:37.185359Z",
-     "shell.execute_reply": "2026-07-06T20:02:37.184783Z"
+     "iopub.execute_input": "2026-07-07T08:09:14.835105Z",
+     "iopub.status.busy": "2026-07-07T08:09:14.834095Z",
+     "iopub.status.idle": "2026-07-07T08:09:14.844075Z",
+     "shell.execute_reply": "2026-07-07T08:09:14.843560Z"
     }
    },
    "outputs": [
@@ -496,7 +485,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JSON-LD exported to: .battinfo\\notebooks\\guide-01-jsonld\\spec\\e4t5-w9re-mpq6-8g7e\\index.jsonld\n",
+      "JSON-LD exported to: <repo>\\docs\\guides\\_scratch\\guide-01\\resolver\\spec\\e4t5-w9re-mpq6-8g7e\\index.jsonld\n",
       "\n",
       "{\n",
       "  \"@context\": [\n",
@@ -547,7 +536,7 @@
    ],
    "source": [
     "jsonld_file = Path(output[\"output_dir\"]) / \"index.jsonld\"\n",
-    "print(f\"JSON-LD exported to: {jsonld_file.relative_to(REPO)}\")\n",
+    "print(f\"JSON-LD exported to: {jsonld_file}\")\n",
     "print()\n",
     "print(json.dumps(jsonld, indent=2))"
    ]
@@ -572,10 +561,10 @@
    "id": "bfc0b477",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:37.187362Z",
-     "iopub.status.busy": "2026-07-06T20:02:37.187362Z",
-     "iopub.status.idle": "2026-07-06T20:02:37.207466Z",
-     "shell.execute_reply": "2026-07-06T20:02:37.206713Z"
+     "iopub.execute_input": "2026-07-07T08:09:14.849734Z",
+     "iopub.status.busy": "2026-07-07T08:09:14.848733Z",
+     "iopub.status.idle": "2026-07-07T08:09:14.879401Z",
+     "shell.execute_reply": "2026-07-07T08:09:14.878394Z"
     }
    },
    "outputs": [
@@ -583,14 +572,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ok:"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " True | errors: 0 | warnings: 0\n"
+      "ok: True | errors: 0 | warnings: 0\n"
      ]
     }
    ],
@@ -602,7 +584,7 @@
     "\n",
     "report = validate_record_report(\n",
     "    record_doc,\n",
-    "    source_root=REPO / \".battinfo/notebooks/guide-01\",\n",
+    "    source_root=SCRATCH,\n",
     ")\n",
     "print(\"ok:\", report.ok, \"| errors:\", len(report.errors), \"| warnings:\", len(report.warnings))"
    ]
@@ -614,7 +596,7 @@
    "source": [
     "## Next\n",
     "\n",
-    "- **[Guide 2 — First cell spec](02-first-cell-type.ipynb)**: full authoring workflow from materials to published record\n",
+    "- **[Guide 2 — Describing a cell](02-first-cell-type.ipynb)**: author and publish a cell spec\n",
     "- **[Guide 3 — Linked records](03-linked-records.ipynb)**: build the complete provenance chain and publish"
    ]
   }

--- a/docs/guides/02-first-cell-type.ipynb
+++ b/docs/guides/02-first-cell-type.ipynb
@@ -5,14 +5,16 @@
    "id": "6aaf49a1",
    "metadata": {},
    "source": [
-    "# Guide 2 — Describing a cell: from materials to published record\n",
+    "# Guide 2 — Describing a cell\n",
     "\n",
-    "This guide covers BattINFO's full cell-description workflow — from authoring individual electrode and electrolyte components, through building a complete cell specification, to saving and publishing the record.\n",
+    "A cell spec is the product datasheet, as data. This guide authors one at\n",
+    "datasheet level and publishes it, then gives a taste of the material-level\n",
+    "depth BattINFO can carry — [Guide 5](05-descriptors.ipynb) goes all the way down.\n",
     "\n",
-    "**Estimated time:** 30 minutes\n",
+    "**Estimated time:** 15 minutes\n",
     "**Prerequisites:** [Guide 1 — Concepts](01-concepts.ipynb)\n",
     "\n",
-    "Everything writes under `.battinfo/notebooks/guide-02`."
+    "Everything this guide writes lands in `_scratch/guide-02/`."
    ]
   },
   {
@@ -21,40 +23,21 @@
    "id": "6aa2a3a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:43.398825Z",
-     "iopub.status.busy": "2026-07-06T20:02:43.398825Z",
-     "iopub.status.idle": "2026-07-06T20:02:43.407491Z",
-     "shell.execute_reply": "2026-07-06T20:02:43.407491Z"
+     "iopub.execute_input": "2026-07-07T08:09:28.564449Z",
+     "iopub.status.busy": "2026-07-07T08:09:28.563449Z",
+     "iopub.status.idle": "2026-07-07T08:09:28.577551Z",
+     "shell.execute_reply": "2026-07-07T08:09:28.576519Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running from the repo root.\n",
-      "Workspace: .battinfo\\notebooks\\guide-02\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os, json, warnings\n",
+    "import json\n",
     "from pathlib import Path\n",
     "\n",
-    "_here = Path.cwd()\n",
-    "if (_here / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here\n",
-    "elif (_here.parent.parent / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here.parent.parent\n",
-    "    os.chdir(REPO)\n",
-    "else:\n",
-    "    REPO = _here\n",
-    "\n",
-    "print(\"Running from the repo root.\")\n",
-    "\n",
-    "WORKSPACE = REPO / '.battinfo/notebooks/guide-02'\n",
-    "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
-    "print(\"Workspace:\", WORKSPACE.relative_to(REPO))"
+    "# This notebook runs from its own folder (docs/guides). Everything it\n",
+    "# writes lands in a throwaway scratch folder next to it.\n",
+    "SCRATCH = Path(\"_scratch/guide-02\").resolve()\n",
+    "SCRATCH.mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
@@ -62,7 +45,7 @@
    "id": "0604504d",
    "metadata": {},
    "source": [
-    "## Part 1 — Simple path (datasheet-level)\n",
+    "## Part 1 — The datasheet path\n",
     "\n",
     "Use this when you have a datasheet and want to describe a commercial cell quickly."
    ]
@@ -73,10 +56,10 @@
    "id": "3e2a2bcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:43.410105Z",
-     "iopub.status.busy": "2026-07-06T20:02:43.410105Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.133809Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.132793Z"
+     "iopub.execute_input": "2026-07-07T08:09:28.577551Z",
+     "iopub.status.busy": "2026-07-07T08:09:28.577551Z",
+     "iopub.status.idle": "2026-07-07T08:09:30.027700Z",
+     "shell.execute_reply": "2026-07-07T08:09:30.027700Z"
     }
    },
    "outputs": [
@@ -119,7 +102,7 @@
     "    },\n",
     ")\n",
     "\n",
-    "result = publish(cell_spec, destination=\"local\", root=WORKSPACE)\n",
+    "result = publish(cell_spec, destination=\"local\", root=SCRATCH)\n",
     "print(\"IRI:\", result.canonical_iri)"
    ]
   },
@@ -129,10 +112,10 @@
    "id": "0bd7097b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.135797Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.135797Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.142358Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.141350Z"
+     "iopub.execute_input": "2026-07-07T08:09:30.035995Z",
+     "iopub.status.busy": "2026-07-07T08:09:30.033974Z",
+     "iopub.status.idle": "2026-07-07T08:09:30.043963Z",
+     "shell.execute_reply": "2026-07-07T08:09:30.043963Z"
     }
    },
    "outputs": [
@@ -208,7 +191,7 @@
       "    \"source_type\": \"datasheet\",\n",
       "    \"source_name\": \"INR21700-50E Product Specification Rev 1.0\",\n",
       "    \"source_url\": \"https://example.com/samsung-inr21700-50e.pdf\",\n",
-      "    \"retrieved_at\": 1783368164,\n",
+      "    \"retrieved_at\": 1783411769,\n",
       "    \"battinfo_version\": \"0.7.0\"\n",
       "  }\n",
       "}\n"
@@ -227,10 +210,10 @@
    "id": "65e1f16b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.145357Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.145357Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.281273Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.280707Z"
+     "iopub.execute_input": "2026-07-07T08:09:30.047613Z",
+     "iopub.status.busy": "2026-07-07T08:09:30.047613Z",
+     "iopub.status.idle": "2026-07-07T08:09:30.880896Z",
+     "shell.execute_reply": "2026-07-07T08:09:30.878021Z"
     }
    },
    "outputs": [
@@ -241,16 +224,16 @@
       "@type: ['BatteryCellSpecification', 'schema:CreativeWork']\n",
       "\n",
       "Properties:\n",
-      "  NominalCapacity: — [AmpereHour]\n",
-      "  NominalVoltage: — [Volt]\n",
-      "  NominalEnergy: — [WattHour]\n",
-      "  Mass: — [Gram]\n",
-      "  Height: — [MilliMetre]\n",
-      "  Diameter: — [MilliMetre]\n",
-      "  MaximumContinuousChargingCurrent: — [Ampere]\n",
-      "  MaximumContinuousDischargingCurrent: — [Ampere]\n",
-      "  MaximumChargingTemperature: — [EMMO_36a9bf69_483b_42fd_8a0c_7ac9206320bc]\n",
-      "  MinimumDischargingTemperature: — [EMMO_36a9bf69_483b_42fd_8a0c_7ac9206320bc]\n",
+      "  NominalCapacity: 5.0 [AmpereHour]\n",
+      "  NominalVoltage: 3.6 [Volt]\n",
+      "  NominalEnergy: 18.0 [WattHour]\n",
+      "  Mass: 68.0 [Gram]\n",
+      "  Height: 70.15 [MilliMetre]\n",
+      "  Diameter: 21.0 [MilliMetre]\n",
+      "  MaximumContinuousChargingCurrent: 4.875 [Ampere]\n",
+      "  MaximumContinuousDischargingCurrent: 9.8 [Ampere]\n",
+      "  MaximumChargingTemperature: 45 [EMMO_36a9bf69_483b_42fd_8a0c_7ac9206320bc]\n",
+      "  MinimumDischargingTemperature: -20 [EMMO_36a9bf69_483b_42fd_8a0c_7ac9206320bc]\n",
       "  CycleLife: — [EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978]\n"
      ]
     }
@@ -261,7 +244,7 @@
     "\n",
     "output = publish_record(\n",
     "    result.debug_paths[\"canonical_record_path\"],\n",
-    "    target_root=WORKSPACE / \"resolver\",\n",
+    "    target_root=SCRATCH / \"resolver\",\n",
     ")\n",
     "jsonld = json.loads(Path(output[\"output_dir\"], \"index.jsonld\").read_text(encoding=\"utf-8\"))\n",
     "\n",
@@ -270,40 +253,41 @@
     "print(\"Properties:\")\n",
     "for prop in jsonld.get(\"hasProperty\", []):\n",
     "    t = prop[\"@type\"][0] if isinstance(prop[\"@type\"], list) else prop[\"@type\"]\n",
-    "    v = prop.get(\"hasNumericalPart\", {}).get(\"hasNumericalValue\", \"—\")\n",
+    "    v = prop.get(\"hasNumericalPart\", {}).get(\"hasNumberValue\", \"—\")\n",
     "    u = prop.get(\"hasMeasurementUnit\", \"\").split(\"#\")[-1]\n",
     "    print(f\"  {t}: {v} [{u}]\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b39008f1",
+   "id": "3ad51cec",
    "metadata": {},
    "source": [
-    "## Part 2 — Descriptor path (material-level)\n",
+    "## Part 2 — A taste of material-level description\n",
     "\n",
-    "Use this for research cells or when electrode composition, electrolyte formulation, and construction details are known.\n",
-    "The workflow builds bottom-up: **materials → BOM → electrode → electrolyte → separator → cell description**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c5cc2c09",
-   "metadata": {},
-   "source": [
-    "### Step 1: Individual materials"
+    "Datasheet fields stop at the can. For research cells you often know what is\n",
+    "*inside* — and BattINFO applies the same spec-and-instance thinking to\n",
+    "materials that it applies to cells:\n",
+    "\n",
+    "- a **component** (`material(...)`) describes a constituent *in the context of\n",
+    "  this cell* — its role and its fraction of a coating or a mixture;\n",
+    "- a **material spec** is a standalone, reusable record for the substance\n",
+    "  itself, with its own IRI, shared by every cell that uses it.\n",
+    "\n",
+    "Salts are materials like any other constituent — they take the same\n",
+    "`material(...)` form as solvents, with the concentration carried inline:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d7efdd70",
+   "id": "bb91e73d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.281983Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.281983Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.288389Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.288389Z"
+     "iopub.execute_input": "2026-07-07T08:09:30.887891Z",
+     "iopub.status.busy": "2026-07-07T08:09:30.886898Z",
+     "iopub.status.idle": "2026-07-07T08:09:30.902460Z",
+     "shell.execute_reply": "2026-07-07T08:09:30.899914Z"
     }
    },
    "outputs": [
@@ -311,207 +295,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Materials defined.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo.authoring import material, properties\n",
-    "\n",
-    "# Positive electrode\n",
-    "lfp   = material(\"LFP\",          mass_fraction={\"value\": 90, \"unit\": \"%\"},\n",
-    "                  comment=\"LiFePO4, olivine, D50 ~ 3 µm\")\n",
-    "pvdf  = material(\"PVDF\",         mass_fraction={\"value\":  5, \"unit\": \"%\"})\n",
-    "c65   = material(\"Carbon black\", mass_fraction={\"value\":  5, \"unit\": \"%\"},\n",
-    "                  comment=\"Imerys C65\")\n",
-    "\n",
-    "# Negative electrode\n",
-    "graphite = material(\"Graphite\",  mass_fraction={\"value\": 95.5, \"unit\": \"%\"},\n",
-    "                     comment=\"Natural graphite, D50 ~ 20 µm\")\n",
-    "cmc  = material(\"CMC\", mass_fraction={\"value\": 1.5, \"unit\": \"%\"})\n",
-    "sbr  = material(\"SBR\", mass_fraction={\"value\": 2.5, \"unit\": \"%\"})\n",
-    "c_ng = material(\"Carbon black\", mass_fraction={\"value\": 0.5, \"unit\": \"%\"})\n",
-    "\n",
-    "print(\"Materials defined.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "mass-fraction-note",
-   "metadata": {},
-   "source": [
-    "> **Semantic note — `mass_fraction` as a compositional property**\n",
-    ">\n",
-    "> Strictly speaking, `mass_fraction` is not an intrinsic property of LFP or PVDF — it is a property of that material *as a constituent of this specific electrode coating*. The fully rigorous EMMO representation would attach the fraction to an intermediate constituent-role node rather than to the material node directly.\n",
-    ">\n",
-    "> BattINFO uses the simpler form — `mass_fraction` on the material node — as a deliberate authoring convenience. The ambiguity is resolved by context: every `material()` call here appears inside an electrode composition, so the fraction is always interpreted as the proportion of that material within the enclosing coating. A material node is never used in isolation where a context-free mass fraction would be meaningless.\n",
-    ">\n",
-    "> The same logic applies to `volume_fraction` on electrolyte solvent nodes in the electrolyte recipe below."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3ed0ac46",
-   "metadata": {},
-   "source": [
-    "### Step 2: Bills of materials"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "b67136fb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.291530Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.291530Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.296709Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.296709Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Positive active material: LFP\n",
-      "Negative binders: ['CMC', 'SBR']\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo.authoring import bom\n",
-    "\n",
-    "positive_bom = bom(active_material=lfp,      binder=pvdf,       additive=c65)\n",
-    "negative_bom = bom(active_material=graphite, binder=[cmc, sbr], additive=c_ng)\n",
-    "\n",
-    "print(\"Positive active material:\", positive_bom.active_material[0].name)\n",
-    "print(\"Negative binders:\", [m.name for m in negative_bom.binder])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6360a5e9",
-   "metadata": {},
-   "source": [
-    "### Step 3: Electrodes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "620158b2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.296709Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.296709Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.304882Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.304882Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Positive loading: {'value': 12.5, 'unit': 'mg/cm2'}\n",
-      "Negative current collector: Copper foil\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo.authoring import electrode\n",
-    "\n",
-    "positive_electrode = electrode(\n",
-    "    bom=positive_bom,\n",
-    "    loading={\"value\": 12.5, \"unit\": \"mg/cm2\"},\n",
-    "    calendered_density={\"value\": 2.4, \"unit\": \"g/cm3\"},\n",
-    "    current_collector=\"Aluminium foil\",\n",
-    "    current_collector_thickness={\"value\": 16.0, \"unit\": \"µm\"},\n",
-    "    coating_comment=\"NMP-cast, roll-calendered\",\n",
-    ")\n",
-    "\n",
-    "negative_electrode = electrode(\n",
-    "    bom=negative_bom,\n",
-    "    loading={\"value\": 7.8, \"unit\": \"mg/cm2\"},\n",
-    "    calendered_density={\"value\": 1.55, \"unit\": \"g/cm3\"},\n",
-    "    current_collector=\"Copper foil\",\n",
-    "    current_collector_thickness={\"value\": 10.0, \"unit\": \"µm\"},\n",
-    ")\n",
-    "\n",
-    "print(\"Positive loading:\", positive_electrode.coating.property.get(\"loading\"))\n",
-    "print(\"Negative current collector:\", negative_electrode.current_collector.name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e638c84f",
-   "metadata": {},
-   "source": [
-    "### Step 4: Electrolyte"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "b4f7cd0a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.308662Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.307653Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.316272Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.315264Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Salt: LiPF6 at {'value': 1.0, 'unit': 'mol/L'}\n",
+      "Salt:     LiPF6 {'value': 1.0, 'unit': 'mol/L'}\n",
       "Solvents: ['EC', 'DMC']\n"
      ]
     }
    ],
    "source": [
-    "from battinfo.authoring import electrolyte_recipe, material as mat\n",
+    "from battinfo.authoring import electrolyte_recipe, material\n",
     "\n",
     "lp30 = electrolyte_recipe(\n",
     "    family=\"organic\",\n",
-    "    salt=\"LiPF6\",\n",
-    "    salt_concentration={\"value\": 1.0, \"unit\": \"mol/L\"},\n",
+    "    salt=material(\"LiPF6\", concentration={\"value\": 1.0, \"unit\": \"mol/L\"}),\n",
     "    solvents=[\n",
-    "        mat(\"EC\",  volume_fraction={\"value\": 50, \"unit\": \"%\"}),\n",
-    "        mat(\"DMC\", volume_fraction={\"value\": 50, \"unit\": \"%\"}),\n",
+    "        material(\"EC\",  volume_fraction={\"value\": 50, \"unit\": \"%\"}),\n",
+    "        material(\"DMC\", volume_fraction={\"value\": 50, \"unit\": \"%\"}),\n",
     "    ],\n",
-    "    additives=[\n",
-    "        mat(\"VC\",  mass_fraction={\"value\": 2.0, \"unit\": \"%\"}, comment=\"SEI-forming additive\"),\n",
-    "    ],\n",
-    "    comment=\"LP30 + 2% VC\",\n",
+    "    comment=\"LP30\",\n",
     ")\n",
     "\n",
-    "print(\"Salt:\", lp30.salt.name, \"at\", lp30.salt.property.get(\"concentration\"))\n",
+    "print(\"Salt:    \", lp30.salt.name, lp30.salt.property.get(\"concentration\"))\n",
     "print(\"Solvents:\", [s.name for s in lp30.solvent_mixture.component])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9e15d1a6",
+   "id": "a7dcee53",
    "metadata": {},
    "source": [
-    "### Step 5: Separator and construction"
+    "Any component can be lifted into a standalone **material spec** — a record\n",
+    "with a deterministic IRI (the same material always mints the same IRI, so\n",
+    "specs deduplicate across cells) — and the component then references it:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "eca67433",
+   "execution_count": 6,
+   "id": "795996e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.319271Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.318303Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.325474Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.324468Z"
+     "iopub.execute_input": "2026-07-07T08:09:30.909458Z",
+     "iopub.status.busy": "2026-07-07T08:09:30.908462Z",
+     "iopub.status.idle": "2026-07-07T08:09:30.923614Z",
+     "shell.execute_reply": "2026-07-07T08:09:30.922603Z"
     }
    },
    "outputs": [
@@ -519,830 +344,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Separator material:"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Polypropylene\n",
-      "Assembly: wound / jelly-roll\n"
+      "Material-spec IRI: https://w3id.org/battinfo/material-spec/xcv1-hpy1-b0bw-z5s2\n",
+      "Component reference: https://w3id.org/battinfo/material-spec/xcv1-hpy1-b0bw-z5s2\n"
      ]
     }
    ],
    "source": [
-    "from battinfo.authoring import separator_spec, construction\n",
+    "from battinfo.materials import link_component_to_spec, material_spec_from_component\n",
     "\n",
-    "sep = separator_spec(\n",
-    "    material=\"Polypropylene\",\n",
-    "    thickness={\"value\": 25.0, \"unit\": \"µm\"},\n",
-    "    properties=properties(porosity={\"value\": 41, \"unit\": \"%\"}),\n",
-    "    comment=\"Celgard 2500, single-layer PP\",\n",
-    ")\n",
+    "lipf6 = material_spec_from_component(lp30.salt, material_class=\"electrolyte_salt\")\n",
+    "lipf6_id = lipf6[\"material_spec\"][\"id\"]\n",
+    "print(\"Material-spec IRI:\", lipf6_id)\n",
     "\n",
-    "build = construction(assembly_type=\"wound\", layering=\"jelly-roll\", layer_count=1)\n",
-    "\n",
-    "print(\"Separator material:\", sep.material)\n",
-    "print(\"Assembly:\", build.assembly_type, \"/\", build.layering)"
+    "linked_salt = link_component_to_spec(lp30.salt, lipf6_id)\n",
+    "print(\"Component reference:\", linked_salt[\"material_spec_id\"])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "505a0d15",
+   "id": "a0ecf048",
    "metadata": {},
    "source": [
-    "### Step 6: Assemble the cell description"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "7a8e2003",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.329476Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.329476Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.335063Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.335063Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cell ID: https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8\n",
-      "Format: cylindrical\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo.authoring import cell_description, source\n",
+    "That is the whole model — the full bottom-up build (electrode bills of\n",
+    "materials, loadings, separator, construction, and the rich JSON-LD graph they\n",
+    "produce) is **[Guide 5 — Cell descriptors](05-descriptors.ipynb)**.\n",
     "\n",
-    "# The id is the BattINFO IRI for this cell spec.\n",
-    "# For new records: publish a CellSpec first to receive the IRI, then enrich it here.\n",
-    "# For this tutorial we use the known IRI for the A123 ANR26650M1-B example.\n",
-    "A123_IRI = \"https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8\"\n",
-    "\n",
-    "spec = cell_description(\n",
-    "    id=A123_IRI,\n",
-    "    manufacturer=\"A123 Systems\",\n",
-    "    model=\"ANR26650M1-B\",\n",
-    "    format=\"cylindrical\",\n",
-    "    chemistry=\"Li-ion\",\n",
-    "    positive_electrode_basis=\"LFP\",\n",
-    "    negative_electrode_basis=\"graphite\",\n",
-    "    size_code=\"R26650\",\n",
-    "    positive_electrode=positive_electrode,\n",
-    "    negative_electrode=negative_electrode,\n",
-    "    electrolyte=lp30,\n",
-    "    separator=sep,\n",
-    "    construction=build,\n",
-    "    source=source(\n",
-    "        type=\"datasheet\",\n",
-    "        name=\"ANR26650M1-B Product Datasheet\",\n",
-    "        url=\"https://example.com/a123-anr26650m1-b.pdf\",\n",
-    "    ),\n",
-    "    comment=\"Detailed descriptor from manufacturer datasheet and published literature.\",\n",
-    ")\n",
-    "\n",
-    "print(\"Cell ID:\", spec.id)\n",
-    "print(\"Format:\", spec.format)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "88d04020",
-   "metadata": {},
-   "source": [
-    "### Step 7: Serialise and inspect the descriptor"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "bfa47a36",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.337113Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.337113Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.348663Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.347657Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Descriptor written to: descriptors\\a123-anr26650m1-b.descriptor.json\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['schema_version',\n",
-       " 'kind',\n",
-       " 'id',\n",
-       " 'name',\n",
-       " 'manufacturer',\n",
-       " 'manufacturer_id',\n",
-       " 'model',\n",
-       " 'format',\n",
-       " 'chemistry',\n",
-       " 'product_type',\n",
-       " 'positive_electrode_basis',\n",
-       " 'negative_electrode_basis',\n",
-       " 'size_code',\n",
-       " 'iec_code',\n",
-       " 'country_of_origin',\n",
-       " 'rechargeable',\n",
-       " 'year',\n",
-       " 'datasheet_revision',\n",
-       " 'cell_specification_id',\n",
-       " 'properties',\n",
-       " 'construction',\n",
-       " 'positive_electrode',\n",
-       " 'negative_electrode',\n",
-       " 'electrolyte',\n",
-       " 'separator',\n",
-       " 'housing',\n",
-       " 'positive_electrode_spec_id',\n",
-       " 'negative_electrode_spec_id',\n",
-       " 'electrolyte_spec_id',\n",
-       " 'separator_spec_id',\n",
-       " 'housing_spec_id',\n",
-       " 'specification_comment',\n",
-       " 'bibliography',\n",
-       " 'source',\n",
-       " 'comment']"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Write the descriptor dict to a JSON file for inspection and downstream use.\n",
-    "# The CellSpec is both the authoring object and the record that publishing uses.\n",
-    "desc_dir = WORKSPACE / \"descriptors\"\n",
-    "desc_dir.mkdir(parents=True, exist_ok=True)\n",
-    "desc_path = desc_dir / \"a123-anr26650m1-b.descriptor.json\"\n",
-    "desc_path.write_text(json.dumps(spec.model_dump(), indent=2, ensure_ascii=False), encoding=\"utf-8\")\n",
-    "print(\"Descriptor written to:\", desc_path.relative_to(WORKSPACE))\n",
-    "\n",
-    "# Preview top-level keys\n",
-    "list(spec.model_dump().keys())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "86d61977",
-   "metadata": {},
-   "source": [
-    "### Export descriptor to domain-battery JSON-LD\n",
-    "\n",
-    "The `CellSpec` maps to EMMO-aligned JSON-LD via `to_jsonld(target=\"domain-battery\")`. This is the rich semantic representation: it includes electrode composition nodes (constituents with mass fractions, loading, current collector), the electrolyte (salt, solvents, additives with concentrations and volume fractions), and the separator (material, thickness, porosity).\n",
-    "\n",
-    "The descriptor pipeline expects the specification wrapped in a document envelope (`{\"schema_version\": ..., \"specification\": ...}`)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "1632d66b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.350666Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.350666Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.464905Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.464905Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Domain-battery JSON-LD exported to: descriptors\\a123-anr26650m1-b.descriptor.domain-battery.jsonld\n",
-      "\n",
-      "@type: ['BatteryCellSpecification', 'schema:CreativeWork']\n",
-      "isDescriptionFor: ['BatteryCell', 'CylindricalBattery', 'LithiumIonBattery', 'LithiumIonIronPhosphateBattery', 'LithiumIonGraphiteBattery']\n",
-      "hasPositiveElectrode: LithiumIronPhosphateElectrode\n",
-      "  hasActiveMaterial: ['LithiumIronPhosphate', 'ActiveMaterial']\n",
-      "  hasBinder: ['PolyvinylideneFluoride', 'Binder']\n",
-      "  hasConductiveAdditive: ['CarbonBlack', 'ConductiveAdditive']\n",
-      "hasNegativeElectrode: GraphiteElectrode\n",
-      "hasElectrolyte: OrganicElectrolyte\n",
-      "  hasSolute: ['LithiumHexafluorophosphate', 'Solute']\n",
-      "  hasSolvent: [['EthyleneCarbonate', 'Solvent'], ['DimethylCarbonate', 'Solvent']]\n",
-      "hasSeparator: ['Polypropylene', 'Separator']\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo.transform.json_to_jsonld import to_jsonld\n",
-    "\n",
-    "descriptor_doc = json.loads(desc_path.read_text(encoding=\"utf-8\"))\n",
-    "\n",
-    "# The descriptor pipeline expects the specification wrapped in a document envelope.\n",
-    "# spec.model_dump() produces the specification fields directly;\n",
-    "# wrapping it here routes to the full descriptor pipeline.\n",
-    "desc_jsonld = to_jsonld(\n",
-    "    {\"schema_version\": descriptor_doc.get(\"schema_version\"), \"specification\": descriptor_doc},\n",
-    "    target=\"domain-battery\",\n",
-    ")\n",
-    "\n",
-    "# Write to disk alongside the descriptor JSON\n",
-    "desc_jsonld_path = desc_path.with_suffix(\".domain-battery.jsonld\")\n",
-    "desc_jsonld_path.write_text(\n",
-    "    json.dumps(desc_jsonld, indent=2, ensure_ascii=False),\n",
-    "    encoding=\"utf-8\",\n",
-    ")\n",
-    "print(f\"Domain-battery JSON-LD exported to: {desc_jsonld_path.relative_to(WORKSPACE)}\")\n",
-    "print()\n",
-    "# Show key structural nodes\n",
-    "spec_node = desc_jsonld[\"@graph\"][0]\n",
-    "pos_coating = spec_node[\"hasPositiveElectrode\"][\"hasCoating\"]\n",
-    "elyte = spec_node[\"hasElectrolyte\"]\n",
-    "print(\"@type:\", spec_node[\"@type\"])\n",
-    "print(\"isDescriptionFor:\", spec_node[\"isDescriptionFor\"][\"@type\"])\n",
-    "print(\"hasPositiveElectrode:\", spec_node[\"hasPositiveElectrode\"][\"@type\"])\n",
-    "print(\"  hasActiveMaterial:\", pos_coating[\"hasActiveMaterial\"][\"@type\"])\n",
-    "print(\"  hasBinder:\", pos_coating[\"hasBinder\"][\"@type\"])\n",
-    "print(\"  hasConductiveAdditive:\", pos_coating[\"hasConductiveAdditive\"][\"@type\"])\n",
-    "print(\"hasNegativeElectrode:\", spec_node[\"hasNegativeElectrode\"][\"@type\"])\n",
-    "print(\"hasElectrolyte:\", elyte[\"@type\"])\n",
-    "print(\"  hasSolute:\", elyte[\"hasSolute\"][\"@type\"])\n",
-    "solvents = elyte[\"hasSolvent\"]\n",
-    "if not isinstance(solvents, list): solvents = [solvents]\n",
-    "print(\"  hasSolvent:\", [s[\"@type\"] for s in solvents])\n",
-    "print(\"hasSeparator:\", spec_node[\"hasSeparator\"][\"@type\"])\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "74b611d0",
-   "metadata": {},
-   "source": [
-    "## Part 3 — Full linked graph\n",
-    "\n",
-    "Combine the specification with a cell instance to produce the complete EMMO-aligned JSON-LD graph. This is the definitive semantic export: every node, predicate, and property value defined in Part 2 is present and verifiable here.\n",
-    "\n",
-    "> **Note on the resolver artifact**: the lightweight JSON-LD served at the cell-spec IRI is a discovery document, not the full graph. It carries `@type`, `schema:name`, and `hasProperty` for top-level specs, but omits electrode composition, electrolyte, and separator to keep file size small. Use the full graph below for semantic validation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "c2ae6a1d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.464905Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.464905Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.518906Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.518906Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Full linked graph written to: descriptors\\a123-anr26650m1-b.linked.jsonld\n",
-      "Graph nodes: 2\n",
-      "  [0] @type=['BatteryCellSpecification', 'schema:CreativeWork']  @id=https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8\n",
-      "  [1] @type=['BatteryCell', 'schema:IndividualProduct']  @id=https://w3id.org/battinfo/cell/a123-anr26650m1-b-demo-001\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Build the full linked graph: specification + one cell instance\n",
-    "# descriptor_doc was written in Step 7; reload it in case cells are run non-linearly.\n",
-    "descriptor_doc = json.loads(desc_path.read_text(encoding=\"utf-8\"))\n",
-    "\n",
-    "# In production, cell IRIs are minted by the registry at registration time.\n",
-    "# For verification we use a placeholder IRI that follows the BattINFO IRI scheme.\n",
-    "DEMO_CELL_IRI = \"https://w3id.org/battinfo/cell/a123-anr26650m1-b-demo-001\"\n",
-    "\n",
-    "full_doc = {\n",
-    "    \"schema_version\": descriptor_doc.get(\"schema_version\"),\n",
-    "    \"specification\": descriptor_doc,\n",
-    "    \"instances\": [\n",
-    "        {\n",
-    "            \"id\": DEMO_CELL_IRI,\n",
-    "            \"name\": \"A123 ANR26650M1-B #demo-001\",\n",
-    "            \"serial_number\": \"demo-001\",\n",
-    "            \"comment\": \"Demonstration instance linked to the cell spec above.\",\n",
-    "        }\n",
-    "    ],\n",
-    "}\n",
-    "\n",
-    "full_jsonld = to_jsonld(full_doc, target=\"domain-battery\")\n",
-    "full_jsonld_path = desc_dir / \"a123-anr26650m1-b.linked.jsonld\"\n",
-    "full_jsonld_path.write_text(\n",
-    "    json.dumps(full_jsonld, indent=2, ensure_ascii=False),\n",
-    "    encoding=\"utf-8\",\n",
-    ")\n",
-    "print(f\"Full linked graph written to: {full_jsonld_path.relative_to(WORKSPACE)}\")\n",
-    "print(f\"Graph nodes: {len(full_jsonld['@graph'])}\")\n",
-    "for i, node in enumerate(full_jsonld[\"@graph\"]):\n",
-    "    node_type = node.get(\"@type\", \"?\")\n",
-    "    node_id = node.get(\"@id\", \"(blank)\")\n",
-    "    print(f\"  [{i}] @type={node_type}  @id={node_id}\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "f63cc430",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.520916Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.520916Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.525052Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.525052Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"@context\": [\n",
-      "    \"https://w3id.org/emmo/domain/battery/context\",\n",
-      "    {\n",
-      "      \"schema\": \"https://schema.org/\"\n",
-      "    }\n",
-      "  ],\n",
-      "  \"@graph\": [\n",
-      "    {\n",
-      "      \"@type\": [\n",
-      "        \"BatteryCellSpecification\",\n",
-      "        \"schema:CreativeWork\"\n",
-      "      ],\n",
-      "      \"isDescriptionFor\": {\n",
-      "        \"@type\": [\n",
-      "          \"BatteryCell\",\n",
-      "          \"CylindricalBattery\",\n",
-      "          \"LithiumIonBattery\",\n",
-      "          \"LithiumIonIronPhosphateBattery\",\n",
-      "          \"LithiumIonGraphiteBattery\"\n",
-      "        ]\n",
-      "      },\n",
-      "      \"@id\": \"https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8\",\n",
-      "      \"schema:name\": \"A123 Systems ANR26650M1-B\",\n",
-      "      \"schema:model\": \"ANR26650M1-B\",\n",
-      "      \"schema:manufacturer\": {\n",
-      "        \"@type\": \"schema:Organization\",\n",
-      "        \"schema:name\": \"A123 Systems\"\n",
-      "      },\n",
-      "      \"schema:size\": \"R26650\",\n",
-      "      \"hasPositiveElectrode\": {\n",
-      "        \"hasCoating\": {\n",
-      "          \"@type\": \"ElectrodeCoating\",\n",
-      "          \"hasActiveMaterial\": {\n",
-      "            \"@type\": [\n",
-      "              \"LithiumIronPhosphate\",\n",
-      "              \"ActiveMaterial\"\n",
-      "            ],\n",
-      "            \"schema:name\": \"LFP\",\n",
-      "            \"hasProperty\": {\n",
-      "              \"@type\": [\n",
-      "                \"MassFraction\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 0.9\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "            },\n",
-      "            \"schema:description\": \"LiFePO4, olivine, D50 ~ 3 µm\"\n",
-      "          },\n",
-      "          \"hasBinder\": {\n",
-      "            \"@type\": [\n",
-      "              \"PolyvinylideneFluoride\",\n",
-      "              \"Binder\"\n",
-      "            ],\n",
-      "            \"schema:name\": \"PVDF\",\n",
-      "            \"hasProperty\": {\n",
-      "              \"@type\": [\n",
-      "                \"MassFraction\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 0.05\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "            }\n",
-      "          },\n",
-      "          \"hasConductiveAdditive\": {\n",
-      "            \"@type\": [\n",
-      "              \"CarbonBlack\",\n",
-      "              \"ConductiveAdditive\"\n",
-      "            ],\n",
-      "            \"schema:name\": \"Carbon black\",\n",
-      "            \"hasProperty\": {\n",
-      "              \"@type\": [\n",
-      "                \"MassFraction\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 0.05\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "            },\n",
-      "            \"schema:description\": \"Imerys C65\"\n",
-      "          },\n",
-      "          \"hasProperty\": [\n",
-      "            {\n",
-      "              \"@type\": [\n",
-      "                \"CalenderedDensity\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 2.4\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#GramPerCubicCentiMetre\"\n",
-      "            },\n",
-      "            {\n",
-      "              \"@type\": [\n",
-      "                \"ActiveMassLoading\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 12.5\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#MilliGramPerSquareCentiMetre\"\n",
-      "            }\n",
-      "          ],\n",
-      "          \"schema:description\": \"NMP-cast, roll-calendered\"\n",
-      "        },\n",
-      "        \"hasCurrentCollector\": {\n",
-      "          \"@type\": [\n",
-      "            \"CurrentCollector\",\n",
-      "            \"Aluminium\",\n",
-      "            \"Foil\"\n",
-      "          ],\n",
-      "          \"schema:name\": \"Aluminium foil\",\n",
-      "          \"hasProperty\": {\n",
-      "            \"@type\": [\n",
-      "              \"Thickness\",\n",
-      "              \"ConventionalProperty\"\n",
-      "            ],\n",
-      "            \"hasNumericalPart\": {\n",
-      "              \"@type\": \"RealData\",\n",
-      "              \"hasNumberValue\": 16.0\n",
-      "            },\n",
-      "            \"hasMeasurementUnit\": \"https://w3id.org/emmo#MicroMetre\"\n",
-      "          }\n",
-      "        },\n",
-      "        \"@type\": \"LithiumIronPhosphateElectrode\"\n",
-      "      },\n",
-      "      \"hasNegativeElectrode\": {\n",
-      "        \"hasCoating\": {\n",
-      "          \"@type\": \"ElectrodeCoating\",\n",
-      "          \"hasActiveMaterial\": {\n",
-      "            \"@type\": [\n",
-      "              \"Graphite\",\n",
-      "              \"ActiveMaterial\"\n",
-      "            ],\n",
-      "            \"schema:name\": \"Graphite\",\n",
-      "            \"hasProperty\": {\n",
-      "              \"@type\": [\n",
-      "                \"MassFraction\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 0.955\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "            },\n",
-      "            \"schema:description\": \"Natural graphite, D50 ~ 20 µm\"\n",
-      "          },\n",
-      "          \"hasBinder\": [\n",
-      "            {\n",
-      "              \"@type\": [\n",
-      "                \"CarboxymethylCellulose\",\n",
-      "                \"Binder\"\n",
-      "              ],\n",
-      "              \"schema:name\": \"CMC\",\n",
-      "              \"hasProperty\": {\n",
-      "                \"@type\": [\n",
-      "                  \"MassFraction\",\n",
-      "                  \"ConventionalProperty\"\n",
-      "                ],\n",
-      "                \"hasNumericalPart\": {\n",
-      "                  \"@type\": \"RealData\",\n",
-      "                  \"hasNumberValue\": 0.015\n",
-      "                },\n",
-      "                \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "              }\n",
-      "            },\n",
-      "            {\n",
-      "              \"@type\": [\n",
-      "                \"StyreneButadiene\",\n",
-      "                \"Binder\"\n",
-      "              ],\n",
-      "              \"schema:name\": \"SBR\",\n",
-      "              \"hasProperty\": {\n",
-      "                \"@type\": [\n",
-      "                  \"MassFraction\",\n",
-      "                  \"ConventionalProperty\"\n",
-      "                ],\n",
-      "                \"hasNumericalPart\": {\n",
-      "                  \"@type\": \"RealData\",\n",
-      "                  \"hasNumberValue\": 0.025\n",
-      "                },\n",
-      "                \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "              }\n",
-      "            }\n",
-      "          ],\n",
-      "          \"hasConductiveAdditive\": {\n",
-      "            \"@type\": [\n",
-      "              \"CarbonBlack\",\n",
-      "              \"ConductiveAdditive\"\n",
-      "            ],\n",
-      "            \"schema:name\": \"Carbon black\",\n",
-      "            \"hasProperty\": {\n",
-      "              \"@type\": [\n",
-      "                \"MassFraction\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 0.005\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "            }\n",
-      "          },\n",
-      "          \"hasProperty\": [\n",
-      "            {\n",
-      "              \"@type\": [\n",
-      "                \"CalenderedDensity\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 1.55\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#GramPerCubicCentiMetre\"\n",
-      "            },\n",
-      "            {\n",
-      "              \"@type\": [\n",
-      "                \"ActiveMassLoading\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 7.8\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#MilliGramPerSquareCentiMetre\"\n",
-      "            }\n",
-      "          ]\n",
-      "        },\n",
-      "        \"hasCurrentCollector\": {\n",
-      "          \"@type\": [\n",
-      "            \"CurrentCollector\",\n",
-      "            \"Copper\",\n",
-      "            \"Foil\"\n",
-      "          ],\n",
-      "          \"schema:name\": \"Copper foil\",\n",
-      "          \"hasProperty\": {\n",
-      "            \"@type\": [\n",
-      "              \"Thickness\",\n",
-      "              \"ConventionalProperty\"\n",
-      "            ],\n",
-      "            \"hasNumericalPart\": {\n",
-      "              \"@type\": \"RealData\",\n",
-      "              \"hasNumberValue\": 10.0\n",
-      "            },\n",
-      "            \"hasMeasurementUnit\": \"https://w3id.org/emmo#MicroMetre\"\n",
-      "          }\n",
-      "        },\n",
-      "        \"@type\": \"GraphiteElectrode\"\n",
-      "      },\n",
-      "      \"hasElectrolyte\": {\n",
-      "        \"@type\": \"OrganicElectrolyte\",\n",
-      "        \"hasSolute\": {\n",
-      "          \"@type\": [\n",
-      "            \"LithiumHexafluorophosphate\",\n",
-      "            \"Solute\"\n",
-      "          ],\n",
-      "          \"schema:name\": \"LiPF6\",\n",
-      "          \"hasProperty\": {\n",
-      "            \"@type\": [\n",
-      "              \"AmountConcentration\",\n",
-      "              \"ConventionalProperty\"\n",
-      "            ],\n",
-      "            \"hasNumericalPart\": {\n",
-      "              \"@type\": \"RealData\",\n",
-      "              \"hasNumberValue\": 1.0\n",
-      "            },\n",
-      "            \"hasMeasurementUnit\": \"https://w3id.org/emmo#MolePerLitre\"\n",
-      "          }\n",
-      "        },\n",
-      "        \"hasSolvent\": [\n",
-      "          {\n",
-      "            \"@type\": [\n",
-      "              \"EthyleneCarbonate\",\n",
-      "              \"Solvent\"\n",
-      "            ],\n",
-      "            \"schema:name\": \"EC\",\n",
-      "            \"hasProperty\": {\n",
-      "              \"@type\": [\n",
-      "                \"VolumeFraction\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 0.5\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "            }\n",
-      "          },\n",
-      "          {\n",
-      "            \"@type\": [\n",
-      "              \"DimethylCarbonate\",\n",
-      "              \"Solvent\"\n",
-      "            ],\n",
-      "            \"schema:name\": \"DMC\",\n",
-      "            \"hasProperty\": {\n",
-      "              \"@type\": [\n",
-      "                \"VolumeFraction\",\n",
-      "                \"ConventionalProperty\"\n",
-      "              ],\n",
-      "              \"hasNumericalPart\": {\n",
-      "                \"@type\": \"RealData\",\n",
-      "                \"hasNumberValue\": 0.5\n",
-      "              },\n",
-      "              \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "            }\n",
-      "          }\n",
-      "        ],\n",
-      "        \"hasAdditive\": {\n",
-      "          \"@type\": [\n",
-      "            \"VinyleneCarbonate\",\n",
-      "            \"ElectrolyteAdditive\"\n",
-      "          ],\n",
-      "          \"schema:name\": \"VC\",\n",
-      "          \"hasProperty\": {\n",
-      "            \"@type\": [\n",
-      "              \"MassFraction\",\n",
-      "              \"ConventionalProperty\"\n",
-      "            ],\n",
-      "            \"hasNumericalPart\": {\n",
-      "              \"@type\": \"RealData\",\n",
-      "              \"hasNumberValue\": 0.02\n",
-      "            },\n",
-      "            \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "          },\n",
-      "          \"schema:description\": \"SEI-forming additive\"\n",
-      "        },\n",
-      "        \"schema:description\": \"LP30 + 2% VC\"\n",
-      "      },\n",
-      "      \"hasSeparator\": {\n",
-      "        \"@type\": [\n",
-      "          \"Polypropylene\",\n",
-      "          \"Separator\"\n",
-      "        ],\n",
-      "        \"schema:name\": \"Polypropylene\",\n",
-      "        \"hasProperty\": [\n",
-      "          {\n",
-      "            \"@type\": [\n",
-      "              \"Porosity\",\n",
-      "              \"ConventionalProperty\"\n",
-      "            ],\n",
-      "            \"hasNumericalPart\": {\n",
-      "              \"@type\": \"RealData\",\n",
-      "              \"hasNumberValue\": 0.41\n",
-      "            },\n",
-      "            \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
-      "          },\n",
-      "          {\n",
-      "            \"@type\": [\n",
-      "              \"Thickness\",\n",
-      "              \"ConventionalProperty\"\n",
-      "            ],\n",
-      "            \"hasNumericalPart\": {\n",
-      "              \"@type\": \"RealData\",\n",
-      "              \"hasNumberValue\": 25.0\n",
-      "            },\n",
-      "            \"hasMeasurementUnit\": \"https://w3id.org/emmo#MicroMetre\"\n",
-      "          }\n",
-      "        ],\n",
-      "        \"schema:description\": \"Celgard 2500, single-layer PP\"\n",
-      "      },\n",
-      "      \"schema:additionalProperty\": [\n",
-      "        {\n",
-      "          \"@type\": \"schema:PropertyValue\",\n",
-      "          \"schema:propertyID\": \"construction.assembly_type\",\n",
-      "          \"schema:name\": \"Assembly Type\",\n",
-      "          \"schema:value\": \"wound\"\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:PropertyValue\",\n",
-      "          \"schema:propertyID\": \"construction.layering\",\n",
-      "          \"schema:name\": \"Layering\",\n",
-      "          \"schema:value\": \"jelly-roll\"\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:PropertyValue\",\n",
-      "          \"schema:propertyID\": \"construction.layer_count\",\n",
-      "          \"schema:name\": \"Layer Count\",\n",
-      "          \"schema:value\": 1\n",
-      "        }\n",
-      "      ],\n",
-      "      \"schema:description\": \"Detailed descriptor from manufacturer datasheet and published literature.\",\n",
-      "      \"schema:schemaVersion\": \"0.2.0\"\n",
-      "    },\n",
-      "    {\n",
-      "      \"@type\": [\n",
-      "        \"BatteryCell\",\n",
-      "        \"schema:IndividualProduct\"\n",
-      "      ],\n",
-      "      \"@id\": \"https://w3id.org/battinfo/cell/a123-anr26650m1-b-demo-001\",\n",
-      "      \"schema:name\": \"A123 ANR26650M1-B #demo-001\",\n",
-      "      \"schema:serialNumber\": \"demo-001\",\n",
-      "      \"schema:description\": \"Demonstration instance linked to the cell spec above.\",\n",
-      "      \"hasDescription\": {\n",
-      "        \"@id\": \"https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8\"\n",
-      "      },\n",
-      "      \"schema:isVariantOf\": {\n",
-      "        \"@id\": \"https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8\"\n",
-      "      }\n",
-      "    }\n",
-      "  ]\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Print the full graph for verification\n",
-    "print(json.dumps(full_jsonld, indent=2, ensure_ascii=False))\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cdc70fc2",
-   "metadata": {},
-   "source": [
-    "### Registry / Battery Genome"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "30c2de71",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:45.528296Z",
-     "iopub.status.busy": "2026-07-06T20:02:45.528296Z",
-     "iopub.status.idle": "2026-07-06T20:02:45.533176Z",
-     "shell.execute_reply": "2026-07-06T20:02:45.532824Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Registry publish shown commented out — fill in credentials to activate.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Fill in real credentials to publish to a registry:\n",
-    "# result = publish(\n",
-    "#     cell_spec,\n",
-    "#     destination=\"registry\",          # or \"battery-genome\"\n",
-    "#     root=\".battinfo/submissions\",\n",
-    "#     registry_base_url=\"https://registry.example.org\",\n",
-    "#     api_key=\"your-api-key\",\n",
-    "#     workspace_id=\"my-lab\",\n",
-    "#     publisher_id=\"sintef-industry\",\n",
-    "#     source_version=\"2026-05-04\",\n",
-    "# )\n",
-    "print(\"Registry publish shown commented out — fill in credentials to activate.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "258ba782",
-   "metadata": {},
-   "source": [
     "## Next\n",
     "\n",
-    "- **[Guide 3 — Linked records](03-linked-records.ipynb)**: connect a cell instance, test, and dataset to the cell spec and publish the chain"
+    "- **[Guide 3 — Linked records](03-linked-records.ipynb)**: record the physical\n",
+    "  cells, tests, and datasets behind this spec\n",
+    "- **[Guide 5 — Cell descriptors](05-descriptors.ipynb)**: the complete\n",
+    "  material-level workflow"
    ]
   }
  ],

--- a/docs/guides/03-linked-records.ipynb
+++ b/docs/guides/03-linked-records.ipynb
@@ -2,81 +2,82 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f6df8e2d",
+   "id": "e7179e7d",
    "metadata": {},
    "source": [
-    "# Guide 3 — Linked records: instance, test, dataset, and publishing\n",
+    "# Guide 3 — Linked records: cells, tests, and datasets\n",
     "\n",
-    "This guide builds the full provenance chain — CellSpec → Cell → TestSpec → Test → Dataset — using the `Workspace` API, validates it, and publishes it.\n",
+    "Guide 2 described a *product*. This guide records what happened in the *lab*:\n",
+    "the physical cells you tested, the procedure you ran, and the data it produced\n",
+    "— the full provenance chain, built with the one `workspace` object:\n",
     "\n",
-    "**Estimated time:** 30 minutes\n",
-    "**Prerequisites:** [Guide 2 — First cell spec](02-first-cell-type.ipynb)\n",
+    "```\n",
+    "CellSpec ─► Cell ─► Test ─► Dataset\n",
+    "                      │\n",
+    "                  TestSpec (the procedure the test followed)\n",
+    "```\n",
     "\n",
-    "Everything writes under `.battinfo/notebooks/guide-03`."
+    "**Estimated time:** 20 minutes\n",
+    "**Prerequisites:** [Guide 2 — Describing a cell](02-first-cell-type.ipynb)\n",
+    "\n",
+    "Everything writes to `_scratch/guide-03/`. This is the depth version of\n",
+    "[Guide 6 — Publish your first dataset](06-publish-your-data.ipynb), which runs\n",
+    "the same chain from a raw cycler file in five minutes."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "58a9385f",
+   "id": "49487b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:50.972460Z",
-     "iopub.status.busy": "2026-07-06T20:02:50.972460Z",
-     "iopub.status.idle": "2026-07-06T20:02:50.984239Z",
-     "shell.execute_reply": "2026-07-06T20:02:50.984239Z"
+     "iopub.execute_input": "2026-07-07T08:09:41.830578Z",
+     "iopub.status.busy": "2026-07-07T08:09:41.829576Z",
+     "iopub.status.idle": "2026-07-07T08:09:42.748651Z",
+     "shell.execute_reply": "2026-07-07T08:09:42.745641Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running from the repo root.\n",
-      "Workspace: .battinfo\\notebooks\\guide-03\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os, json, warnings\n",
+    "import json\n",
+    "import shutil\n",
     "from pathlib import Path\n",
     "\n",
-    "_here = Path.cwd()\n",
-    "if (_here / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here\n",
-    "elif (_here.parent.parent / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here.parent.parent\n",
-    "    os.chdir(REPO)\n",
-    "else:\n",
-    "    REPO = _here\n",
+    "# Throwaway scratch folder next to this notebook — fresh on every run, so the\n",
+    "# outputs below are exactly what a first run produces.\n",
+    "SCRATCH = Path(\"_scratch/guide-03\").resolve()\n",
+    "if SCRATCH.exists():\n",
+    "    shutil.rmtree(SCRATCH)\n",
+    "SCRATCH.mkdir(parents=True)\n",
     "\n",
-    "print(\"Running from the repo root.\")\n",
+    "import battinfo\n",
     "\n",
-    "WORKSPACE = REPO / '.battinfo/notebooks/guide-03'\n",
-    "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
-    "print(\"Workspace:\", WORKSPACE.relative_to(REPO))"
+    "ws = battinfo.workspace(root=SCRATCH)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d2234055",
+   "id": "c0b916e5",
    "metadata": {},
    "source": [
-    "## The Workspace\n",
+    "## Step 1 — The cell spec\n",
     "\n",
-    "`Workspace` is BattINFO's Python authoring surface for linked records. It keeps all objects in memory, assigns consistent IRIs, and writes everything to disk in one call."
+    "In a connected session you would reuse the registry's identity for the product\n",
+    "(`spec = ws.search(\"samsung inr21700 50e\")[0]` — Guide 6 shows that path).\n",
+    "Offline, describe it yourself with the `CellSpec` model — the same object\n",
+    "works either way:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ab862669",
+   "id": "d5e7a580",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:50.990843Z",
-     "iopub.status.busy": "2026-07-06T20:02:50.990285Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.360627Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.360115Z"
+     "iopub.execute_input": "2026-07-07T08:09:42.759187Z",
+     "iopub.status.busy": "2026-07-07T08:09:42.757060Z",
+     "iopub.status.idle": "2026-07-07T08:09:42.771900Z",
+     "shell.execute_reply": "2026-07-07T08:09:42.768883Z"
     }
    },
    "outputs": [
@@ -84,48 +85,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workspace root: <repo>\\.battinfo\\notebooks\\guide-03\n"
+      "Cell spec: Samsung SDI INR21700-50E\n"
      ]
     }
    ],
    "source": [
-    "from battinfo import Workspace\n",
-    "\n",
-    "workspace = Workspace(root=WORKSPACE)\n",
-    "print(\"Workspace root:\", workspace.root)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "39bef141",
-   "metadata": {},
-   "source": [
-    "## Step 1: Cell spec"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "5c110179",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.360627Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.360627Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.366649Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.366649Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cell spec created: Samsung SDI INR21700-50E\n"
-     ]
-    }
-   ],
-   "source": [
-    "cell_spec = workspace.cell_spec(\n",
+    "spec = battinfo.CellSpec(\n",
     "    manufacturer=\"Samsung SDI\",\n",
     "    model=\"INR21700-50E\",\n",
     "    format=\"cylindrical\",\n",
@@ -140,28 +105,78 @@
     "    },\n",
     ")\n",
     "\n",
-    "# IRIs are minted when the workspace is saved (Step 6).\n",
-    "print(\"Cell spec created:\", cell_spec.manufacturer, cell_spec.model)"
+    "print(\"Cell spec:\", spec.manufacturer, spec.model)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8e1173b8",
+   "id": "6438764c",
    "metadata": {},
    "source": [
-    "## Step 2: Cell instance"
+    "## Step 2 — The physical cells\n",
+    "\n",
+    "A `Cell` is one specific physical item with a serial number, always linked to\n",
+    "its spec. Register every cell you actually tested:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "05b87289",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:09:42.780842Z",
+     "iopub.status.busy": "2026-07-07T08:09:42.780842Z",
+     "iopub.status.idle": "2026-07-07T08:09:42.805487Z",
+     "shell.execute_reply": "2026-07-07T08:09:42.802475Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cell: A001  (IRI auto-assigned)\n",
+      "  cell: A002  (IRI auto-assigned)\n"
+     ]
+    }
+   ],
+   "source": [
+    "cells = ws.add(\n",
+    "    \"cell\",\n",
+    "    spec=spec,\n",
+    "    serial_numbers=[\"A001\", \"A002\"],\n",
+    "    production_date=\"2026-01-15\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a9854ac",
+   "metadata": {},
+   "source": [
+    "## Step 3 — The test spec\n",
+    "\n",
+    "A `TestSpec` is the reusable procedure definition — *what you planned to do*,\n",
+    "independent of any one cell. Steps use PyBaMM experiment syntax, so the stored\n",
+    "protocol can be handed straight to `pybamm.Experiment(steps * cycles)`; each\n",
+    "step also receives an EMMO electrochemistry process type when it can be\n",
+    "determined unambiguously from the step text.\n",
+    "\n",
+    "Test specs are authored as small draft files (`ws.template(\"test-spec\")`\n",
+    "writes a skeleton to fill in). Here we write the draft directly and load it:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b40a6c5d",
+   "id": "3f90949f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.368843Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.368843Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.374780Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.374780Z"
+     "iopub.execute_input": "2026-07-07T08:09:42.812489Z",
+     "iopub.status.busy": "2026-07-07T08:09:42.811488Z",
+     "iopub.status.idle": "2026-07-07T08:09:42.833130Z",
+     "shell.execute_reply": "2026-07-07T08:09:42.830122Z"
     }
    },
    "outputs": [
@@ -169,50 +184,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cell instance created: sdi-inr21700-50e-batch2026-A001\n",
-      "Link verified.\n"
-     ]
-    }
-   ],
-   "source": [
-    "cell = workspace.cell(\n",
-    "    cell_spec,\n",
-    "    serial_number=\"sdi-inr21700-50e-batch2026-A001\",\n",
-    ")\n",
-    "\n",
-    "print(\"Cell instance created:\", cell.serial_number)\n",
-    "# The spec link is held as an object reference; the IRI pair is minted at save time (Step 6).\n",
-    "assert cell.cell_spec is cell_spec, \"instance must reference the cell spec\"\n",
-    "print(\"Link verified.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2ea6ea8d",
-   "metadata": {},
-   "source": [
-    "## Step 3: Test protocol"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "2a6d7acf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.376852Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.376852Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.382334Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.381824Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test spec created: 1C Cycle Life at 25 °C\n",
-      "Steps (rendered back from the stored method):\n",
+      "Test spec: 1C cycle life at 25 °C\n",
       "  1. Discharge at 1C for 10 hours or until 2.5 V\n",
       "  2. Rest for 10 minutes\n",
       "  3. Charge at 1C until 4.2 V\n",
@@ -222,11 +194,6 @@
     }
    ],
    "source": [
-    "# PyBaMM experiment syntax: a list of step strings.\n",
-    "# BattINFO stores these verbatim so they can be passed directly to pybamm.Experiment(steps * cycles).\n",
-    "# Each step also receives an EMMO electrochemistry process type (ConstantCurrentDischarging,\n",
-    "# Resting, etc.) when it can be determined unambiguously from the step text.\n",
-    "\n",
     "PROTOCOL_STEPS = [\n",
     "    \"Discharge at 1C for 10 hours or until 2.5 V\",\n",
     "    \"Rest for 10 minutes\",\n",
@@ -235,115 +202,58 @@
     "    \"Rest for 10 minutes\",\n",
     "]\n",
     "\n",
-    "protocol = workspace.test_spec(\n",
-    "    name=\"1C Cycle Life at 25 °C\",\n",
-    "    kind=\"cycling\",\n",
-    "    steps=PROTOCOL_STEPS,\n",
-    "    cycles=3,\n",
-    "    description=(\n",
+    "draft_path = SCRATCH / \"cycle-life.test-spec.json\"\n",
+    "draft_path.write_text(json.dumps({\n",
+    "    \"name\": \"1C cycle life at 25 °C\",\n",
+    "    \"type\": \"cycling\",\n",
+    "    \"steps\": PROTOCOL_STEPS,\n",
+    "    \"cycles\": 3,\n",
+    "    \"description\": (\n",
     "        \"1C CC-CV charge (4.2 V, C/20 cut-off) / 1C CC discharge (2.5 V cut-off). \"\n",
     "        \"10-minute rest periods. 25 ± 2 °C. PyBaMM-compatible step syntax.\"\n",
     "    ),\n",
-    "    version=\"1.0\",\n",
-    ")\n",
+    "}, indent=2), encoding=\"utf-8\")\n",
     "\n",
-    "print(\"Test spec created:\", protocol.name)\n",
-    "print(\"Steps (rendered back from the stored method):\")\n",
+    "protocol = ws.load(draft_path)\n",
+    "print(\"Test spec:\", protocol.name)\n",
     "for i, step in enumerate(protocol.experiment, 1):\n",
-    "    print(f\"  {i}. {step}\")\n"
+    "    print(f\"  {i}. {step}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "protocol-semantics-note",
+   "id": "0b121542",
    "metadata": {},
    "source": [
-    "### Semantic depth of a test protocol\n",
-    "\n",
-    "The current representation types the protocol at the class level and carries a free-text\n",
-    "`description`. EMMO domain-electrochemistry has richer terms that allow a more explicit,\n",
-    "machine-replicable representation — here is what is available and when to use it.\n",
-    "\n",
-    "#### What the ontology provides\n",
-    "\n",
-    "| EMMO term | Meaning |\n",
-    "|---|---|\n",
-    "| `ConstantCurrentConstantVoltageCycling` | The complete CC-CV cycle-life protocol |\n",
-    "| `ConstantCurrentConstantVoltageCharging` | A single CC-CV charge step |\n",
-    "| `ConstantCurrentDischarging` | A single CC discharge step |\n",
-    "| `Resting` | A rest / OCV hold step |\n",
-    "| `ElectrochemicalTestingProcedure` | General electrochemical test container |\n",
-    "| `SerialWorkflow` / `IterativeWorkflow` | Structural containers for step sequences |\n",
-    "| `hasNext` / `precedes` / `follows` | Step-to-step sequencing predicates |\n",
-    "| `StepDuration`, `StepSignalCurrent`, `StepSignalVoltage` | Per-step parameters |\n",
-    "\n",
-    "A 1C CC-CV cycle-life protocol could therefore be expressed as an `IterativeWorkflow`\n",
-    "containing a `SerialWorkflow` whose steps are:\n",
-    "`ConstantCurrentConstantVoltageCharging` → `Resting` → `ConstantCurrentDischarging` →\n",
-    "`Resting`, each step carrying typed parameters for C-rate, voltage limit, cut-off\n",
-    "current, rest duration, and temperature.\n",
-    "\n",
-    "#### Pros of explicit step decomposition\n",
-    "\n",
-    "- **Machine-replicable**: the test can be reproduced from the JSON-LD alone without\n",
-    "  parsing free text.\n",
-    "- **SPARQL-queryable at step level**: structured queries like *\"find all datasets charged\n",
-    "  to 4.2 V at 1C CC-CV\"* become precise rather than text-search-based.\n",
-    "- **Parameter validation**: step parameters (C-rate, voltage limits, temperatures) can\n",
-    "  be range-checked against cell specs and standards (IEC 62660, EUCAR) automatically.\n",
-    "- **Stable protocol identity**: the semantic structure survives even if the free-text\n",
-    "  description is incomplete or updated.\n",
-    "\n",
-    "#### Cons and practical limits\n",
-    "\n",
-    "- **Authoring burden**: a four-step cycle becomes a graph of ~10 typed nodes. No\n",
-    "  researcher will author this by hand, so tooling is a prerequisite.\n",
-    "- **EMMO coverage gaps**: GITT, interspersed EIS, multi-rate formation sequences, and\n",
-    "  temperature ramps do not yet have first-class EMMO step types. Mixed typed/free-text\n",
-    "  nodes undermine the value of the graph.\n",
-    "- **Cycler-file redundancy and false precision**: the ground-truth protocol is usually\n",
-    "  the binary file in Biologic BT-Lab, Maccor, or Arbin format. A parallel step graph\n",
-    "  that was hand-authored can silently diverge from what was actually run — which is\n",
-    "  worse than no graph at all.\n",
-    "- **Version fragility**: step-graph records couple tightly to specific EMMO term IRIs.\n",
-    "  An upstream rename invalidates stored records in a way that a text description does\n",
-    "  not.\n",
-    "\n",
-    "#### Current recommendation\n",
-    "\n",
-    "Type the protocol at the class level (e.g. `ConstantCurrentConstantVoltageCycling`) and\n",
-    "record protocol-level parameters (C-rate, voltage window, temperature, cut-off\n",
-    "condition) as typed properties. Keep the free-text `description` as the human-readable\n",
-    "ground truth. Reserve step-level decomposition for cases where:\n",
-    "\n",
-    "1. The protocol is simple enough to express without gaps (standard CC, CC-CV, or rest\n",
-    "   steps only), **and**\n",
-    "2. The step graph is generated programmatically from a machine-readable protocol\n",
-    "   definition (e.g. a cycler script), not authored by hand.\n",
-    "\n",
-    "When the cycler file is included as a dataset distribution, it already carries the\n",
-    "authoritative step definition — the EMMO class typing on the protocol record is\n",
-    "then sufficient for discovery and filtering."
+    "> **How much semantics should a protocol carry?** EMMO can express a CC-CV\n",
+    "> protocol as a full step-by-step process graph — machine-replicable and\n",
+    "> queryable at step level — but authoring one is heavy. The trade-offs and the\n",
+    "> current recommendation are discussed in\n",
+    "> [Test specs — semantic depth](../test-specs.md)."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5526d60f",
+   "id": "d74cb4b8",
    "metadata": {},
    "source": [
-    "## Step 4: Test"
+    "## Step 4 — The test and its data\n",
+    "\n",
+    "A `Test` is one execution of the test spec on one cell. Passing `data=`\n",
+    "attaches the measured file, and the workspace creates the linked `Dataset`\n",
+    "record for it in the same call:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "fcc598be",
+   "execution_count": 5,
+   "id": "0ae05fc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.384341Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.384341Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.389250Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.388242Z"
+     "iopub.execute_input": "2026-07-07T08:09:42.841131Z",
+     "iopub.status.busy": "2026-07-07T08:09:42.840136Z",
+     "iopub.status.idle": "2026-07-07T08:09:42.859545Z",
+     "shell.execute_reply": "2026-07-07T08:09:42.859545Z"
     }
    },
    "outputs": [
@@ -351,55 +261,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test created: 1C cycle-life test on cell A001, April 2026.\n"
+      "  test [cycling] on A001  +1 dataset(s)\n"
      ]
     }
    ],
    "source": [
-    "test = workspace.test(\n",
-    "    cell,\n",
-    "    kind=\"cycling\",\n",
-    "    protocol_ref=protocol,\n",
-    "    instrument=\"Biologic VMP-300\",\n",
-    "    status=\"completed\",\n",
-    "    description=\"1C cycle-life test on cell A001, April 2026.\",\n",
-    ")\n",
-    "\n",
-    "print(\"Test created:\", test.description)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8c847324",
-   "metadata": {},
-   "source": [
-    "## Step 5: Dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "7fa1dbbb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.390940Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.390940Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.401002Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.400482Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset created: INR21700-50E A001 cycle-life dataset\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create a minimal stand-in CSV\n",
-    "data_dir = WORKSPACE / \"inputs\"\n",
+    "data_dir = SCRATCH / \"inputs\"\n",
     "data_dir.mkdir(exist_ok=True)\n",
     "csv_path = data_dir / \"sdi-a001-cycle-life.csv\"\n",
     "csv_path.write_text(\n",
@@ -408,38 +275,41 @@
     "    encoding=\"utf-8\",\n",
     ")\n",
     "\n",
-    "dataset = workspace.dataset(\n",
-    "    cell,\n",
-    "    test=test,\n",
-    "    path=csv_path,\n",
-    "    title=\"INR21700-50E A001 cycle-life dataset\",\n",
-    "    description=\"Voltage, current, and temperature time-series, 500 cycles.\",\n",
+    "tests = ws.add(\n",
+    "    \"test\",\n",
+    "    cell=\"A001\",\n",
+    "    spec=protocol,\n",
+    "    data=csv_path,\n",
+    "    instrument=\"Biologic VMP-300\",\n",
+    "    name=\"1C cycle life, cell A001\",\n",
     "    license=\"CC-BY-4.0\",\n",
-    "    curated_by=\"Jane Smith\",\n",
-    "    comment=\"Cycle-life dataset from Guide 3 walkthrough.\",\n",
-    ")\n",
-    "\n",
-    "print(\"Dataset created:\", dataset.name)"
+    "    description=\"1C cycle-life test on cell A001, April 2026.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "68087146",
+   "id": "dac02242",
    "metadata": {},
    "source": [
-    "## Step 6: Save all records"
+    "## Step 5 — Save\n",
+    "\n",
+    "`ws.save()` validates every record against the canonical JSON Schemas\n",
+    "(policy `strict`) and writes them with stable `w3id.org/battinfo/...` IRIs,\n",
+    "minted deterministically from each record's identity — re-running an\n",
+    "identical save updates in place, never duplicates:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "65d4b2d7",
+   "execution_count": 6,
+   "id": "f739b75c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.404886Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.403886Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.624415Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.624415Z"
+     "iopub.execute_input": "2026-07-07T08:09:42.868337Z",
+     "iopub.status.busy": "2026-07-07T08:09:42.859545Z",
+     "iopub.status.idle": "2026-07-07T08:09:43.916939Z",
+     "shell.execute_reply": "2026-07-07T08:09:43.915931Z"
     }
    },
    "outputs": [
@@ -447,196 +317,57 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cell spec IRI:      https://w3id.org/battinfo/spec/me0t-k16f-eh5y-rq0k\n",
-      "Cell instance IRI:  https://w3id.org/battinfo/cell/7nq8-4h5y-febz-zbgf\n",
-      "Test spec IRI:      https://w3id.org/battinfo/spec/m6v9-nnpe-krwk-f652\n",
-      "Test IRI:           https://w3id.org/battinfo/test/v8gg-g6as-hync-2wb9\n",
-      "Dataset IRI:        https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\n",
+      "Saved 6 record(s) under <repo>\\docs\\guides\\_scratch\\guide-03\\.battinfo\\records:\n",
+      "  cell spec   Samsung SDI INR21700-50E             [created]  .battinfo\\records\\examples\\cell-spec\\cell-spec-me0t-k16f-eh5y-rq0k.json\n",
+      "  cell        A001                                 [created]  .battinfo\\records\\examples\\cell-instance\\cell-y9xy-kr0v-y5tn-dfj7.json\n",
+      "  cell        A002                                 [created]  .battinfo\\records\\examples\\cell-instance\\cell-3w87-0ddf-ryjg-evxe.json\n",
+      "  test spec   1C cycle life at 25 °C               [created]  .battinfo\\records\\examples\\test-protocol\\test-protocol-kxwy-5f5f-f682-hhch.json\n",
+      "  test        1C cycle life, cell A001             [created]  .battinfo\\records\\examples\\test\\test-6nec-h262-tthy-4rnt.json\n",
+      "  dataset     1C cycle life, cell A001 data        [created]  .battinfo\\records\\examples\\dataset\\dataset-0rp6-kncv-cyem-qwcd.json\n",
       "\n",
-      "Records written:\n",
-      "  examples\\cell-instance\\cell-7nq8-4h5y-febz-zbgf.json\n",
-      "  examples\\cell-spec\\cell-spec-me0t-k16f-eh5y-rq0k.json\n",
-      "  examples\\dataset\\dataset-96kd-vyes-9dp1-6cx6.json\n",
-      "  examples\\test\\test-v8gg-g6as-hync-2wb9.json\n",
-      "  examples\\test-protocol\\test-protocol-m6v9-nnpe-krwk-f652.json\n"
+      "  Next: ws.list(verbose=True) to inspect, or ws.publish() to publish.\n",
+      "\n",
+      "  cell-instance/cell-3w87-0ddf-ryjg-evxe.json\n",
+      "  cell-instance/cell-y9xy-kr0v-y5tn-dfj7.json\n",
+      "  cell-spec/cell-spec-me0t-k16f-eh5y-rq0k.json\n",
+      "  dataset/dataset-0rp6-kncv-cyem-qwcd.json\n",
+      "  test/test-6nec-h262-tthy-4rnt.json\n",
+      "  test-protocol/test-protocol-kxwy-5f5f-f682-hhch.json\n"
      ]
     }
    ],
    "source": [
-    "workspace.save()\n",
+    "result = ws.save()\n",
     "\n",
-    "# save() mints the canonical IRIs on the in-memory objects and links the chain.\n",
-    "print(\"Cell spec IRI:     \", cell_spec.id)\n",
-    "print(\"Cell instance IRI: \", cell.id)\n",
-    "print(\"Test spec IRI:     \", protocol.id)\n",
-    "print(\"Test IRI:          \", test.id)\n",
-    "print(\"Dataset IRI:       \", dataset.id)\n",
-    "assert cell.cell_spec_id == cell_spec.id, \"cell_spec_id must match cell_spec.id\"\n",
-    "\n",
-    "print(\"\\nRecords written:\")\n",
-    "for record_file in sorted((WORKSPACE / \"examples\").rglob(\"*.json\")):\n",
-    "    print(\" \", record_file.relative_to(WORKSPACE))"
+    "records_root = SCRATCH / \".battinfo/records/examples\"\n",
+    "print()\n",
+    "for record_file in sorted(records_root.rglob(\"*.json\")):\n",
+    "    print(f\"  {record_file.parent.name}/{record_file.name}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "877a8f18",
+   "id": "ceb9b131",
    "metadata": {},
    "source": [
-    "### Export resolver JSON-LD for each record\n",
+    "## Step 6 — Inspect the chain\n",
     "\n",
-    "`publish_record()` builds the resolver artifact for a single record: `index.json`, `index.jsonld`, and `index.html`. Running it on each saved record produces the full set of resolver artifacts for the chain."
+    "The links are ordinary fields in the saved records — the dataset knows its\n",
+    "cell and its test, the test knows its spec. Validation is layered (JSON Schema\n",
+    "→ Pydantic → JSON-LD; see Guide 1), and `validate_record_report` gives the\n",
+    "machine-readable report for any record:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a9550242",
+   "execution_count": 7,
+   "id": "b1bde293",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.627421Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.626421Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.981881Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.980875Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Resolver JSON-LD files written (5):\n",
-      "  resolver\\cell\\7nq8-4h5y-febz-zbgf\\index.jsonld\n",
-      "  resolver\\dataset\\96kd-vyes-9dp1-6cx6\\index.jsonld\n",
-      "  resolver\\spec\\m6v9-nnpe-krwk-f652\\index.jsonld\n",
-      "  resolver\\spec\\me0t-k16f-eh5y-rq0k\\index.jsonld\n",
-      "  resolver\\test\\v8gg-g6as-hync-2wb9\\index.jsonld\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo.api import publish_record as _pr\n",
-    "\n",
-    "for record_file in sorted((WORKSPACE / \"examples\").rglob(\"*.json\")):\n",
-    "    _pr(record_file, target_root=WORKSPACE / \"resolver\")\n",
-    "\n",
-    "resolver_jsonld_files = sorted((WORKSPACE / \"resolver\").rglob(\"index.jsonld\"))\n",
-    "print(f\"Resolver JSON-LD files written ({len(resolver_jsonld_files)}):\")\n",
-    "for f in resolver_jsonld_files:\n",
-    "    print(f\"  {f.relative_to(WORKSPACE)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "414a4092",
-   "metadata": {},
-   "source": [
-    "## Step 7: Validate the chain"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "3560d2aa",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.984117Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.984117Z",
-     "iopub.status.idle": "2026-07-06T20:02:52.993129Z",
-     "shell.execute_reply": "2026-07-06T20:02:52.993129Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ok: True | errors: 0 | warnings: 0\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo.validate.record import validate_record_report\n",
-    "\n",
-    "# validate_record_report takes a dict, not a path\n",
-    "dataset_path = next((WORKSPACE / \"examples\" / \"dataset\").glob(\"*.json\"), None)\n",
-    "if dataset_path:\n",
-    "    dataset_doc = json.loads(dataset_path.read_text(encoding=\"utf-8\"))\n",
-    "    report = validate_record_report(dataset_doc, source_root=WORKSPACE / \"examples\")\n",
-    "    print(\"ok:\", report.ok, \"| errors:\", len(report.errors), \"| warnings:\", len(report.warnings))\n",
-    "else:\n",
-    "    print(\"No dataset record found — run workspace.save() first.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5618beb9",
-   "metadata": {},
-   "source": [
-    "## Step 8: Build a publication package"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "1d83e0e5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:52.993129Z",
-     "iopub.status.busy": "2026-07-06T20:02:52.993129Z",
-     "iopub.status.idle": "2026-07-06T20:02:53.199902Z",
-     "shell.execute_reply": "2026-07-06T20:02:53.199902Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Package: publication\\sdi-a001-cycle-life\\battinfo.publish.jsonld\n",
-      "Nodes in @graph: 5\n",
-      "  ['dcat:Catalog', 'schema:DataCatalog', 'schema:Dataset']  —  sdi-a001-cycle-life\n",
-      "  ['dcat:Dataset', 'schema:Dataset']  —  96kd-vyes-9dp1-6cx6\n",
-      "  ['BatteryCellSpecification', 'schema:CreativeWork']  —  me0t-k16f-eh5y-rq0k\n",
-      "  ['BatteryCell', 'CylindricalBattery', 'LithiumIonBattery']  —  7nq8-4h5y-febz-zbgf\n",
-      "  ['BatteryTest', 'schema:Action', 'prov:Activity']  —  v8gg-g6as-hync-2wb9\n"
-     ]
-    }
-   ],
-   "source": [
-    "package = workspace.build_publication_package(dataset)\n",
-    "pkg_path = Path(package[\"publish_path\"])\n",
-    "\n",
-    "print(\"Package:\", pkg_path.relative_to(WORKSPACE))\n",
-    "\n",
-    "bundle = json.loads(pkg_path.read_text(encoding=\"utf-8\"))\n",
-    "print(f\"Nodes in @graph: {len(bundle['@graph'])}\")\n",
-    "for node in bundle[\"@graph\"]:\n",
-    "    types = node.get(\"@type\", \"?\")\n",
-    "    uid = node.get(\"@id\", \"\").split(\"/\")[-1]\n",
-    "    print(f\"  {types}  —  {uid}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a491a9f7",
-   "metadata": {},
-   "source": [
-    "### Full publication package JSON-LD\n",
-    "\n",
-    "The publication package is a single JSON-LD document with a `@graph` containing all four linked records. This is the artifact submitted to a registry or shared with collaborators."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "07c27fec",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:53.203363Z",
-     "iopub.status.busy": "2026-07-06T20:02:53.202115Z",
-     "iopub.status.idle": "2026-07-06T20:02:53.207242Z",
-     "shell.execute_reply": "2026-07-06T20:02:53.207242Z"
+     "iopub.execute_input": "2026-07-07T08:09:43.926952Z",
+     "iopub.status.busy": "2026-07-07T08:09:43.924945Z",
+     "iopub.status.idle": "2026-07-07T08:09:43.942783Z",
+     "shell.execute_reply": "2026-07-07T08:09:43.940773Z"
     }
    },
    "outputs": [
@@ -645,662 +376,66 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "  \"@context\": {\n",
-      "    \"@version\": 1.1,\n",
-      "    \"battery\": \"https://w3id.org/emmo/domain/battery#\",\n",
-      "    \"electrochemistry\": \"https://w3id.org/emmo/domain/electrochemistry#\",\n",
-      "    \"emmo\": \"https://w3id.org/emmo#\",\n",
-      "    \"battinfo\": \"https://w3id.org/battinfo/\",\n",
-      "    \"schema\": \"https://schema.org/\",\n",
-      "    \"dcterms\": \"http://purl.org/dc/terms/\",\n",
-      "    \"prov\": \"http://www.w3.org/ns/prov#\",\n",
-      "    \"dcat\": \"http://www.w3.org/ns/dcat#\",\n",
-      "    \"dqv\": \"http://www.w3.org/ns/dqv#\",\n",
-      "    \"oa\": \"http://www.w3.org/ns/oa#\",\n",
-      "    \"earl\": \"http://www.w3.org/ns/earl#\",\n",
-      "    \"spdx\": \"http://spdx.org/rdf/terms#\",\n",
-      "    \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n",
-      "    \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n",
-      "    \"BatteryCell\": \"battery:battery_68ed592a_7924_45d0_a108_94d6275d57f0\",\n",
-      "    \"BatteryCellSpecification\": \"battery:battery_1cfbba6c_8824_4932_a23e_2141483acef7\",\n",
-      "    \"CylindricalBattery\": \"battery:battery_ac604ecd_cc60_4b98_b57c_74cd5d3ccd40\",\n",
-      "    \"PrismaticBattery\": \"battery:battery_86c9ca80_de6f_417f_afdc_a7e52fa6322d\",\n",
-      "    \"PouchCell\": \"battery:battery_392b3f47_d62a_4bd4_a819_b58b09b8843a\",\n",
-      "    \"CoinCell\": \"battery:battery_b7fdab58_6e91_4c84_b097_b06eff86a124\",\n",
-      "    \"LithiumIonBattery\": \"battery:battery_96addc62_ea04_449a_8237_4cd541dd8e5f\",\n",
-      "    \"LithiumMetalBattery\": \"battery:battery_ada13509_4eed_4e40_a7b1_4cc488144154\",\n",
-      "    \"SodiumIonBattery\": \"battery:battery_42329a95_03fe_4ec1_83cb_b7e8ed52f68a\",\n",
-      "    \"AlkalineZincManganeseDioxideBattery\": \"battery:battery_b572826a_b4e4_4986_b57d_f7b945061f8b\",\n",
-      "    \"AlkalineCell\": \"battery:battery_50b911f7_c903_4700_9764_c308d8a95470\",\n",
-      "    \"PrimaryBattery\": \"battery:battery_3b0b0d6e_8b0e_4491_885e_8421d3eb3b69\",\n",
-      "    \"SecondaryBattery\": \"battery:battery_efc38420_ecbb_42e4_bb3f_208e7c417098\",\n",
-      "    \"BatteryTest\": \"battery:battery_dca7729a_421a_4921_90cf_9692bb9eb081\",\n",
-      "    \"name\": \"schema:name\",\n",
-      "    \"model\": \"schema:model\",\n",
-      "    \"manufacturer\": \"schema:manufacturer\",\n",
-      "    \"hasProperty\": {\n",
-      "      \"@id\": \"emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"hasNumericalPart\": {\n",
-      "      \"@id\": \"emmo:EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"hasNumberValue\": \"emmo:EMMO_faf79f53_749d_40b2_807c_d34244c192f4\",\n",
-      "    \"hasNumericalValue\": \"emmo:EMMO_faf79f53_749d_40b2_807c_d34244c192f4\",\n",
-      "    \"hasMeasurementUnit\": {\n",
-      "      \"@id\": \"emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"isDescriptionFor\": {\n",
-      "      \"@id\": \"emmo:EMMO_f702bad4_fc77_41f0_a26d_79f6444fd4f3\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"hasDescription\": {\n",
-      "      \"@id\": \"emmo:EMMO_c58c799e_cc6c_4310_a3f1_78da70705b2a\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"hasTestObject\": {\n",
-      "      \"@id\": \"battery:battery_da3b3f28_aaad_4d67_b674_df47e109fb8b\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"hasTestEquipment\": {\n",
-      "      \"@id\": \"battery:battery_df4ff8f1_2cf2_444a_9498_23f533bd295c\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"hasOutput\": {\n",
-      "      \"@id\": \"emmo:EMMO_c4bace1d_4db0_4cd3_87e9_18122bae2840\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"id\": \"schema:productID\",\n",
-      "    \"nominal_capacity\": \"electrochemistry:electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\",\n",
-      "    \"minimum_capacity\": \"electrochemistry:electrochemistry_d3c0078e_c1d3_461e_873d_e5c3adf441c5\",\n",
-      "    \"rated_capacity\": \"electrochemistry:electrochemistry_9b3b4668_0795_4a35_9965_2af383497a26\",\n",
-      "    \"typical_capacity\": \"electrochemistry:electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\",\n",
-      "    \"nominal_voltage\": \"electrochemistry:electrochemistry_639b844a_e801_436b_985d_28926129ead6\",\n",
-      "    \"charging_voltage\": \"electrochemistry:electrochemistry_79a9e1be_35b0_4c3c_8087_b5f967ca0e87\",\n",
-      "    \"discharging_cutoff_voltage\": \"electrochemistry:electrochemistry_534dd59c_904c_45d9_8550_ae9d2eb6bbc9\",\n",
-      "    \"charging_cutoff_voltage\": \"electrochemistry:electrochemistry_6dcd5baf_58cd_43f5_a692_51508e036c88\",\n",
-      "    \"upper_voltage_limit\": \"electrochemistry:electrochemistry_6dcd5baf_58cd_43f5_a692_51508e036c88\",\n",
-      "    \"maximum_continuous_charging_current\": \"electrochemistry:electrochemistry_39d8a6ee_cd55_4855_8b5b_d42bef95ac78\",\n",
-      "    \"nominal_continuous_charging_current\": \"electrochemistry:electrochemistry_39d8a6ee_cd55_4855_8b5b_d42bef95ac78\",\n",
-      "    \"maximum_pulse_charging_current\": \"electrochemistry:electrochemistry_1b2a7137_64d4_483a_8437_dcb3bedcb6da\",\n",
-      "    \"maximum_continuous_discharging_current\": \"electrochemistry:electrochemistry_ba7ac581_0e13_4815_b888_013c378932f5\",\n",
-      "    \"nominal_continuous_discharging_current\": \"electrochemistry:electrochemistry_ba7ac581_0e13_4815_b888_013c378932f5\",\n",
-      "    \"maximum_pulse_discharging_current\": \"electrochemistry:electrochemistry_3e54f9e3_a31d_4821_9bfb_ef953a42c35b\",\n",
-      "    \"nominal_energy\": \"electrochemistry:electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\",\n",
-      "    \"typical_energy\": \"electrochemistry:electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\",\n",
-      "    \"rated_energy\": \"electrochemistry:electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\",\n",
-      "    \"certified_usable_energy\": \"electrochemistry:electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\",\n",
-      "    \"power_capability\": \"battinfo:powerCapability\",\n",
-      "    \"maximum_power\": \"battinfo:maximumPower\",\n",
-      "    \"specific_energy\": \"emmo:EMMO_e218c625_6a39_47a9_8d08_a2ef41c152a9\",\n",
-      "    \"energy_density\": \"electrochemistry:electrochemistry_4aa1b96e_44a0_4b1a_a0ac_723d0223d80b\",\n",
-      "    \"specific_power\": \"battinfo:specificPower\",\n",
-      "    \"power_density\": \"battinfo:powerDensity\",\n",
-      "    \"power_energy_ratio\": \"battinfo:powerEnergyRatio\",\n",
-      "    \"internal_resistance\": \"electrochemistry:electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\",\n",
-      "    \"dc_internal_resistance\": \"electrochemistry:electrochemistry_7b3eb826_b968_493a_8396_cc3a5f09ecb3\",\n",
-      "    \"ac_internal_resistance\": \"electrochemistry:electrochemistry_964cd426_f3cf_4a52_8c5d_0490cf48edb5\",\n",
-      "    \"impedance\": \"emmo:EMMO_79a02de5_b884_4eab_bc18_f67997d597a2\",\n",
-      "    \"round_trip_energy_efficiency\": \"battinfo:roundTripEnergyEfficiency\",\n",
-      "    \"round_trip_energy_efficiency_50pct\": \"battinfo:roundTripEnergyEfficiency50Pct\",\n",
-      "    \"initial_coulombic_efficiency\": \"electrochemistry:electrochemistry_469b9516_a96d_4aa2_b8e5_05ae982e2084\",\n",
-      "    \"mass\": \"emmo:EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\",\n",
-      "    \"diameter\": \"emmo:EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\",\n",
-      "    \"height\": \"emmo:EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\",\n",
-      "    \"width\": \"emmo:EMMO_e4de48b1_dabb_4490_ac2b_040f926c64f0\",\n",
-      "    \"length\": \"emmo:EMMO_cd2cd0de_e0cc_4ef1_b27e_2e88db027bac\",\n",
-      "    \"thickness\": \"emmo:EMMO_43003c86_9d15_433b_9789_ee2940920656\",\n",
-      "    \"volume\": \"emmo:EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed\",\n",
-      "    \"maximum_charging_temperature\": \"electrochemistry:electrochemistry_4a354510_4dc2_4803_8845_f4024a1a7260\",\n",
-      "    \"minimum_charging_temperature\": \"electrochemistry:electrochemistry_b90b1ad7_b9a8_44df_ad45_bfd25aac2e49\",\n",
-      "    \"maximum_discharging_temperature\": \"electrochemistry:electrochemistry_de612af2_a029_4a02_8090_4a75ab13271d\",\n",
-      "    \"minimum_discharging_temperature\": \"electrochemistry:electrochemistry_2a1de79f_e927_45a2_9619_3799a0d61e9b\",\n",
-      "    \"maximum_storage_temperature\": \"electrochemistry:electrochemistry_0ea4d188_9701_4699_a5ca_812a98a9afa7\",\n",
-      "    \"minimum_storage_temperature\": \"electrochemistry:electrochemistry_0ddfd57a_d338_4690_be45_b26884ed6302\",\n",
-      "    \"operating_temperature_min\": \"battinfo:operatingTemperatureMin\",\n",
-      "    \"operating_temperature_max\": \"battinfo:operatingTemperatureMax\",\n",
-      "    \"cycle_life\": \"electrochemistry:electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\",\n",
-      "    \"cycle_life_c_rate\": \"battinfo:cycleLifeCRate\",\n",
-      "    \"calendar_life\": \"electrochemistry:electrochemistry_743c71a3_b80c_42e3_92fa_13a67b8167df\",\n",
-      "    \"capacity_fade\": \"battinfo:capacityFade\",\n",
-      "    \"capacity_threshold_exhaustion\": \"battinfo:capacityThresholdExhaustion\",\n",
-      "    \"charging_time\": \"battinfo:chargingTime\",\n",
-      "    \"self_discharge_rate\": \"electrochemistry:electrochemistry_c3e97d58_1854_4c23_bb42_d2972172865e\",\n",
-      "    \"state_of_health\": \"electrochemistry:electrochemistry_a7a4614f_2426_46f3_8475_cda4a9fabfce\",\n",
-      "    \"source_type\": \"battinfo:sourceType\",\n",
-      "    \"source_url\": \"battinfo:sourceURL\",\n",
-      "    \"source_file\": \"battinfo:sourceFile\",\n",
-      "    \"citation\": \"dcterms:bibliographicCitation\",\n",
-      "    \"citation_doi\": \"battinfo:citationDOI\",\n",
-      "    \"retrieved_at\": \"battinfo:retrievedAt\",\n",
-      "    \"workflow_version\": \"battinfo:workflowVersion\",\n",
-      "    \"curated_by\": \"dcterms:contributor\",\n",
-      "    \"protocol_name\": \"schema:name\",\n",
-      "    \"protocol_url\": \"schema:url\",\n",
-      "    \"V\": \"emmo:Volt\",\n",
-      "    \"mV\": \"emmo:MilliVolt\",\n",
-      "    \"kV\": \"emmo:KiloVolt\",\n",
-      "    \"Ah\": \"emmo:AmpereHour\",\n",
-      "    \"mAh\": \"emmo:MilliAmpereHour\",\n",
-      "    \"A\": \"emmo:Ampere\",\n",
-      "    \"mA\": \"emmo:MilliAmpere\",\n",
-      "    \"W\": \"emmo:Watt\",\n",
-      "    \"kW\": \"emmo:KiloWatt\",\n",
-      "    \"Wh\": \"emmo:WattHour\",\n",
-      "    \"kWh\": \"emmo:KiloWattHour\",\n",
-      "    \"MWh\": \"emmo:MegaWattHour\",\n",
-      "    \"Ohm\": \"emmo:Ohm\",\n",
-      "    \"mOhm\": \"emmo:MilliOhm\",\n",
-      "    \"mohm\": \"emmo:MilliOhm\",\n",
-      "    \"degC\": \"emmo:EMMO_36a9bf69_483b_42fd_8a0c_7ac9206320bc\",\n",
-      "    \"K\": \"emmo:Kelvin\",\n",
-      "    \"g\": \"emmo:Gram\",\n",
-      "    \"kg\": \"emmo:Kilogram\",\n",
-      "    \"mg\": \"emmo:MilliGram\",\n",
-      "    \"mm\": \"emmo:MilliMetre\",\n",
-      "    \"cm\": \"emmo:CentiMetre\",\n",
-      "    \"m\": \"emmo:Metre\",\n",
-      "    \"L\": \"emmo:Litre\",\n",
-      "    \"mL\": \"emmo:MilliLitre\",\n",
-      "    \"cm3\": \"emmo:CubicCentiMetre\",\n",
-      "    \"h\": \"emmo:Hour\",\n",
-      "    \"min\": \"emmo:Minute\",\n",
-      "    \"s\": \"emmo:Second\",\n",
-      "    \"C\": \"emmo:CoulombUnit\",\n",
-      "    \"1\": \"emmo:EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\",\n",
-      "    \"%\": \"emmo:Percent\",\n",
-      "    \"license\": {\n",
-      "      \"@id\": \"dcterms:license\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"created_at\": {\n",
-      "      \"@id\": \"dcterms:created\",\n",
-      "      \"@type\": \"xsd:integer\"\n",
-      "    },\n",
-      "    \"modified_at\": {\n",
-      "      \"@id\": \"dcterms:modified\",\n",
-      "      \"@type\": \"xsd:integer\"\n",
-      "    },\n",
-      "    \"LR03\": \"battery:battery_a5299801_2a8d_4d03_a476_ca2c5e9ca702\",\n",
-      "    \"LR6\": \"battery:battery_6b2540b9_5af6_478a_81ae_583db9636db8\",\n",
-      "    \"LR14\": \"battery:battery_d00e842e_ee0b_4e25_bd17_d64d76d69730\",\n",
-      "    \"LR20\": \"battery:battery_0c9979c2_c981_48ea_a8e1_72bdcb58fd58\",\n",
-      "    \"LR1\": \"battery:battery_1c0306f5_5698_4874_b6ce_e5cc45a46b91\",\n",
-      "    \"CR2032\": \"battery:battery_b61b96ac_f2f4_4b74_82d5_565fe3a2d88b\",\n",
-      "    \"CR2025\": \"battery:battery_9984642f_c9dc_4b98_94f6_6ffe20cfc014\",\n",
-      "    \"LR44\": \"battery:battery_d10ff656_f9fd_4b0e_9de9_4812a44ea359\",\n",
-      "    \"HR6\": \"battery:battery_a71a4bf2_dee6_4aa4_8ad4_9f38c261fb84\",\n",
-      "    \"KR6\": \"battery:battery_ad7c1d81_9a9f_4174_88ea_3ba3e8f4dbe2\",\n",
-      "    \"NominalCapacity\": \"electrochemistry:electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\",\n",
-      "    \"MinimumCapacity\": \"electrochemistry:electrochemistry_d3c0078e_c1d3_461e_873d_e5c3adf441c5\",\n",
-      "    \"RatedCapacity\": \"electrochemistry:electrochemistry_9b3b4668_0795_4a35_9965_2af383497a26\",\n",
-      "    \"NominalVoltage\": \"electrochemistry:electrochemistry_639b844a_e801_436b_985d_28926129ead6\",\n",
-      "    \"ChargingVoltage\": \"electrochemistry:electrochemistry_79a9e1be_35b0_4c3c_8087_b5f967ca0e87\",\n",
-      "    \"LowerVoltageLimit\": \"electrochemistry:electrochemistry_534dd59c_904c_45d9_8550_ae9d2eb6bbc9\",\n",
-      "    \"UpperVoltageLimit\": \"electrochemistry:electrochemistry_6dcd5baf_58cd_43f5_a692_51508e036c88\",\n",
-      "    \"MaximumContinuousChargingCurrent\": \"electrochemistry:electrochemistry_39d8a6ee_cd55_4855_8b5b_d42bef95ac78\",\n",
-      "    \"MaximumPulseChargingCurrent\": \"electrochemistry:electrochemistry_1b2a7137_64d4_483a_8437_dcb3bedcb6da\",\n",
-      "    \"MaximumContinuousDischargingCurrent\": \"electrochemistry:electrochemistry_ba7ac581_0e13_4815_b888_013c378932f5\",\n",
-      "    \"MaximumPulseDischargingCurrent\": \"electrochemistry:electrochemistry_3e54f9e3_a31d_4821_9bfb_ef953a42c35b\",\n",
-      "    \"MaximumChargingTemperature\": \"electrochemistry:electrochemistry_4a354510_4dc2_4803_8845_f4024a1a7260\",\n",
-      "    \"MinimumChargingTemperature\": \"electrochemistry:electrochemistry_b90b1ad7_b9a8_44df_ad45_bfd25aac2e49\",\n",
-      "    \"MaximumDischargingTemperature\": \"electrochemistry:electrochemistry_de612af2_a029_4a02_8090_4a75ab13271d\",\n",
-      "    \"MinimumDischargingTemperature\": \"electrochemistry:electrochemistry_2a1de79f_e927_45a2_9619_3799a0d61e9b\",\n",
-      "    \"MaximumStorageTemperature\": \"electrochemistry:electrochemistry_0ea4d188_9701_4699_a5ca_812a98a9afa7\",\n",
-      "    \"MinimumStorageTemperature\": \"electrochemistry:electrochemistry_0ddfd57a_d338_4690_be45_b26884ed6302\",\n",
-      "    \"CycleLife\": \"electrochemistry:electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\",\n",
-      "    \"SpecificEnergy\": \"emmo:EMMO_e218c625_6a39_47a9_8d08_a2ef41c152a9\",\n",
-      "    \"EnergyDensity\": \"electrochemistry:electrochemistry_4aa1b96e_44a0_4b1a_a0ac_723d0223d80b\",\n",
-      "    \"InternalResistance\": \"electrochemistry:electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\",\n",
-      "    \"ElectricImpedance\": \"emmo:EMMO_79a02de5_b884_4eab_bc18_f67997d597a2\",\n",
-      "    \"Mass\": \"emmo:EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\",\n",
-      "    \"Diameter\": \"emmo:EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\",\n",
-      "    \"Height\": \"emmo:EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\",\n",
-      "    \"Width\": \"emmo:EMMO_e4de48b1_dabb_4490_ac2b_040f926c64f0\",\n",
-      "    \"Length\": \"emmo:EMMO_cd2cd0de_e0cc_4ef1_b27e_2e88db027bac\",\n",
-      "    \"Thickness\": \"emmo:EMMO_43003c86_9d15_433b_9789_ee2940920656\",\n",
-      "    \"Volume\": \"emmo:EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed\",\n",
-      "    \"NominalEnergy\": \"electrochemistry:electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\",\n",
-      "    \"CalendarLife\": \"electrochemistry:electrochemistry_743c71a3_b80c_42e3_92fa_13a67b8167df\",\n",
-      "    \"InitialCoulombicEfficiency\": \"electrochemistry:electrochemistry_469b9516_a96d_4aa2_b8e5_05ae982e2084\",\n",
-      "    \"DCInternalResistance\": \"electrochemistry:electrochemistry_7b3eb826_b968_493a_8396_cc3a5f09ecb3\",\n",
-      "    \"ACInternalResistance\": \"electrochemistry:electrochemistry_964cd426_f3cf_4a52_8c5d_0490cf48edb5\",\n",
-      "    \"SelfDischargeRate\": \"electrochemistry:electrochemistry_c3e97d58_1854_4c23_bb42_d2972172865e\",\n",
-      "    \"StateOfHealth\": \"electrochemistry:electrochemistry_a7a4614f_2426_46f3_8475_cda4a9fabfce\",\n",
-      "    \"TheoreticalCapacity\": \"electrochemistry:electrochemistry_372c89d0_adab_4585_9662_33c912acef23\",\n",
-      "    \"NPRatio\": \"electrochemistry:electrochemistry_05012606_b93d_4016_bbc7_8a927efdf723\",\n",
-      "    \"Tortuosity\": \"emmo:EMMO_c413d96f_c57b_4c70_9ac1_312db6c009a8\",\n",
-      "    \"D50ParticleSize\": \"electrochemistry:electrochemistry_3cfdfc10_a5cb_4e3e_b1a1_281010d1465c\",\n",
-      "    \"AreicCapacity\": \"electrochemistry:electrochemistry_bcb33f7e_5573_4bc2_b636_4ea313a9dd3a\",\n",
-      "    \"DischargingSpecificCapacity\": \"electrochemistry:electrochemistry_884650fd_6cc6_4ec6_8264_c18fbe6b90ee\",\n",
-      "    \"CalenderedDensity\": \"electrochemistry:electrochemistry_520995f8_ec9c_4b3c_bb64_2cd691947379\",\n",
-      "    \"MassLoading\": \"electrochemistry:electrochemistry_c955c089_6ee1_41a2_95fc_d534c5cfd3d5\",\n",
-      "    \"AmpereHour\": \"emmo:AmpereHour\",\n",
-      "    \"MilliAmpereHour\": \"emmo:MilliAmpereHour\",\n",
-      "    \"Volt\": \"emmo:Volt\",\n",
-      "    \"MilliVolt\": \"emmo:MilliVolt\",\n",
-      "    \"Ampere\": \"emmo:Ampere\",\n",
-      "    \"MilliAmpere\": \"emmo:MilliAmpere\",\n",
-      "    \"Watt\": \"emmo:Watt\",\n",
-      "    \"WattHour\": \"emmo:WattHour\",\n",
-      "    \"KiloWattHour\": \"emmo:KiloWattHour\",\n",
-      "    \"MilliOhm\": \"emmo:MilliOhm\",\n",
-      "    \"CelsiusTemperature\": \"emmo:EMMO_36a9bf69_483b_42fd_8a0c_7ac9206320bc\",\n",
-      "    \"Kelvin\": \"emmo:Kelvin\",\n",
-      "    \"Gram\": \"emmo:Gram\",\n",
-      "    \"Kilogram\": \"emmo:Kilogram\",\n",
-      "    \"MilliMetre\": \"emmo:MilliMetre\",\n",
-      "    \"CentiMetre\": \"emmo:CentiMetre\",\n",
-      "    \"Metre\": \"emmo:Metre\",\n",
-      "    \"Litre\": \"emmo:Litre\",\n",
-      "    \"MilliLitre\": \"emmo:MilliLitre\",\n",
-      "    \"UnitOne\": \"emmo:EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\",\n",
-      "    \"Hour\": \"emmo:Hour\",\n",
-      "    \"Minute\": \"emmo:Minute\",\n",
-      "    \"Second\": \"emmo:Second\",\n",
-      "    \"WattHourPerKilogram\": \"emmo:WattHourPerKilogram\",\n",
-      "    \"WattHourPerLitre\": \"emmo:WattHourPerLitre\",\n",
-      "    \"WattPerKilogram\": \"http://qudt.org/vocab/unit/W-PER-KiloGM\",\n",
-      "    \"WattPerLitre\": \"http://qudt.org/vocab/unit/W-PER-L\",\n",
-      "    \"WeightPercent\": \"electrochemistry:electrochemistry_2c0e66c8_d58d_44b2_b0ce_ba55194bd505\",\n",
-      "    \"VolumePercent\": \"electrochemistry:electrochemistry_db37b358_b2f0_4e06_b6ae_8c56c8fbb6ba\",\n",
-      "    \"MicroMetre\": \"emmo:MicroMetre\",\n",
-      "    \"MilliGramPerSquareCentiMetre\": \"emmo:MilliGramPerSquareCentiMetre\",\n",
-      "    \"GramPerCubicCentiMetre\": \"emmo:GramPerCubicCentiMetre\",\n",
-      "    \"MolePerLitre\": \"emmo:MolePerLitre\",\n",
-      "    \"hasControlParameter\": {\n",
-      "      \"@id\": \"electrochemistry:electrochemistry_e55f2798_55c8_4fc5_9abb_2f8ac101f3b8\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"hasTerminationParameter\": {\n",
-      "      \"@id\": \"electrochemistry:electrochemistry_e6a7d617_a581_4782_8374_37d3305e0258\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"ControlProperty\": \"electrochemistry:electrochemistry_33e6986c_b35a_4cae_9a94_acb23248065c\",\n",
-      "    \"ConventionalProperty\": \"emmo:EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\",\n",
-      "    \"CRate\": \"electrochemistry:electrochemistry_e1fd84eb_acdb_4b2c_b90c_e899d552a3ee\",\n",
-      "    \"Voltage\": \"emmo:EMMO_17b031fb_4695_49b6_bb69_189ec63df3ee\",\n",
-      "    \"ElectricCurrent\": \"emmo:EMMO_c995ae70_3b84_4ebb_bcfc_69e6a281bb88\",\n",
-      "    \"Duration\": \"emmo:EMMO_0adabf6f_7404_44cb_9f65_32d83d8101a3\",\n",
-      "    \"NumberOfIterations\": \"electrochemistry:electrochemistry_88dd2bce_fb17_4705_905d_892681812290\",\n",
-      "    \"AmperePerAmpereHour\": \"electrochemistry:AmperePerAmpereHour\",\n",
-      "    \"hasTask\": {\n",
-      "      \"@id\": \"https://w3id.org/emmo#EMMO_70da982d_1810_4b01_9630_a28e216ecd9a\",\n",
-      "      \"@type\": \"@id\"\n",
-      "    },\n",
-      "    \"ConstantCurrentCharging\": \"https://w3id.org/emmo/domain/electrochemistry#electrochemistry_83f2b1e9_cb67_4dbf_977f_ba54bbae374f\",\n",
-      "    \"ConstantCurrentDischarging\": \"https://w3id.org/emmo/domain/electrochemistry#electrochemistry_53fe3f58_0802_41cf_af69_4784fc42cc30\",\n",
-      "    \"ConstantCurrentConstantVoltageCharging\": \"https://w3id.org/emmo/domain/electrochemistry#electrochemistry_0cc8f231_0ce5_467e_9c76_29b2c80349ad\",\n",
-      "    \"ConstantPowerCharging\": \"https://w3id.org/emmo/domain/electrochemistry#electrochemistry_dcd4a15d_52cf_44fb_b826_df18e4baa89c\",\n",
-      "    \"ConstantPowerDischarging\": \"https://w3id.org/emmo/domain/electrochemistry#electrochemistry_a2f65954_1ed8_4faf_9efe_597018d03e8d\",\n",
-      "    \"VoltageHold\": \"https://w3id.org/emmo/domain/electrochemistry#electrochemistry_f07be701_9d6a_415b_ac6d_63202297a7a1\",\n",
-      "    \"OpenCircuitHold\": \"https://w3id.org/emmo/domain/characterisation-methodology/chameo#OpenCircuitHold\",\n",
-      "    \"IterativeWorkflow\": \"https://w3id.org/emmo#EMMO_ddecfff6_d3a1_4972_b9e9_3d0ca11a3a0b\",\n",
-      "    \"ElectrochemicalImpedanceSpectroscopy\": \"https://w3id.org/emmo/domain/characterisation-methodology/chameo#ElectrochemicalImpedanceSpectroscopy\",\n",
-      "    \"LinearScanVoltammetry\": \"https://w3id.org/emmo/domain/characterisation-methodology/chameo#LinearScanVoltammetry\",\n",
-      "    \"TerminationQuantity\": \"https://w3id.org/emmo/domain/electrochemistry#electrochemistry_44a67eb4_52e8_433c_aef7_a928c2b9906c\",\n",
-      "    \"Power\": \"https://w3id.org/emmo#EMMO_09b9021b_f97b_43eb_b83d_0a764b472bc2\"\n",
-      "  },\n",
-      "  \"@graph\": [\n",
+      "  \"id\": \"https://w3id.org/battinfo/dataset/0rp6-kncv-cyem-qwcd\",\n",
+      "  \"short_id\": \"0rp6kn\",\n",
+      "  \"identifier\": \"dataset:0rp6-kncv-cyem-qwcd\",\n",
+      "  \"name\": \"1C cycle life, cell A001 data\",\n",
+      "  \"license\": \"CC-BY-4.0\",\n",
+      "  \"access_url\": \"file:///<repo>/docs/guides/_scratch/guide-03/inputs/sdi-a001-cycle-life.csv\",\n",
+      "  \"created_at\": 1783411782,\n",
+      "  \"modified_at\": 1783411782,\n",
+      "  \"published_at\": 1783411782,\n",
+      "  \"about\": [\n",
+      "    \"https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7\",\n",
+      "    \"https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt\"\n",
+      "  ],\n",
+      "  \"distributions\": [\n",
       "    {\n",
-      "      \"@type\": [\n",
-      "        \"dcat:Catalog\",\n",
-      "        \"schema:DataCatalog\",\n",
-      "        \"schema:Dataset\"\n",
-      "      ],\n",
-      "      \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
-      "      \"schema:url\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
-      "      \"dcat:dataset\": [\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"schema:hasPart\": [\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"rdfs:seeAlso\": {\n",
-      "        \"@id\": \"https://www.battery-genome.org/registry\"\n",
-      "      },\n",
-      "      \"schema:distribution\": [\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
-      "          \"schema:encodingFormat\": \"application/vnd.battinfo.dataset-directory\",\n",
-      "          \"schema:name\": \"sdi-a001-cycle-life\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
-      "          \"schema:encodingFormat\": \"application/json\",\n",
-      "          \"schema:name\": \"datacite-metadata.json\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          },\n",
-      "          \"schema:sha256\": \"71ec2531c00a52b7ef4afd301c550a12ae690363d61ba94441f37166c2850a60\"\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
-      "          \"schema:encodingFormat\": \"application/json\",\n",
-      "          \"schema:name\": \"ro-crate-metadata.json\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          },\n",
-      "          \"schema:sha256\": \"3a4998201bf15f4414843be26e226440c36731f22d0c1bf973090c625684b86a\"\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
-      "          \"schema:encodingFormat\": \"application/vnd.ms-excel\",\n",
-      "          \"schema:name\": \"sdi-a001-cycle-life.csv\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          },\n",
-      "          \"schema:sha256\": \"96969df113b96d2eb06ec66053d03351116ac55828caea0a13441e0e0e5a3bd6\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"schema:name\": \"INR21700-50E A001 cycle-life dataset\",\n",
-      "      \"dcterms:title\": \"INR21700-50E A001 cycle-life dataset\",\n",
-      "      \"schema:description\": \"Voltage, current, and temperature time-series, 500 cycles.\",\n",
-      "      \"dcterms:description\": \"Voltage, current, and temperature time-series, 500 cycles.\",\n",
-      "      \"dcterms:language\": \"en\",\n",
-      "      \"schema:inLanguage\": \"en\",\n",
-      "      \"schema:about\": [\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/spec/me0t-k16f-eh5y-rq0k\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"schema:keywords\": [\n",
-      "        \"Li-ion\",\n",
-      "        \"Samsung SDI\",\n",
-      "        \"battery\",\n",
-      "        \"cycling\",\n",
-      "        \"cylindrical\"\n",
-      "      ],\n",
-      "      \"dcat:keyword\": [\n",
-      "        \"Li-ion\",\n",
-      "        \"Samsung SDI\",\n",
-      "        \"battery\",\n",
-      "        \"cycling\",\n",
-      "        \"cylindrical\"\n",
-      "      ]\n",
-      "    },\n",
-      "    {\n",
-      "      \"@type\": [\n",
-      "        \"dcat:Dataset\",\n",
-      "        \"schema:Dataset\"\n",
-      "      ],\n",
-      "      \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\",\n",
-      "      \"schema:name\": \"INR21700-50E A001 cycle-life dataset\",\n",
-      "      \"dcat:distribution\": [\n",
-      "        {\n",
-      "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
-      "          \"dcat:mediaType\": {\n",
-      "            \"@id\": \"https://www.iana.org/assignments/media-types/application/vnd.battinfo.dataset-directory\"\n",
-      "          },\n",
-      "          \"schema:name\": \"sdi-a001-cycle-life\",\n",
-      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
-      "          \"prov:wasDerivedFrom\": {\n",
-      "            \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\"\n",
-      "          },\n",
-      "          \"prov:wasGeneratedBy\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/test/v8gg-g6as-hync-2wb9\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
-      "          \"dcat:mediaType\": {\n",
-      "            \"@id\": \"https://www.iana.org/assignments/media-types/application/json\"\n",
-      "          },\n",
-      "          \"schema:name\": \"datacite-metadata.json\",\n",
-      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
-      "          \"spdx:checksum\": {\n",
-      "            \"@type\": \"spdx:Checksum\",\n",
-      "            \"spdx:checksumAlgorithm\": {\n",
-      "              \"@id\": \"spdx:checksumAlgorithm_sha256\"\n",
-      "            },\n",
-      "            \"spdx:checksumValue\": \"71ec2531c00a52b7ef4afd301c550a12ae690363d61ba94441f37166c2850a60\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
-      "          \"dcat:mediaType\": {\n",
-      "            \"@id\": \"https://www.iana.org/assignments/media-types/application/json\"\n",
-      "          },\n",
-      "          \"schema:name\": \"ro-crate-metadata.json\",\n",
-      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
-      "          \"spdx:checksum\": {\n",
-      "            \"@type\": \"spdx:Checksum\",\n",
-      "            \"spdx:checksumAlgorithm\": {\n",
-      "              \"@id\": \"spdx:checksumAlgorithm_sha256\"\n",
-      "            },\n",
-      "            \"spdx:checksumValue\": \"3a4998201bf15f4414843be26e226440c36731f22d0c1bf973090c625684b86a\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"dcat:Distribution\",\n",
-      "          \"dcat:downloadURL\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
-      "          \"dcat:mediaType\": {\n",
-      "            \"@id\": \"https://www.iana.org/assignments/media-types/application/vnd.ms-excel\"\n",
-      "          },\n",
-      "          \"schema:name\": \"sdi-a001-cycle-life.csv\",\n",
-      "          \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
-      "          \"spdx:checksum\": {\n",
-      "            \"@type\": \"spdx:Checksum\",\n",
-      "            \"spdx:checksumAlgorithm\": {\n",
-      "              \"@id\": \"spdx:checksumAlgorithm_sha256\"\n",
-      "            },\n",
-      "            \"spdx:checksumValue\": \"96969df113b96d2eb06ec66053d03351116ac55828caea0a13441e0e0e5a3bd6\"\n",
-      "          }\n",
-      "        }\n",
-      "      ],\n",
-      "      \"schema:distribution\": [\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life\",\n",
-      "          \"schema:encodingFormat\": \"application/vnd.battinfo.dataset-directory\",\n",
-      "          \"schema:name\": \"sdi-a001-cycle-life\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/datacite-metadata.json\",\n",
-      "          \"schema:encodingFormat\": \"application/json\",\n",
-      "          \"schema:name\": \"datacite-metadata.json\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          },\n",
-      "          \"schema:sha256\": \"71ec2531c00a52b7ef4afd301c550a12ae690363d61ba94441f37166c2850a60\"\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/ro-crate-metadata.json\",\n",
-      "          \"schema:encodingFormat\": \"application/json\",\n",
-      "          \"schema:name\": \"ro-crate-metadata.json\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          },\n",
-      "          \"schema:sha256\": \"3a4998201bf15f4414843be26e226440c36731f22d0c1bf973090c625684b86a\"\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"schema:DataDownload\",\n",
-      "          \"schema:contentUrl\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life/sdi-a001-cycle-life.csv\",\n",
-      "          \"schema:encodingFormat\": \"application/vnd.ms-excel\",\n",
-      "          \"schema:name\": \"sdi-a001-cycle-life.csv\",\n",
-      "          \"schema:isPartOf\": {\n",
-      "            \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "          },\n",
-      "          \"schema:sha256\": \"96969df113b96d2eb06ec66053d03351116ac55828caea0a13441e0e0e5a3bd6\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"dcterms:isPartOf\": {\n",
-      "        \"@id\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\"\n",
-      "      },\n",
-      "      \"schema:about\": [\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/cell/7nq8-4h5y-febz-zbgf\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"schema:description\": \"Voltage, current, and temperature time-series, 500 cycles.\",\n",
-      "      \"schema:license\": \"CC-BY-4.0\",\n",
-      "      \"schema:dateCreated\": \"2026-07-06T20:02:52Z\",\n",
-      "      \"schema:dateModified\": \"2026-07-06T20:02:52Z\",\n",
-      "      \"schema:url\": \"file:///<repo>/.battinfo/notebooks/guide-03/publication/sdi-a001-cycle-life\",\n",
-      "      \"schema:datePublished\": 1783368172\n",
-      "    },\n",
-      "    {\n",
-      "      \"@type\": [\n",
-      "        \"BatteryCellSpecification\",\n",
-      "        \"schema:CreativeWork\"\n",
-      "      ],\n",
-      "      \"@id\": \"https://w3id.org/battinfo/spec/me0t-k16f-eh5y-rq0k\",\n",
-      "      \"schema:name\": \"Samsung SDI INR21700-50E\",\n",
-      "      \"schema:model\": \"INR21700-50E\",\n",
-      "      \"schema:manufacturer\": {\n",
-      "        \"@type\": \"schema:Organization\",\n",
-      "        \"schema:name\": \"Samsung SDI\"\n",
-      "      },\n",
-      "      \"schema:url\": \"https://www.battery-genome.org/registry/spec/me0t-k16f-eh5y-rq0k\",\n",
-      "      \"isDescriptionFor\": {\n",
-      "        \"@type\": [\n",
-      "          \"BatteryCell\",\n",
-      "          \"CylindricalBattery\",\n",
-      "          \"LithiumIonBattery\"\n",
-      "        ]\n",
-      "      },\n",
-      "      \"battinfo:chemistry\": \"Li-ion\",\n",
-      "      \"battinfo:cellFormat\": \"cylindrical\",\n",
-      "      \"hasProperty\": [\n",
-      "        {\n",
-      "          \"@type\": \"NominalCapacity\",\n",
-      "          \"hasNumericalPart\": {\n",
-      "            \"hasNumberValue\": 5.0\n",
-      "          },\n",
-      "          \"hasMeasurementUnit\": {\n",
-      "            \"@id\": \"emmo:AmpereHour\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"NominalVoltage\",\n",
-      "          \"hasNumericalPart\": {\n",
-      "            \"hasNumberValue\": 3.6\n",
-      "          },\n",
-      "          \"hasMeasurementUnit\": {\n",
-      "            \"@id\": \"emmo:Volt\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"NominalEnergy\",\n",
-      "          \"hasNumericalPart\": {\n",
-      "            \"hasNumberValue\": 18.0\n",
-      "          },\n",
-      "          \"hasMeasurementUnit\": {\n",
-      "            \"@id\": \"emmo:WattHour\"\n",
-      "          }\n",
-      "        },\n",
-      "        {\n",
-      "          \"@type\": \"Mass\",\n",
-      "          \"hasNumericalPart\": {\n",
-      "            \"hasNumberValue\": 68.0\n",
-      "          },\n",
-      "          \"hasMeasurementUnit\": {\n",
-      "            \"@id\": \"emmo:Gram\"\n",
-      "          }\n",
-      "        }\n",
-      "      ]\n",
-      "    },\n",
-      "    {\n",
-      "      \"@type\": [\n",
-      "        \"BatteryCell\",\n",
-      "        \"CylindricalBattery\",\n",
-      "        \"LithiumIonBattery\"\n",
-      "      ],\n",
-      "      \"@id\": \"https://w3id.org/battinfo/cell/7nq8-4h5y-febz-zbgf\",\n",
-      "      \"dcterms:conformsTo\": {\n",
-      "        \"@id\": \"https://w3id.org/battinfo/spec/me0t-k16f-eh5y-rq0k\"\n",
-      "      },\n",
-      "      \"hasDescription\": {\n",
-      "        \"@id\": \"https://w3id.org/battinfo/spec/me0t-k16f-eh5y-rq0k\"\n",
-      "      },\n",
-      "      \"schema:name\": \"sdi-inr21700-50e-batch2026-A001\",\n",
-      "      \"schema:serialNumber\": \"sdi-inr21700-50e-batch2026-A001\"\n",
-      "    },\n",
-      "    {\n",
-      "      \"@type\": [\n",
-      "        \"BatteryTest\",\n",
-      "        \"schema:Action\",\n",
-      "        \"prov:Activity\"\n",
-      "      ],\n",
-      "      \"@id\": \"https://w3id.org/battinfo/test/v8gg-g6as-hync-2wb9\",\n",
-      "      \"hasTestObject\": {\n",
-      "        \"@id\": \"https://w3id.org/battinfo/cell/7nq8-4h5y-febz-zbgf\"\n",
-      "      },\n",
-      "      \"prov:used\": [\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/cell/7nq8-4h5y-febz-zbgf\"\n",
-      "        },\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/spec/m6v9-nnpe-krwk-f652\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"schema:name\": \"1C Cycle Life at 25 \\u00b0C \\u2014 sdi-inr21700-50e-batch2026-A001\",\n",
-      "      \"rdfs:label\": \"1C Cycle Life at 25 \\u00b0C \\u2014 sdi-inr21700-50e-batch2026-A001\",\n",
-      "      \"schema:additionalType\": \"cycling\",\n",
-      "      \"schema:measurementTechnique\": \"1C Cycle Life at 25 \\u00b0C\",\n",
-      "      \"hasTestEquipment\": {\n",
-      "        \"@type\": \"schema:Thing\",\n",
-      "        \"schema:name\": \"Biologic VMP-300\"\n",
-      "      },\n",
-      "      \"hasOutput\": [\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "        }\n",
-      "      ],\n",
-      "      \"prov:generated\": [\n",
-      "        {\n",
-      "          \"@id\": \"https://w3id.org/battinfo/dataset/96kd-vyes-9dp1-6cx6\"\n",
-      "        }\n",
-      "      ]\n",
-      "    }\n",
-      "  ]\n",
-      "}\n"
+      "      \"type\": \"DataDownload\",\n",
+      "      \"content_url\": \"file:///<repo>/docs/guides/_scratch/guide-03/inputs/sdi-a001-cycle-life.c\n",
+      "  ...\n",
+      "\n",
+      "ok: True | errors: 0 | warnings: 0\n"
      ]
     }
    ],
    "source": [
-    "print(json.dumps(bundle, indent=2))"
+    "from battinfo import validate_record_report\n",
+    "\n",
+    "dataset_file = next((records_root / \"dataset\").glob(\"*.json\"))\n",
+    "dataset_doc = json.loads(dataset_file.read_text(encoding=\"utf-8\"))\n",
+    "\n",
+    "print(json.dumps(dataset_doc[\"dataset\"], indent=2)[:800])\n",
+    "print(\"  ...\")\n",
+    "\n",
+    "report = validate_record_report(dataset_doc, source_root=records_root)\n",
+    "print(\"\\nok:\", report.ok, \"| errors:\", len(report.errors),\n",
+    "      \"| warnings:\", len(report.warnings))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6cc5c602",
+   "id": "a573976a",
    "metadata": {},
    "source": [
-    "## Step 9: Publish"
+    "## Step 7 — Preview the publication\n",
+    "\n",
+    "`ws.preview_jsonld()` builds the exact JSON-LD document that publishing would\n",
+    "produce — one `@graph` with every linked record — without creating any\n",
+    "deposit. `ws.export(\"ttl\")` serialises the workspace as Turtle or any other\n",
+    "RDF format:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "500848dc",
+   "execution_count": 8,
+   "id": "bac15f6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:53.210249Z",
-     "iopub.status.busy": "2026-07-06T20:02:53.210249Z",
-     "iopub.status.idle": "2026-07-06T20:02:53.253324Z",
-     "shell.execute_reply": "2026-07-06T20:02:53.252304Z"
+     "iopub.execute_input": "2026-07-07T08:09:43.945782Z",
+     "iopub.status.busy": "2026-07-07T08:09:43.945782Z",
+     "iopub.status.idle": "2026-07-07T08:09:44.305456Z",
+     "shell.execute_reply": "2026-07-07T08:09:44.305456Z"
     }
    },
    "outputs": [
@@ -1308,95 +443,58 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Published IRI: https://w3id.org/battinfo/spec/me0t-k16f-eh5y-rq0k\n",
-      "Registry publish shown commented out.\n"
+      "  Gold-standard: PASS (no validation issues)\n",
+      "  Written: <repo>\\docs\\guides\\_scratch\\guide-03\\battinfo.preview.jsonld\n",
+      "  Graph nodes: 7\n",
+      "  Data files:  1\n",
+      "  dcat:Catalog/schema:DataCatalog               RECORD_ID\n",
+      "  dcat:Dataset/schema:Dataset                   0rp6-kncv-cyem-qwcd\n",
+      "  BatteryCellSpecification/schema:CreativeWork  me0t-k16f-eh5y-rq0k\n",
+      "  prov:Plan/schema:HowTo                        kxwy-5f5f-f682-hhch\n",
+      "  BatteryCell/CylindricalBattery                3w87-0ddf-ryjg-evxe\n",
+      "  BatteryCell/CylindricalBattery                y9xy-kr0v-y5tn-dfj7\n",
+      "  BatteryTest/schema:Action                     6nec-h262-tthy-4rnt\n"
      ]
     }
    ],
    "source": [
-    "from battinfo import publish\n",
-    "\n",
-    "result = publish(cell_spec, destination=\"local\", root=WORKSPACE / \"published\")\n",
-    "print(\"Published IRI:\", result.canonical_iri)\n",
-    "\n",
-    "# Registry publish (fill in credentials):\n",
-    "# result = publish(\n",
-    "#     cell_spec, destination=\"registry\",\n",
-    "#     root=WORKSPACE / \"submissions\",\n",
-    "#     registry_base_url=\"https://registry.example.org\",\n",
-    "#     api_key=\"your-api-key\",\n",
-    "#     workspace_id=\"example-lab\",\n",
-    "#     publisher_id=\"sintef-industry\",\n",
-    "#     source_version=\"2026-05-04\",\n",
-    "# )\n",
-    "print(\"Registry publish shown commented out.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e8eb7e6",
-   "metadata": {},
-   "source": [
-    "## Querying saved records"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "6881e18a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:53.255313Z",
-     "iopub.status.busy": "2026-07-06T20:02:53.255313Z",
-     "iopub.status.idle": "2026-07-06T20:02:53.260838Z",
-     "shell.execute_reply": "2026-07-06T20:02:53.260838Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 1 cylindrical Li-ion cell spec(s)\n",
-      "Found 1 dataset(s) linked to cell 7nq8-4h5y-febz-zbgf\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo import query_cell_specs, query_datasets\n",
-    "\n",
-    "cell_specs = query_cell_specs(\n",
-    "    chemistry=\"Li-ion\",\n",
-    "    format=\"cylindrical\",\n",
-    "    cell_specs_dir=WORKSPACE / \"examples\" / \"cell-spec\",\n",
+    "preview_path = ws.preview_jsonld(\n",
+    "    title=\"INR21700-50E cycle-life walkthrough\",\n",
+    "    license=\"CC-BY-4.0\",\n",
+    "    creators=[{\"name\": \"Jane Smith\", \"orcid\": \"0000-0002-1825-0097\"}],\n",
     ")\n",
-    "print(f\"Found {len(cell_specs)} cylindrical Li-ion cell spec(s)\")\n",
+    "preview = json.loads(preview_path.read_text(encoding=\"utf-8\"))\n",
     "\n",
-    "datasets = query_datasets(\n",
-    "    related_cell_id=cell.id,\n",
-    "    directory=WORKSPACE / \"examples\" / \"dataset\",\n",
-    ")\n",
-    "print(f\"Found {len(datasets)} dataset(s) linked to cell {cell.id.split('/')[-1]}\")"
+    "for node in preview[\"@graph\"]:\n",
+    "    types = node.get(\"@type\", \"?\")\n",
+    "    label = types if isinstance(types, str) else \"/\".join(types[:2])\n",
+    "    uid = str(node.get(\"@id\", \"\")).rsplit(\"/\", 1)[-1]\n",
+    "    print(f\"  {label:45s} {uid[:40]}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "59e152df",
+   "id": "e5115a73",
    "metadata": {},
    "source": [
-    "## Loading a received package"
+    "## Step 8 — Publish\n",
+    "\n",
+    "`ws.publish()` submits the records to the registry review queue (staged — a\n",
+    "curator promotes them to the public index); `zenodo=True` archives the data\n",
+    "with a citable DOI first. Both need credentials, so this cell is a guarded\n",
+    "no-op without them:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "756b68ff",
+   "execution_count": 9,
+   "id": "17b1abe0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:53.262850Z",
-     "iopub.status.busy": "2026-07-06T20:02:53.262850Z",
-     "iopub.status.idle": "2026-07-06T20:02:53.267911Z",
-     "shell.execute_reply": "2026-07-06T20:02:53.267911Z"
+     "iopub.execute_input": "2026-07-07T08:09:44.305456Z",
+     "iopub.status.busy": "2026-07-07T08:09:44.305456Z",
+     "iopub.status.idle": "2026-07-07T08:09:44.312137Z",
+     "shell.execute_reply": "2026-07-07T08:09:44.312137Z"
     }
    },
    "outputs": [
@@ -1404,33 +502,113 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cell spec manufacturer: Samsung SDI\n",
-      "Cell serial number:     sdi-inr21700-50e-batch2026-A001\n",
-      "Test kind:              cycling\n",
-      "Dataset object type:    Dataset\n"
+      "Records are saved and validated locally.\n",
+      "To publish: ws.login(api_key='...') then ws.publish() — see ws.quickstart().\n"
      ]
     }
    ],
    "source": [
-    "from battinfo import load_publication_package\n",
+    "import os\n",
     "\n",
-    "bundle_obj = load_publication_package(pkg_path)\n",
-    "\n",
-    "print(\"Cell spec manufacturer:\", bundle_obj.cell_spec.manufacturer)\n",
-    "print(\"Cell serial number:    \", bundle_obj.cell_instance.serial_number)\n",
-    "print(\"Test kind:             \", bundle_obj.test.test_kind)\n",
-    "print(\"Dataset object type:   \", type(bundle_obj.dataset).__name__)"
+    "if os.environ.get(\"BATTINFO_API_KEY\"):\n",
+    "    ws.publish(note=\"Guide 3 walkthrough — INR21700-50E cycle life\")\n",
+    "    ws.status()\n",
+    "else:\n",
+    "    print(\"Records are saved and validated locally.\")\n",
+    "    print(\"To publish: ws.login(api_key='...') then ws.publish() — see ws.quickstart().\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cecf7263",
+   "id": "44839ab5",
+   "metadata": {},
+   "source": [
+    "## What the workspace holds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2647bdf5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:09:44.314999Z",
+     "iopub.status.busy": "2026-07-07T08:09:44.314999Z",
+     "iopub.status.idle": "2026-07-07T08:09:44.324761Z",
+     "shell.execute_reply": "2026-07-07T08:09:44.324761Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Workspace: <repo>\\docs\\guides\\_scratch\\guide-03\\.battinfo\\records\n",
+      "  6 record(s) across 5 type(s):\n",
+      "\n",
+      "  cell-spec (1)\n",
+      "    Samsung SDI INR21700-50E\n",
+      "  cell-instance (2)\n",
+      "    A002, A001\n",
+      "  test (1)\n",
+      "    1C cycle life, cell A001\n",
+      "  dataset (1)\n",
+      "    1C cycle life, cell A001 data\n",
+      "  test-protocol (1)\n",
+      "    1C cycle life at 25 °C\n",
+      "\n",
+      "  * 6 record(s) from this session (will be submitted by ws.submit())\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'cell-spec': [{'name': 'Samsung SDI INR21700-50E',\n",
+       "   'id': 'https://w3id.org/battinfo/spec/me0t-k16f-eh5y-rq0k',\n",
+       "   'file': 'cell-spec-me0t-k16f-eh5y-rq0k.json',\n",
+       "   'session': True}],\n",
+       " 'cell-instance': [{'name': 'A002',\n",
+       "   'id': 'https://w3id.org/battinfo/cell/3w87-0ddf-ryjg-evxe',\n",
+       "   'file': 'cell-3w87-0ddf-ryjg-evxe.json',\n",
+       "   'session': True},\n",
+       "  {'name': 'A001',\n",
+       "   'id': 'https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7',\n",
+       "   'file': 'cell-y9xy-kr0v-y5tn-dfj7.json',\n",
+       "   'session': True}],\n",
+       " 'test': [{'name': '1C cycle life, cell A001',\n",
+       "   'id': 'https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt',\n",
+       "   'file': 'test-6nec-h262-tthy-4rnt.json',\n",
+       "   'session': True}],\n",
+       " 'dataset': [{'name': '1C cycle life, cell A001 data',\n",
+       "   'id': 'https://w3id.org/battinfo/dataset/0rp6-kncv-cyem-qwcd',\n",
+       "   'file': 'dataset-0rp6-kncv-cyem-qwcd.json',\n",
+       "   'session': True}],\n",
+       " 'test-protocol': [{'name': '1C cycle life at 25 °C',\n",
+       "   'id': 'https://w3id.org/battinfo/spec/kxwy-5f5f-f682-hhch',\n",
+       "   'file': 'test-protocol-kxwy-5f5f-f682-hhch.json',\n",
+       "   'session': True}]}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ws.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b531ba9",
    "metadata": {},
    "source": [
     "## Next\n",
     "\n",
-    "- **[Guide 4 — Semantic layer](04-semantic-layer.ipynb)**: understand the JSON-LD and work with it as RDF\n",
-    "- **[Guide 5 — Descriptors](05-descriptors.ipynb)**: add electrode composition and construction details"
+    "- **[Guide 4 — Semantic layer](04-semantic-layer.ipynb)**: the JSON-LD behind\n",
+    "  these records, and how to work with it as RDF\n",
+    "- **[Guide 6 — Publish your first dataset](06-publish-your-data.ipynb)**: this\n",
+    "  same chain, built from a raw cycler export in five stages"
    ]
   }
  ],

--- a/docs/guides/04-semantic-layer.ipynb
+++ b/docs/guides/04-semantic-layer.ipynb
@@ -19,20 +19,13 @@
    "id": "b9975261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:02:58.573233Z",
-     "iopub.status.busy": "2026-07-06T20:02:58.573233Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.222597Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.222092Z"
+     "iopub.execute_input": "2026-07-07T08:09:49.704192Z",
+     "iopub.status.busy": "2026-07-07T08:09:49.704192Z",
+     "iopub.status.idle": "2026-07-07T08:09:50.775737Z",
+     "shell.execute_reply": "2026-07-07T08:09:50.774729Z"
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running from the repo root.\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -42,25 +35,15 @@
     }
    ],
    "source": [
-    "import os, json, warnings\n",
+    "import json\n",
+    "import warnings\n",
     "from pathlib import Path\n",
     "\n",
-    "_here = Path.cwd()\n",
-    "if (_here / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here\n",
-    "elif (_here.parent.parent / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here.parent.parent\n",
-    "    os.chdir(REPO)\n",
-    "else:\n",
-    "    REPO = _here\n",
+    "SCRATCH = Path(\"_scratch/guide-04\")\n",
+    "SCRATCH.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "print(\"Running from the repo root.\")\n",
-    "\n",
-    "from battinfo import CellSpec, publish, Workspace\n",
+    "from battinfo import CellSpec, publish\n",
     "from battinfo.api import publish_record\n",
-    "\n",
-    "WORKSPACE = REPO / '.battinfo/notebooks/guide-04'\n",
-    "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "cell_spec = CellSpec(\n",
     "    manufacturer=\"A123 Systems\",\n",
@@ -82,10 +65,10 @@
     "    },\n",
     ")\n",
     "\n",
-    "result = publish(cell_spec, destination=\"local\", root=WORKSPACE)\n",
+    "result = publish(cell_spec, destination=\"local\", root=SCRATCH)\n",
     "output = publish_record(\n",
     "    result.debug_paths[\"canonical_record_path\"],\n",
-    "    target_root=WORKSPACE / \"resolver\",\n",
+    "    target_root=SCRATCH / \"resolver\",\n",
     ")\n",
     "\n",
     "jsonld_path = Path(output[\"output_dir\"], \"index.jsonld\")\n",
@@ -107,10 +90,10 @@
    "id": "df15cfe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.225603Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.225603Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.229933Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.228920Z"
+     "iopub.execute_input": "2026-07-07T08:09:50.781734Z",
+     "iopub.status.busy": "2026-07-07T08:09:50.781734Z",
+     "iopub.status.idle": "2026-07-07T08:09:50.787247Z",
+     "shell.execute_reply": "2026-07-07T08:09:50.786742Z"
     }
    },
    "outputs": [
@@ -255,10 +238,10 @@
    "id": "310d641b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.230943Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.230943Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.234583Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.234583Z"
+     "iopub.execute_input": "2026-07-07T08:09:50.790253Z",
+     "iopub.status.busy": "2026-07-07T08:09:50.789253Z",
+     "iopub.status.idle": "2026-07-07T08:09:50.794230Z",
+     "shell.execute_reply": "2026-07-07T08:09:50.793225Z"
     }
    },
    "outputs": [
@@ -335,10 +318,10 @@
    "id": "idf-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.234583Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.234583Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.242028Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.241390Z"
+     "iopub.execute_input": "2026-07-07T08:09:50.797230Z",
+     "iopub.status.busy": "2026-07-07T08:09:50.796231Z",
+     "iopub.status.idle": "2026-07-07T08:09:50.801814Z",
+     "shell.execute_reply": "2026-07-07T08:09:50.801814Z"
     }
    },
    "outputs": [
@@ -373,10 +356,10 @@
    "id": "117501cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.244040Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.244040Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.247505Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.247505Z"
+     "iopub.execute_input": "2026-07-07T08:09:50.804987Z",
+     "iopub.status.busy": "2026-07-07T08:09:50.803985Z",
+     "iopub.status.idle": "2026-07-07T08:09:50.808906Z",
+     "shell.execute_reply": "2026-07-07T08:09:50.808906Z"
     }
    },
    "outputs": [
@@ -385,13 +368,13 @@
      "output_type": "stream",
      "text": [
       "Quantitative properties:\n",
-      "  NominalCapacity: None  (AmpereHour)\n",
-      "  NominalVoltage: None  (Volt)\n",
-      "  NominalEnergy: None  (WattHour)\n",
-      "  Mass: None  (Gram)\n",
-      "  Diameter: None  (MilliMetre)\n",
-      "  Height: None  (MilliMetre)\n",
-      "  InternalResistance: None  (MilliOhm)\n",
+      "  NominalCapacity: 2.5  (AmpereHour)\n",
+      "  NominalVoltage: 3.3  (Volt)\n",
+      "  NominalEnergy: 8.25  (WattHour)\n",
+      "  Mass: 76.0  (Gram)\n",
+      "  Diameter: 26.0  (MilliMetre)\n",
+      "  Height: 65.0  (MilliMetre)\n",
+      "  InternalResistance: 6.0  (MilliOhm)\n",
       "  CycleLife: None  (EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978)\n"
      ]
     }
@@ -401,7 +384,7 @@
     "for prop in jsonld.get(\"hasProperty\", []):\n",
     "    types = prop[\"@type\"]\n",
     "    class_name = types[0] if isinstance(types, list) else types\n",
-    "    value = prop.get(\"hasNumericalPart\", {}).get(\"hasNumericalValue\")\n",
+    "    value = prop.get(\"hasNumericalPart\", {}).get(\"hasNumberValue\")\n",
     "    unit  = prop.get(\"hasMeasurementUnit\", \"\").split(\"#\")[-1]\n",
     "    print(f\"  {class_name}: {value}  ({unit})\")"
    ]
@@ -430,10 +413,10 @@
    "id": "cfe8dd30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.250163Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.250163Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.324961Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.324961Z"
+     "iopub.execute_input": "2026-07-07T08:09:50.812156Z",
+     "iopub.status.busy": "2026-07-07T08:09:50.811121Z",
+     "iopub.status.idle": "2026-07-07T08:09:50.915238Z",
+     "shell.execute_reply": "2026-07-07T08:09:50.914229Z"
     }
    },
    "outputs": [
@@ -474,10 +457,10 @@
    "id": "8b6bd11a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.328129Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.328129Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.900805Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.900283Z"
+     "iopub.execute_input": "2026-07-07T08:09:50.919237Z",
+     "iopub.status.busy": "2026-07-07T08:09:50.919237Z",
+     "iopub.status.idle": "2026-07-07T08:09:51.763031Z",
+     "shell.execute_reply": "2026-07-07T08:09:51.761438Z"
     }
    },
    "outputs": [
@@ -506,10 +489,10 @@
    "id": "efb494cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.900805Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.900805Z",
-     "iopub.status.idle": "2026-07-06T20:03:00.908232Z",
-     "shell.execute_reply": "2026-07-06T20:03:00.907867Z"
+     "iopub.execute_input": "2026-07-07T08:09:51.767011Z",
+     "iopub.status.busy": "2026-07-07T08:09:51.767011Z",
+     "iopub.status.idle": "2026-07-07T08:09:51.771522Z",
+     "shell.execute_reply": "2026-07-07T08:09:51.771522Z"
     }
    },
    "outputs": [
@@ -517,68 +500,68 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  N1d3e1e9c7f124e6fb970956779aaf50a  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N1d3e1e9c7f124e6fb970956779aaf50a  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
-      "  N3462097cbee64177b0a774a5fbe26dbc  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N3462097cbee64177b0a774a5fbe26dbc  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
-      "  N3462097cbee64177b0a774a5fbe26dbc  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N7742f700df934ae5b5c455f4cb59ad69\n",
-      "  N3462097cbee64177b0a774a5fbe26dbc  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
-      "  N38eac6c93bd24d57b0b7cc3a311e072c  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N38eac6c93bd24d57b0b7cc3a311e072c  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
-      "  N4017de0fdb5746e9bba3a37a50d3adfa  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N4017de0fdb5746e9bba3a37a50d3adfa  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
-      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
-      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  value  →  >1000\n",
-      "  N4fc85383ee2c427096ff71b4b9c3be0f  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
-      "  N59d1b51113b94e67b7e854a2b3e31d59  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N59d1b51113b94e67b7e854a2b3e31d59  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
-      "  N59d1b51113b94e67b7e854a2b3e31d59  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N4017de0fdb5746e9bba3a37a50d3adfa\n",
-      "  N59d1b51113b94e67b7e854a2b3e31d59  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
-      "  N662170ea88794178be978ed0c04a4203  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
-      "  N662170ea88794178be978ed0c04a4203  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N662170ea88794178be978ed0c04a4203  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N7490722fb7ce4c408b10c103476c2920\n",
-      "  N662170ea88794178be978ed0c04a4203  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
-      "  N72d63abe691c46738ae43e6f80c95d30  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
-      "  N72d63abe691c46738ae43e6f80c95d30  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N72d63abe691c46738ae43e6f80c95d30  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N85703d1cd50548ada56c0bf072be6bc3\n",
-      "  N72d63abe691c46738ae43e6f80c95d30  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
-      "  N7490722fb7ce4c408b10c103476c2920  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N7490722fb7ce4c408b10c103476c2920  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
-      "  N7742f700df934ae5b5c455f4cb59ad69  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N7742f700df934ae5b5c455f4cb59ad69  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
-      "  N85703d1cd50548ada56c0bf072be6bc3  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N85703d1cd50548ada56c0bf072be6bc3  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
-      "  N8fb8bf41565a47ada3ecc495cc006e54  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N8fb8bf41565a47ada3ecc495cc006e54  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
-      "  N8fb8bf41565a47ada3ecc495cc006e54  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N1d3e1e9c7f124e6fb970956779aaf50a\n",
-      "  N8fb8bf41565a47ada3ecc495cc006e54  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
-      "  Na2e070ae2c3f49888e4c6ffa1bc0498c  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  Na2e070ae2c3f49888e4c6ffa1bc0498c  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
-      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
-      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Na2e070ae2c3f49888e4c6ffa1bc0498c\n",
-      "  Nac9ed68bb617479e8ac93b18e3aeec28  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
-      "  Nb46ae90a1af64e0f9eec363ade23d2f0  →  type  →  Organization\n",
-      "  Nb46ae90a1af64e0f9eec363ade23d2f0  →  name  →  A123 Systems\n",
-      "  Nca4c488c619b40acb7c4616118adbf4b  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nca4c488c619b40acb7c4616118adbf4b  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
-      "  Nca4c488c619b40acb7c4616118adbf4b  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N38eac6c93bd24d57b0b7cc3a311e072c\n",
-      "  Nca4c488c619b40acb7c4616118adbf4b  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
+      "  N0525a14af0004e1f96fa91977385f77c  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N0525a14af0004e1f96fa91977385f77c  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
+      "  N174e0cfccaff4d80979012ba155693f4  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N174e0cfccaff4d80979012ba155693f4  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
+      "  N1b18ce350ca541098835287c5deee1ab  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N1b18ce350ca541098835287c5deee1ab  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
+      "  N1b18ce350ca541098835287c5deee1ab  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N4b4fb6e0dc444465a90c7713fe8255d7\n",
+      "  N1b18ce350ca541098835287c5deee1ab  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
+      "  N2804906720a94571ae9fbd8b809a316f  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N2804906720a94571ae9fbd8b809a316f  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
+      "  N2804906720a94571ae9fbd8b809a316f  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Ndbdf5fdaa6834cb7add4e2e873283d4e\n",
+      "  N2804906720a94571ae9fbd8b809a316f  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
+      "  N2a0214b12a4c4b22ad5f805850d45d85  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N2a0214b12a4c4b22ad5f805850d45d85  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
+      "  N2a0214b12a4c4b22ad5f805850d45d85  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N3548a07986974e458efd5e2e1cb7b095\n",
+      "  N2a0214b12a4c4b22ad5f805850d45d85  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
+      "  N3548a07986974e458efd5e2e1cb7b095  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N3548a07986974e458efd5e2e1cb7b095  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
+      "  N3eebbe98573f4b3e86c3fb7c10ea45c0  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N3eebbe98573f4b3e86c3fb7c10ea45c0  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
+      "  N3eebbe98573f4b3e86c3fb7c10ea45c0  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N0525a14af0004e1f96fa91977385f77c\n",
+      "  N3eebbe98573f4b3e86c3fb7c10ea45c0  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
+      "  N4b4fb6e0dc444465a90c7713fe8255d7  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N4b4fb6e0dc444465a90c7713fe8255d7  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
+      "  N5861f8d4f2854c709527d26c25bbca8b  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N5861f8d4f2854c709527d26c25bbca8b  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
+      "  N6edeff87c41841bc86d41aed8cadc7ba  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
+      "  N6edeff87c41841bc86d41aed8cadc7ba  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N6edeff87c41841bc86d41aed8cadc7ba  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Na79989b6b4d84b34a3dab214986f1b83\n",
+      "  N6edeff87c41841bc86d41aed8cadc7ba  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  N7b3b4683456e45cbbb7652878358beb2  →  type  →  Organization\n",
+      "  N7b3b4683456e45cbbb7652878358beb2  →  name  →  A123 Systems\n",
+      "  Na79989b6b4d84b34a3dab214986f1b83  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Na79989b6b4d84b34a3dab214986f1b83  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
+      "  Nc6d0a1808fe542bc8eb26f19041e5cf8  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
+      "  Nc6d0a1808fe542bc8eb26f19041e5cf8  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nc6d0a1808fe542bc8eb26f19041e5cf8  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N5861f8d4f2854c709527d26c25bbca8b\n",
+      "  Nc6d0a1808fe542bc8eb26f19041e5cf8  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  Ndbdf5fdaa6834cb7add4e2e873283d4e  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Ndbdf5fdaa6834cb7add4e2e873283d4e  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
+      "  Ne11b669bf35748db9762292f9eb8e57e  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Ne11b669bf35748db9762292f9eb8e57e  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
+      "  Ne11b669bf35748db9762292f9eb8e57e  →  value  →  >1000\n",
+      "  Ne11b669bf35748db9762292f9eb8e57e  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
+      "  Nf5b55083f8b6464da059e8491f9048db  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nf5b55083f8b6464da059e8491f9048db  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
+      "  Nf5b55083f8b6464da059e8491f9048db  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N174e0cfccaff4d80979012ba155693f4\n",
+      "  Nf5b55083f8b6464da059e8491f9048db  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  CreativeWork\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  battery_1cfbba6c_8824_4932_a23e_2141483acef7\n",
       "  wckm-y5a4-he0k-2scd  →  identifier  →  wckm-y5a4-he0k-2scd\n",
-      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  Nb46ae90a1af64e0f9eec363ade23d2f0\n",
+      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  N7b3b4683456e45cbbb7652878358beb2\n",
       "  wckm-y5a4-he0k-2scd  →  name  →  A123 Systems ANR26650M1-B\n",
       "  wckm-y5a4-he0k-2scd  →  size  →  R26650\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N3462097cbee64177b0a774a5fbe26dbc\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N4fc85383ee2c427096ff71b4b9c3be0f\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N59d1b51113b94e67b7e854a2b3e31d59\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N662170ea88794178be978ed0c04a4203\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N72d63abe691c46738ae43e6f80c95d30\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N8fb8bf41565a47ada3ecc495cc006e54\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nac9ed68bb617479e8ac93b18e3aeec28\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nca4c488c619b40acb7c4616118adbf4b\n"
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N1b18ce350ca541098835287c5deee1ab\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N2804906720a94571ae9fbd8b809a316f\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N2a0214b12a4c4b22ad5f805850d45d85\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N3eebbe98573f4b3e86c3fb7c10ea45c0\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N6edeff87c41841bc86d41aed8cadc7ba\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nc6d0a1808fe542bc8eb26f19041e5cf8\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ne11b669bf35748db9762292f9eb8e57e\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nf5b55083f8b6464da059e8491f9048db\n"
      ]
     }
    ],
@@ -605,13 +588,25 @@
    "id": "f05bb577",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:00.910743Z",
-     "iopub.status.busy": "2026-07-06T20:03:00.910743Z",
-     "iopub.status.idle": "2026-07-06T20:03:02.228025Z",
-     "shell.execute_reply": "2026-07-06T20:03:02.226534Z"
+     "iopub.execute_input": "2026-07-07T08:09:51.774529Z",
+     "iopub.status.busy": "2026-07-07T08:09:51.773571Z",
+     "iopub.status.idle": "2026-07-07T08:09:53.317469Z",
+     "shell.execute_reply": "2026-07-07T08:09:53.315405Z"
     }
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cell: a123-demo-multi-001  (IRI auto-assigned)\n",
+      "Saved 2 record(s) under <repo>\\docs\\guides\\_scratch\\guide-04\\multi\\.battinfo\\records:\n",
+      "  cell spec   A123 Systems ANR26650M1-B            [updated]  .battinfo\\records\\examples\\cell-spec\\cell-spec-e4t5-w9re-mpq6-8g7e.json\n",
+      "  cell        a123-demo-multi-001                  [updated]  .battinfo\\records\\examples\\cell-instance\\cell-aaqe-rvbd-c0b6-p1k3.json\n",
+      "\n",
+      "  Next: ws.list(verbose=True) to inspect, or ws.publish() to publish.\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -621,21 +616,24 @@
     }
    ],
    "source": [
-    "ws = Workspace(root=WORKSPACE / \"multi\")\n",
-    "ct = ws.cell_spec(\n",
+    "import battinfo\n",
+    "\n",
+    "ws = battinfo.workspace(root=SCRATCH / \"multi\")\n",
+    "multi_spec = battinfo.CellSpec(\n",
     "    manufacturer=\"A123 Systems\", model=\"ANR26650M1-B\",\n",
     "    format=\"cylindrical\", chemistry=\"Li-ion\",\n",
     "    positive_electrode_basis=\"LFP\", negative_electrode_basis=\"graphite\",\n",
     "    properties={\"nominal_capacity\": {\"value\": 2.5, \"unit\": \"Ah\"}},\n",
     ")\n",
-    "ws.cell(ct, serial_number=\"a123-demo-multi-001\")\n",
+    "ws.add(\"cell\", spec=multi_spec, serial_numbers=[\"a123-demo-multi-001\"])\n",
     "ws.save()\n",
     "\n",
-    "# Publish each record as a resolver artifact\n",
+    "# Publish each saved record as a resolver artifact\n",
     "from battinfo.api import publish_record as _publish_one\n",
     "\n",
-    "multi_resolver = WORKSPACE / \"multi-resolver\"\n",
-    "for record_file in sorted((WORKSPACE / \"multi\" / \"examples\").rglob(\"*.json\")):\n",
+    "multi_records = SCRATCH / \"multi\" / \".battinfo\" / \"records\" / \"examples\"\n",
+    "multi_resolver = SCRATCH / \"multi-resolver\"\n",
+    "for record_file in sorted(multi_records.rglob(\"*.json\")):\n",
     "    _publish_one(record_file, target_root=multi_resolver)\n",
     "\n",
     "jsonld_files = list(multi_resolver.rglob(\"index.jsonld\"))\n",
@@ -670,10 +668,10 @@
    "id": "97dfdfc6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:02.229999Z",
-     "iopub.status.busy": "2026-07-06T20:03:02.229999Z",
-     "iopub.status.idle": "2026-07-06T20:03:02.235748Z",
-     "shell.execute_reply": "2026-07-06T20:03:02.234742Z"
+     "iopub.execute_input": "2026-07-07T08:09:53.322466Z",
+     "iopub.status.busy": "2026-07-07T08:09:53.322466Z",
+     "iopub.status.idle": "2026-07-07T08:09:53.329620Z",
+     "shell.execute_reply": "2026-07-07T08:09:53.329620Z"
     }
    },
    "outputs": [
@@ -698,7 +696,8 @@
    ],
    "source": [
     "prop_map = json.loads(\n",
-    "    (REPO / \"assets/mappings/domain-battery/property_map.curated.json\").read_text(encoding=\"utf-8\")\n",
+    "    # Repo files sit two levels up from this notebook.\n",
+    "    Path(\"../../assets/mappings/domain-battery/property_map.curated.json\").read_text(encoding=\"utf-8\")\n",
     ")\n",
     "print(f\"Property map version: {prop_map['version']}\")\n",
     "print(f\"Curated entries: {len(prop_map['mappings'])}\")\n",

--- a/docs/guides/05-descriptors.ipynb
+++ b/docs/guides/05-descriptors.ipynb
@@ -12,7 +12,7 @@
     "**Estimated time:** 40 minutes\n",
     "**Prerequisites:** [Guide 2 — Describing a cell](02-first-cell-type.ipynb)\n",
     "\n",
-    "Everything writes under `.battinfo/notebooks/guide-05`."
+    "Everything writes under `_scratch/guide-05/`."
    ]
   },
   {
@@ -21,40 +21,21 @@
    "id": "1cf55ef0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:07.327667Z",
-     "iopub.status.busy": "2026-07-06T20:03:07.327667Z",
-     "iopub.status.idle": "2026-07-06T20:03:07.338011Z",
-     "shell.execute_reply": "2026-07-06T20:03:07.336537Z"
+     "iopub.execute_input": "2026-07-07T08:10:02.882887Z",
+     "iopub.status.busy": "2026-07-07T08:10:02.882887Z",
+     "iopub.status.idle": "2026-07-07T08:10:02.902105Z",
+     "shell.execute_reply": "2026-07-07T08:10:02.900558Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running from the repo root.\n",
-      "Workspace: .battinfo\\notebooks\\guide-05\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os, json, warnings\n",
+    "import json\n",
     "from pathlib import Path\n",
     "\n",
-    "_here = Path.cwd()\n",
-    "if (_here / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here\n",
-    "elif (_here.parent.parent / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here.parent.parent\n",
-    "    os.chdir(REPO)\n",
-    "else:\n",
-    "    REPO = _here\n",
-    "\n",
-    "print(\"Running from the repo root.\")\n",
-    "\n",
-    "WORKSPACE = REPO / '.battinfo/notebooks/guide-05'\n",
-    "WORKSPACE.mkdir(parents=True, exist_ok=True)\n",
-    "print(\"Workspace:\", WORKSPACE.relative_to(REPO))"
+    "# This notebook runs from its own folder (docs/guides). Everything it\n",
+    "# writes lands in a throwaway scratch folder next to it.\n",
+    "SCRATCH = Path(\"_scratch/guide-05\").resolve()\n",
+    "SCRATCH.mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
@@ -71,10 +52,10 @@
    "id": "ddcca263",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:07.341083Z",
-     "iopub.status.busy": "2026-07-06T20:03:07.341083Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.871547Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.870996Z"
+     "iopub.execute_input": "2026-07-07T08:10:02.910534Z",
+     "iopub.status.busy": "2026-07-07T08:10:02.910534Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.122831Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.121821Z"
     }
    },
    "outputs": [
@@ -120,10 +101,10 @@
    "id": "4b04c30f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.873943Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.872895Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.879493Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.878940Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.132298Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.131298Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.147991Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.146792Z"
     }
    },
    "outputs": [
@@ -160,10 +141,10 @@
    "id": "38095956",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.882069Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.882069Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.887307Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.887307Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.150004Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.150004Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.164985Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.163321Z"
     }
    },
    "outputs": [
@@ -214,10 +195,10 @@
    "id": "3fcb31b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.890669Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.890127Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.895932Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.895932Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.169976Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.169976Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.177729Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.176718Z"
     }
    },
    "outputs": [
@@ -234,10 +215,11 @@
    "source": [
     "from battinfo.authoring import electrolyte_recipe, material as mat\n",
     "\n",
+    "# Salts are materials like any other constituent: the same material(...) form\n",
+    "# as solvents, with the concentration carried inline.\n",
     "lp30 = electrolyte_recipe(\n",
     "    family=\"organic\",\n",
-    "    salt=\"LiPF6\",\n",
-    "    salt_concentration={\"value\": 1.0, \"unit\": \"mol/L\"},\n",
+    "    salt=mat(\"LiPF6\", concentration={\"value\": 1.0, \"unit\": \"mol/L\"}),\n",
     "    solvents=[\n",
     "        mat(\"EC\",  volume_fraction={\"value\": 50, \"unit\": \"%\"}),\n",
     "        mat(\"DMC\", volume_fraction={\"value\": 50, \"unit\": \"%\"}),\n",
@@ -268,10 +250,10 @@
    "id": "7e673ceb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.895932Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.895932Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.904098Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.902855Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.181693Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.181037Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.189234Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.187040Z"
     }
    },
    "outputs": [
@@ -314,10 +296,10 @@
    "id": "70bef49a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.904098Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.904098Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.912518Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.912009Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.193267Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.193267Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.200793Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.200793Z"
     }
    },
    "outputs": [
@@ -325,7 +307,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Assembly: wound / jelly-roll\n"
+      "Assembly: wound / single_layer\n"
      ]
     }
    ],
@@ -334,7 +316,7 @@
     "\n",
     "build = construction(\n",
     "    assembly_type=\"wound\",\n",
-    "    layering=\"jelly-roll\",\n",
+    "    layering=\"single_layer\",\n",
     "    layer_count=1,\n",
     "    comment=\"Single jelly-roll, wound on 4 mm mandrel\",\n",
     ")\n",
@@ -356,10 +338,10 @@
    "id": "b6297d58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.916529Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.915534Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.922153Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.921045Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.200793Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.200793Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.211044Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.211044Z"
     }
    },
    "outputs": [
@@ -401,10 +383,10 @@
    "id": "f9d5ffe7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.924155Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.924155Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.930685Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.929660Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.214970Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.214970Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.223862Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.223862Z"
     }
    },
    "outputs": [
@@ -451,22 +433,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d857cea",
+   "id": "ccf1f5a3",
    "metadata": {},
    "source": [
-    "## Step 9: Serialise the descriptor"
+    "## Step 9: Materials as first-class records\n",
+    "\n",
+    "Every material embedded above can also stand alone. `extract_material_specs`\n",
+    "walks the descriptor — electrode coatings, electrolyte, separator — and lifts\n",
+    "each distinct material into a standalone **material-spec** record with a\n",
+    "deterministic IRI (the same material always mints the same IRI, so specs\n",
+    "deduplicate across cells). Components then reference their spec via\n",
+    "`material_spec_id` — the same spec-and-instance pattern cells use:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "0c953dd6",
+   "id": "85a1b7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.932294Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.932294Z",
-     "iopub.status.idle": "2026-07-06T20:03:08.939313Z",
-     "shell.execute_reply": "2026-07-06T20:03:08.938306Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.223862Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.223862Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.234796Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.234796Z"
     }
    },
    "outputs": [
@@ -474,19 +463,72 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Written: descriptors\\a123-anr26650m1-b.descriptor.json\n",
+      "14 standalone material spec(s):\n",
+      "  LFP            active_material        https://w3id.org/battinfo/material-spec/s6y8-5mne-94gx-e5ve\n",
+      "  PVDF           binder                 https://w3id.org/battinfo/material-spec/fm9p-sqkk-tbx3-rr66\n",
+      "  Carbon black   conductive_additive    https://w3id.org/battinfo/material-spec/xz03-r714-wpa0-bwpb\n",
+      "  Aluminium foil current_collector      https://w3id.org/battinfo/material-spec/92ny-p3qm-6j9n-vrym\n",
+      "  Graphite       active_material        https://w3id.org/battinfo/material-spec/sm7b-n4y5-2hrk-dv6h\n",
+      "  CMC            binder                 https://w3id.org/battinfo/material-spec/t4wz-ff8s-6vp6-af48\n",
+      "  SBR            binder                 https://w3id.org/battinfo/material-spec/7p3d-2e22-7yae-spyb\n",
+      "  Copper foil    current_collector      https://w3id.org/battinfo/material-spec/ftdw-5z5h-mbn7-x13m\n",
+      "  LiPF6          electrolyte_salt       https://w3id.org/battinfo/material-spec/xcv1-hpy1-b0bw-z5s2\n",
+      "  EC             electrolyte_solvent    https://w3id.org/battinfo/material-spec/z6sr-a9yw-gryf-3q55\n",
+      "  DMC            electrolyte_solvent    https://w3id.org/battinfo/material-spec/va82-gnpn-v0bt-3qed\n",
+      "  VC             electrolyte_additive   https://w3id.org/battinfo/material-spec/nbz6-pn8h-4458-dh91\n",
+      "  FEC            electrolyte_additive   https://w3id.org/battinfo/material-spec/t59c-yz22-48as-tdkx\n",
+      "  Polypropylene  separator_material     https://w3id.org/battinfo/material-spec/n24p-ymxz-gj1j-q6pb\n"
+     ]
+    }
+   ],
+   "source": [
+    "from battinfo.materials import extract_material_specs\n",
+    "\n",
+    "material_specs = extract_material_specs(spec.model_dump())\n",
+    "print(f\"{len(material_specs)} standalone material spec(s):\")\n",
+    "for record in material_specs:\n",
+    "    m = record[\"material_spec\"]\n",
+    "    print(f\"  {m['name']:14s} {m.get('material_class', '?'):22s} {m['id']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d857cea",
+   "metadata": {},
+   "source": [
+    "## Step 10: Serialise the descriptor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0c953dd6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:10:04.234796Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.234796Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.249183Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.249183Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Written: <repo>\\docs\\guides\\_scratch\\guide-05\\descriptors\\a123-anr26650m1-b.descriptor.json\n",
       "Top-level keys: ['schema_version', 'specification']\n"
      ]
     }
    ],
    "source": [
     "# Write the descriptor to disk for inspection and downstream use.\n",
-    "desc_dir = WORKSPACE / \"descriptors\"\n",
+    "desc_dir = SCRATCH / \"descriptors\"\n",
     "desc_dir.mkdir(parents=True, exist_ok=True)\n",
     "desc_path = desc_dir / \"a123-anr26650m1-b.descriptor.json\"\n",
     "spec_dict = {\"schema_version\": \"1.0.0\", \"specification\": spec.to_json()}\n",
     "desc_path.write_text(json.dumps(spec_dict, indent=2, ensure_ascii=False), encoding=\"utf-8\")\n",
-    "print(\"Written:\", desc_path.relative_to(WORKSPACE))\n",
+    "print(\"Written:\", desc_path)\n",
     "print(\"Top-level keys:\", list(spec_dict.keys())[:8])"
    ]
   },
@@ -495,19 +537,19 @@
    "id": "f4cebbcd",
    "metadata": {},
    "source": [
-    "## Step 10: Map to domain-battery JSON-LD"
+    "## Step 11: Map to domain-battery JSON-LD"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "cc431ddd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:08.941400Z",
-     "iopub.status.busy": "2026-07-06T20:03:08.941400Z",
-     "iopub.status.idle": "2026-07-06T20:03:09.068066Z",
-     "shell.execute_reply": "2026-07-06T20:03:09.068066Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.249183Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.249183Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.954618Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.954618Z"
     }
    },
    "outputs": [
@@ -515,14 +557,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "@type:"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " ['BatteryCellSpecification', 'schema:CreativeWork']\n",
+      "@type: ['BatteryCellSpecification', 'schema:CreativeWork']\n",
       "\n",
       "Positive electrode @type: LithiumIronPhosphateElectrode\n",
       "Negative electrode @type: GraphiteElectrode\n"
@@ -546,14 +581,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "6cc0a7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:09.073427Z",
-     "iopub.status.busy": "2026-07-06T20:03:09.072420Z",
-     "iopub.status.idle": "2026-07-06T20:03:09.081577Z",
-     "shell.execute_reply": "2026-07-06T20:03:09.081577Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.954618Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.954618Z",
+     "iopub.status.idle": "2026-07-07T08:10:04.970375Z",
+     "shell.execute_reply": "2026-07-07T08:10:04.970375Z"
     }
    },
    "outputs": [
@@ -561,7 +596,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Domain-battery JSON-LD exported to: descriptors\\a123-anr26650m1-b.domain-battery.jsonld\n",
+      "Domain-battery JSON-LD exported to: <repo>\\docs\\guides\\_scratch\\guide-05\\descriptors\\a123-anr26650m1-b.domain-battery.jsonld\n",
       "\n",
       "{\n",
       "  \"@context\": [\n",
@@ -966,7 +1001,7 @@
       "          \"@type\": \"schema:PropertyValue\",\n",
       "          \"schema:propertyID\": \"construction.layering\",\n",
       "          \"schema:name\": \"Layering\",\n",
-      "          \"schema:value\": \"jelly-roll\"\n",
+      "          \"schema:value\": \"single_layer\"\n",
       "        },\n",
       "        {\n",
       "          \"@type\": \"schema:PropertyValue\",\n",
@@ -994,12 +1029,12 @@
    ],
    "source": [
     "# Export the domain-battery JSON-LD to disk\n",
-    "desc_jsonld_path = WORKSPACE / \"descriptors\" / \"a123-anr26650m1-b.domain-battery.jsonld\"\n",
+    "desc_jsonld_path = SCRATCH / \"descriptors\" / \"a123-anr26650m1-b.domain-battery.jsonld\"\n",
     "desc_jsonld_path.write_text(\n",
     "    json.dumps(desc_jsonld, indent=2, ensure_ascii=False),\n",
     "    encoding=\"utf-8\",\n",
     ")\n",
-    "print(f\"Domain-battery JSON-LD exported to: {desc_jsonld_path.relative_to(WORKSPACE)}\")\n",
+    "print(f\"Domain-battery JSON-LD exported to: {desc_jsonld_path}\")\n",
     "print()\n",
     "print(json.dumps(desc_jsonld, indent=2))"
    ]
@@ -1009,19 +1044,19 @@
    "id": "cd0eaf8c",
    "metadata": {},
    "source": [
-    "## Step 11: Validate the descriptor JSON-LD"
+    "## Step 12: Validate the descriptor JSON-LD"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "1b0ac8c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:09.089914Z",
-     "iopub.status.busy": "2026-07-06T20:03:09.088406Z",
-     "iopub.status.idle": "2026-07-06T20:03:09.191877Z",
-     "shell.execute_reply": "2026-07-06T20:03:09.191877Z"
+     "iopub.execute_input": "2026-07-07T08:10:04.976411Z",
+     "iopub.status.busy": "2026-07-07T08:10:04.974398Z",
+     "iopub.status.idle": "2026-07-07T08:10:05.056504Z",
+     "shell.execute_reply": "2026-07-07T08:10:05.055993Z"
     }
    },
    "outputs": [
@@ -1048,55 +1083,23 @@
    "id": "239f94a0",
    "metadata": {},
    "source": [
-    "## Step 12: Publish"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "8e638265",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:09.191877Z",
-     "iopub.status.busy": "2026-07-06T20:03:09.191877Z",
-     "iopub.status.idle": "2026-07-06T20:03:09.303652Z",
-     "shell.execute_reply": "2026-07-06T20:03:09.302091Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "IRI: https://w3id.org/battinfo/spec/e4t5-w9re-mpq6-8g7e\n"
-     ]
-    }
-   ],
-   "source": [
-    "from battinfo import CellSpec, publish\n",
-    "from battinfo.api import publish_record\n",
+    "## Step 13: Publish\n",
     "\n",
-    "ct = CellSpec(\n",
-    "    manufacturer=spec.manufacturer, model=spec.model,\n",
-    "    format=spec.format, chemistry=spec.chemistry,\n",
-    "    positive_electrode_basis=spec.positive_electrode_basis,\n",
-    "    negative_electrode_basis=spec.negative_electrode_basis,\n",
-    ")\n",
-    "\n",
-    "pub = publish(ct, destination=\"local\", root=WORKSPACE / \"published\")\n",
-    "print(\"IRI:\", pub.canonical_iri)"
+    "The descriptor **is** the cell-spec record — publish it directly and the\n",
+    "composition travels with it (note the `positive_electrode` key in the saved\n",
+    "record, and that the IRI set in Step 8 is preserved):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "e7e19b64",
+   "id": "8e638265",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:09.303652Z",
-     "iopub.status.busy": "2026-07-06T20:03:09.303652Z",
-     "iopub.status.idle": "2026-07-06T20:03:09.365572Z",
-     "shell.execute_reply": "2026-07-06T20:03:09.365572Z"
+     "iopub.execute_input": "2026-07-07T08:10:05.060564Z",
+     "iopub.status.busy": "2026-07-07T08:10:05.060564Z",
+     "iopub.status.idle": "2026-07-07T08:10:05.543591Z",
+     "shell.execute_reply": "2026-07-07T08:10:05.543591Z"
     }
    },
    "outputs": [
@@ -1104,28 +1107,53 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "@type: ['BatteryCellSpecification', 'schema:CreativeWork']\n",
-      "\n",
-      "Properties:\n"
+      "IRI:          https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\n",
+      "Record keys:  ['schema_version', 'cell_spec', 'properties', 'provenance', 'notes', 'construction', 'positive_electrode', 'negative_electrode', 'electrolyte', 'separator']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from battinfo import publish\n",
+    "from battinfo.api import publish_record\n",
+    "\n",
+    "pub = publish(spec, destination=\"local\", root=SCRATCH / \"published\")\n",
+    "record = json.loads(Path(pub.debug_paths[\"canonical_record_path\"]).read_text(encoding=\"utf-8\"))\n",
+    "\n",
+    "print(\"IRI:         \", pub.canonical_iri)\n",
+    "print(\"Record keys: \", list(record.keys()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "e7e19b64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:10:05.547130Z",
+     "iopub.status.busy": "2026-07-07T08:10:05.547130Z",
+     "iopub.status.idle": "2026-07-07T08:10:05.659387Z",
+     "shell.execute_reply": "2026-07-07T08:10:05.659387Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@type: ['BatteryCellSpecification', 'schema:CreativeWork']\n"
      ]
     }
    ],
    "source": [
     "output = publish_record(\n",
     "    pub.debug_paths[\"canonical_record_path\"],\n",
-    "    target_root=WORKSPACE / \"resolver\",\n",
+    "    target_root=SCRATCH / \"resolver\",\n",
     ")\n",
     "jsonld_out = json.loads(\n",
     "    Path(output[\"output_dir\"], \"index.jsonld\").read_text(encoding=\"utf-8\")\n",
     ")\n",
     "\n",
-    "print(\"@type:\", jsonld_out[\"@type\"])\n",
-    "print()\n",
-    "print(\"Properties:\")\n",
-    "for prop in jsonld_out.get(\"hasProperty\", []):\n",
-    "    t = prop[\"@type\"][0] if isinstance(prop[\"@type\"], list) else prop[\"@type\"]\n",
-    "    v = prop.get(\"hasNumericalPart\", {}).get(\"hasNumericalValue\", \"—\")\n",
-    "    print(f\"  {t}: {v}\")"
+    "print(\"@type:\", jsonld_out[\"@type\"])"
    ]
   },
   {

--- a/docs/guides/06-publish-your-data.ipynb
+++ b/docs/guides/06-publish-your-data.ipynb
@@ -5,7 +5,7 @@
    "id": "1cb77488",
    "metadata": {},
    "source": [
-    "# 06 — Publish your first dataset\n",
+    "# Guide 6 — Publish your first dataset\n",
     "\n",
     "**The tutorial version of the [publishing journey](https://battinfo.org/publish):** you start\n",
     "with a raw cycler export and finish with validated, linked records, a citable archive, and a\n",
@@ -20,7 +20,7 @@
     "4. **Save & validate** — canonical records with stable IRIs\n",
     "5. **Publish** — a DOI on Zenodo + the registry review queue\n",
     "\n",
-    "*Prerequisites: `pip install battinfo` (or this repo's dev environment). Stage 5 needs\n",
+    "*Prerequisites: `pip install \"battinfo[processing]\"` — the `processing` extra brings the BDF converter (`batterydf`) that Stage 1 uses. Stage 5 needs\n",
     "credentials and is guarded so the notebook runs fully offline without them.*"
    ]
   },
@@ -30,47 +30,31 @@
    "id": "e43cee13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:14.521030Z",
-     "iopub.status.busy": "2026-07-06T20:03:14.520513Z",
-     "iopub.status.idle": "2026-07-06T20:03:16.348721Z",
-     "shell.execute_reply": "2026-07-06T20:03:16.347373Z"
+     "iopub.execute_input": "2026-07-07T08:10:14.610440Z",
+     "iopub.status.busy": "2026-07-07T08:10:14.610440Z",
+     "iopub.status.idle": "2026-07-07T08:10:15.093136Z",
+     "shell.execute_reply": "2026-07-07T08:10:15.092111Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Workspace ready: .battinfo\\notebooks\\guide-06\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os, shutil\n",
+    "import os\n",
+    "import shutil\n",
     "from pathlib import Path\n",
     "\n",
-    "# Run from the repo root (so the sample data resolves) with a scratch workspace.\n",
-    "_here = Path.cwd()\n",
-    "if (_here / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here\n",
-    "elif (_here.parent.parent / \"src\" / \"battinfo\").exists():\n",
-    "    REPO = _here.parent.parent\n",
-    "    os.chdir(REPO)\n",
-    "else:\n",
-    "    REPO = _here\n",
-    "\n",
-    "WORKSPACE = REPO / \".battinfo/notebooks/guide-06\"\n",
-    "if WORKSPACE.exists():\n",
-    "    shutil.rmtree(WORKSPACE)  # fresh start on every run\n",
-    "WORKSPACE.mkdir(parents=True)\n",
+    "# This notebook runs from its own folder (docs/guides); fresh scratch every run.\n",
+    "SCRATCH = Path(\"_scratch/guide-06\").resolve()\n",
+    "if SCRATCH.exists():\n",
+    "    shutil.rmtree(SCRATCH)\n",
+    "SCRATCH.mkdir(parents=True)\n",
     "\n",
     "# Your starting point: a folder with raw cycler exports. Here, the sample\n",
     "# Neware CSV that ships with the repo (one CC charge + discharge cycle).\n",
-    "shutil.copy(REPO / \"docs/guides/data/neware-sample.csv\", WORKSPACE / \"neware-sample.csv\")\n",
+    "shutil.copy(Path(\"data/neware-sample.csv\"), SCRATCH / \"neware-sample.csv\")\n",
     "\n",
     "import battinfo\n",
-    "ws = battinfo.workspace(root=WORKSPACE)\n",
-    "print(\"Workspace ready:\", WORKSPACE.relative_to(REPO))"
+    "\n",
+    "ws = battinfo.workspace(root=SCRATCH)"
    ]
   },
   {
@@ -91,10 +75,10 @@
    "id": "e2c1ddca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:16.352413Z",
-     "iopub.status.busy": "2026-07-06T20:03:16.351816Z",
-     "iopub.status.idle": "2026-07-06T20:03:16.975873Z",
-     "shell.execute_reply": "2026-07-06T20:03:16.975873Z"
+     "iopub.execute_input": "2026-07-07T08:10:15.097555Z",
+     "iopub.status.busy": "2026-07-07T08:10:15.096603Z",
+     "iopub.status.idle": "2026-07-07T08:10:17.522859Z",
+     "shell.execute_reply": "2026-07-07T08:10:17.521347Z"
     }
    },
    "outputs": [
@@ -104,7 +88,7 @@
      "text": [
       "  neware-sample.csv  ->  neware-sample.bdf.csv  (0.0 MB)\n",
       "\n",
-      "Converted 1 file(s) -> <repo>\\.battinfo\\notebooks\\guide-06\\bdf\n",
+      "Converted 1 file(s) -> <repo>\\docs\\guides\\_scratch\\guide-06\\bdf\n",
       "\n",
       "BDF columns: test_time_second,voltage_volt,current_ampere,step_index,unix_time_second\n"
      ]
@@ -113,7 +97,7 @@
    "source": [
     "converted = ws.convert(\"*.csv\")\n",
     "\n",
-    "bdf_file = sorted((WORKSPACE / \"bdf\").glob(\"*.bdf.csv\"))[0]\n",
+    "bdf_file = sorted((SCRATCH / \"bdf\").glob(\"*.bdf.csv\"))[0]\n",
     "print()\n",
     "print(\"BDF columns:\", bdf_file.read_text(encoding=\"utf-8\").splitlines()[0])"
    ]
@@ -136,10 +120,10 @@
    "id": "c7d97399",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:16.975873Z",
-     "iopub.status.busy": "2026-07-06T20:03:16.975873Z",
-     "iopub.status.idle": "2026-07-06T20:03:19.002996Z",
-     "shell.execute_reply": "2026-07-06T20:03:19.002996Z"
+     "iopub.execute_input": "2026-07-07T08:10:17.525864Z",
+     "iopub.status.busy": "2026-07-07T08:10:17.525864Z",
+     "iopub.status.idle": "2026-07-07T08:10:18.837365Z",
+     "shell.execute_reply": "2026-07-07T08:10:18.837365Z"
     }
    },
    "outputs": [
@@ -189,10 +173,10 @@
    "id": "d9a22b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:19.002996Z",
-     "iopub.status.busy": "2026-07-06T20:03:19.002996Z",
-     "iopub.status.idle": "2026-07-06T20:03:19.021488Z",
-     "shell.execute_reply": "2026-07-06T20:03:19.021488Z"
+     "iopub.execute_input": "2026-07-07T08:10:18.840446Z",
+     "iopub.status.busy": "2026-07-07T08:10:18.840446Z",
+     "iopub.status.idle": "2026-07-07T08:10:18.857721Z",
+     "shell.execute_reply": "2026-07-07T08:10:18.857721Z"
     }
    },
    "outputs": [
@@ -236,10 +220,10 @@
    "id": "241ee167",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:19.024494Z",
-     "iopub.status.busy": "2026-07-06T20:03:19.023492Z",
-     "iopub.status.idle": "2026-07-06T20:03:19.389407Z",
-     "shell.execute_reply": "2026-07-06T20:03:19.389407Z"
+     "iopub.execute_input": "2026-07-07T08:10:18.857721Z",
+     "iopub.status.busy": "2026-07-07T08:10:18.857721Z",
+     "iopub.status.idle": "2026-07-07T08:10:19.290534Z",
+     "shell.execute_reply": "2026-07-07T08:10:19.290534Z"
     }
    },
    "outputs": [
@@ -247,16 +231,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Saved 4 record(s) under <repo>\\.battinfo\\notebooks\\guide-06\\.battinfo\\records:\n",
+      "Saved 4 record(s) under <repo>\\docs\\guides\\_scratch\\guide-06\\.battinfo\\records:\n",
       "  cell spec   Molicel INR21700-P45B                [created]  .battinfo\\records\\examples\\cell-spec\\cell-spec-fpdr-z1qt-23v0-stzx.json\n",
       "  cell        S1                                   [created]  .battinfo\\records\\examples\\cell-instance\\cell-d6tp-jgqy-a3s9-4qem.json\n",
       "  test        S1 cycling                           [created]  .battinfo\\records\\examples\\test\\test-9f4c-mxny-yhym-2zh4.json\n",
-      "  dataset     S1 data                              [created]  .battinfo\\records\\examples\\dataset\\dataset-4g59-2qnt-jqy8-n2qt.json\n",
+      "  dataset     S1 data                              [created]  .battinfo\\records\\examples\\dataset\\dataset-22bt-7jxb-yv3k-xgq4.json\n",
       "\n",
       "  Next: ws.list(verbose=True) to inspect, or ws.publish() to publish.\n",
       "cell-instance/cell-d6tp-jgqy-a3s9-4qem.json\n",
       "cell-spec/cell-spec-fpdr-z1qt-23v0-stzx.json\n",
-      "dataset/dataset-4g59-2qnt-jqy8-n2qt.json\n",
+      "dataset/dataset-22bt-7jxb-yv3k-xgq4.json\n",
       "test/test-9f4c-mxny-yhym-2zh4.json\n"
      ]
     }
@@ -264,7 +248,7 @@
    "source": [
     "ws.save()\n",
     "\n",
-    "records_root = WORKSPACE / \".battinfo/records/examples\"\n",
+    "records_root = SCRATCH / \".battinfo/records/examples\"\n",
     "for record_file in sorted(records_root.rglob(\"*.json\")):\n",
     "    print(f\"{record_file.parent.name}/{record_file.name}\")"
    ]
@@ -275,10 +259,10 @@
    "id": "03b2dfb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:19.392110Z",
-     "iopub.status.busy": "2026-07-06T20:03:19.392110Z",
-     "iopub.status.idle": "2026-07-06T20:03:19.398118Z",
-     "shell.execute_reply": "2026-07-06T20:03:19.398118Z"
+     "iopub.execute_input": "2026-07-07T08:10:19.295634Z",
+     "iopub.status.busy": "2026-07-07T08:10:19.293624Z",
+     "iopub.status.idle": "2026-07-07T08:10:19.305908Z",
+     "shell.execute_reply": "2026-07-07T08:10:19.304899Z"
     }
    },
    "outputs": [
@@ -296,7 +280,7 @@
       "...\n",
       "provenance: {\n",
       "  \"source_type\": \"measurement\",\n",
-      "  \"retrieved_at\": 1783368199,\n",
+      "  \"retrieved_at\": 1783411818,\n",
       "  \"battinfo_version\": \"0.7.0\"\n",
       "}\n"
      ]
@@ -335,10 +319,10 @@
    "id": "5e115f9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T20:03:19.400056Z",
-     "iopub.status.busy": "2026-07-06T20:03:19.400056Z",
-     "iopub.status.idle": "2026-07-06T20:03:19.405584Z",
-     "shell.execute_reply": "2026-07-06T20:03:19.404576Z"
+     "iopub.execute_input": "2026-07-07T08:10:19.308920Z",
+     "iopub.status.busy": "2026-07-07T08:10:19.308920Z",
+     "iopub.status.idle": "2026-07-07T08:10:19.317070Z",
+     "shell.execute_reply": "2026-07-07T08:10:19.316068Z"
     }
    },
    "outputs": [
@@ -372,7 +356,7 @@
     "## What you have now\n",
     "\n",
     "```\n",
-    "guide-06/\n",
+    "_scratch/guide-06/\n",
     "├── neware-sample.csv           # your raw export (untouched)\n",
     "├── bdf/neware-sample.bdf.csv   # the tidy, shareable table\n",
     "└── .battinfo/records/examples/ # validated, linked records with stable IRIs\n",
@@ -384,8 +368,8 @@
     "\n",
     "**Next steps**\n",
     "\n",
-    "- [Guide 01 — Concepts](01-concepts.ipynb): the data model behind what you just did\n",
-    "- [Guide 03 — Linked records](03-linked-records.ipynb): the full provenance chain in depth\n",
+    "- [Guide 1 — Concepts](01-concepts.ipynb): the data model behind what you just did\n",
+    "- [Guide 3 — Linked records](03-linked-records.ipynb): the full provenance chain in depth\n",
     "- [battinfo.org/validate](https://battinfo.org/validate): check any record in the browser\n",
     "- `ws.quickstart()` — this whole recipe, printed in your terminal"
    ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,14 +9,14 @@ BattINFO is the implementation layer for the EMMO domain-battery ontology — pr
 | | |
 |---|---|
 | **[Quickstart](../QUICKSTART.md)** | Create and publish your first cell-spec record in 5 minutes |
-| **[01 — Concepts](guides/01-concepts.ipynb)** | Data model, record types, IRIs, and the semantic layer |
-| **[02 — First cell spec](guides/02-first-cell-type.ipynb)** | Materials → components → cell spec → publish |
-| **[03 — Linked records](guides/03-linked-records.ipynb)** | Cell instance → test → dataset → registry submission |
-| **[04 — Semantic layer](guides/04-semantic-layer.ipynb)** | JSON-LD anatomy, EMMO type stacking, RDF validation, SPARQL |
-| **[05 — Descriptors](guides/05-descriptors.ipynb)** | Research-grade descriptors: electrode composition, electrolyte, separator |
-| **[06 — Publish your data](guides/06-publish-your-data.ipynb)** | The end-to-end tutorial: raw cycler CSV → validated records → DOI + registry |
+| **[1 — Concepts](guides/01-concepts.ipynb)** | The record model, IRIs, and the semantic layer |
+| **[2 — Describing a cell](guides/02-first-cell-type.ipynb)** | Author and publish a cell spec, with a taste of material-level depth |
+| **[3 — Linked records](guides/03-linked-records.ipynb)** | Cells, test specs, tests, and datasets with the workspace |
+| **[4 — Semantic layer](guides/04-semantic-layer.ipynb)** | JSON-LD anatomy, EMMO type stacking, RDF and SPARQL |
+| **[5 — Cell descriptors](guides/05-descriptors.ipynb)** | Research-grade composition: materials, BOMs, electrodes, electrolyte |
+| **[6 — Publish your first dataset](guides/06-publish-your-data.ipynb)** | End to end: raw cycler CSV → validated records → DOI + registry |
 
-Open notebooks from the repo root with the `.venv` kernel selected.
+Each notebook runs from its own folder and writes only to a throwaway `_scratch/` directory next to it.
 
 ---
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,10 @@ Here is a minimal example that creates a canonical cell-spec record and publishe
 Explore the documentation
 --------------------------
 
+The documentation follows the `Diátaxis <https://diataxis.fr/>`_ structure:
+**tutorials** teach, **how-to guides** solve one task each, **reference**
+states the facts, and **concepts** explain the design.
+
 .. grid:: 2
 
     .. grid-item-card::
@@ -87,27 +91,43 @@ Explore the documentation
 
         :octicon:`rocket;1em;sd-text-info`  Get Started
         ^^^^^^^^^^^
-        Install BattINFO and publish your first cell-type record in five minutes.
+        Install BattINFO and publish your first records in five minutes.
 
     .. grid-item-card::
         :link: pages/guides.html
 
-        :octicon:`book;1em;sd-text-info`  Guides
-        ^^^^^^^
-        Step-by-step notebooks covering concepts, cell types, linked records, and the semantic layer.
+        :octicon:`book;1em;sd-text-info`  Tutorials
+        ^^^^^^^^^
+        Six notebooks, one story — from the record model to a published, citable dataset.
 
 .. grid:: 2
+
+    .. grid-item-card::
+        :link: pages/howto.html
+
+        :octicon:`checklist;1em;sd-text-info`  How-to guides
+        ^^^^^^^^^^^^^
+        Task-shaped recipes: bulk ingest, fixing validation errors, resuming submissions, funding tags.
 
     .. grid-item-card::
         :link: pages/reference.html
 
         :octicon:`code;1em;sd-text-info`  Reference
         ^^^^^^^^^
-        Python API, CLI commands, and the validation policy contract.
+        Python API, CLI commands, schemas, and the validation policy contract.
+
+.. grid:: 2
 
     .. grid-item-card::
         :link: pages/concepts.html
 
         :octicon:`gear;1em;sd-text-info`  Concepts
         ^^^^^^^^
-        Ontology architecture, authoring workflows, and the Linked Data model.
+        Ontology architecture, the spec-and-instance model, and how BattINFO is built.
+
+    .. grid-item-card::
+        :link: how-battinfo-is-built.html
+
+        :octicon:`stack;1em;sd-text-info`  How BattINFO is built
+        ^^^^^^^^^^^^^^^^^^^^^
+        The orientation roadmap: layers, data flow, and where each module fits.

--- a/docs/pages/getting-started.rst
+++ b/docs/pages/getting-started.rst
@@ -4,7 +4,7 @@ Get Started
 BattINFO is the semantic data layer for battery science. It gives you:
 
 - A Python library and CLI for authoring, validating, and publishing canonical battery metadata
-- JSON Schema validation for cell specs, cell instances, tests, and datasets
+- JSON Schema validation for cell specs, cells, test specs, tests, and datasets
 - Automatic JSON → JSON-LD conversion aligned with the EMMO Battery Domain Ontology
 - A reusable cell-spec library backed by canonical records in ``battinfo-records``
 
@@ -18,6 +18,15 @@ BattINFO requires Python 3.11 or later.
 
    pip install battinfo
 
+Optional extras add features as you need them (each missing dependency raises
+an error naming the extra to install):
+
+.. code-block:: bash
+
+   pip install "battinfo[processing]"   # cycler-file conversion (ws.convert) + plotting
+   pip install "battinfo[tabular]"      # CSV/Parquet/XLSX readers
+   pip install "battinfo[publish]"      # RO-Crate validation for publishing
+
 Or install from source for the latest development version:
 
 .. code-block:: bash
@@ -27,58 +36,64 @@ Or install from source for the latest development version:
    pip install -e ".[dev]"
 
 
-Your first cell-spec record
----------------------------
+If you have data: the workspace
+-------------------------------
 
-The fastest path is the ``publish`` shortcut:
+The ``workspace`` is the one object for the whole journey — convert raw cycler
+files, register the cells you tested, link tests and data, save validated
+records, publish. ``ws.quickstart()`` prints the full recipe in your terminal;
+the offline-safe core is:
+
+.. doc-snippet: skip
+
+.. code-block:: python
+
+   import battinfo
+
+   ws = battinfo.workspace(".")
+
+   ws.convert()                                  # raw cycler files → tidy BDF tables
+
+   spec = battinfo.CellSpec(                     # or reuse the registry's identity:
+       manufacturer="Molicel",                   #   spec = ws.search("molicel p45b")[0]
+       model="INR21700-P45B",
+       format="cylindrical",
+       chemistry="Li-ion",
+   )
+   ws.add("cell", spec=spec, serial_numbers=["S1"])
+   ws.add("test", type="cycling", cell="S1", data="bdf/S1.bdf.csv")
+
+   ws.save()                                     # validated records, stable IRIs
+   # ws.login(api_key="...")                     # then: ws.publish() for the registry
+   #                                             # (zenodo=True mints a citable DOI)
+
+:doc:`Tutorial 6 — Publish your first dataset <../guides/06-publish-your-data>`
+walks this exact flow against a sample Neware CSV.
+
+
+If you are describing a product: models
+---------------------------------------
+
+For a standalone cell-spec record — a datasheet as data — use the ``CellSpec``
+model and the ``publish`` shortcut:
 
 .. code-block:: python
 
    from battinfo import CellSpec, publish
 
-   cell_spec = CellSpec(
+   spec = CellSpec(
        manufacturer="Energizer",
        model="CR2032",
        format="coin",
        chemistry="Li-primary",
+       properties={"nominal_capacity": {"value": 0.235, "unit": "Ah"}},
    )
 
-   result = publish(cell_spec, destination="local")
-   print(result.debug_paths)
+   result = publish(spec, destination="local")
+   print(result.canonical_iri)
 
-This validates the record, assigns it a stable BattINFO IRI, and writes the canonical JSON file to ``.battinfo/``.
-
-
-Linking a cell instance, test, and dataset
-------------------------------------------
-
-Use ``Workspace`` to build a fully linked chain of records:
-
-.. code-block:: python
-
-   from pathlib import Path
-   from battinfo import Workspace
-
-   workspace = Workspace(root=Path(".battinfo/demo"))
-
-   cell_spec = workspace.cell_spec(
-       manufacturer="Energizer",
-       model="CR2032",
-       format="coin",
-       chemistry="Li-primary",
-   )
-   cell = workspace.cell(cell_spec, serial_number="LAB-001")
-
-   protocol = workspace.test_spec(
-       name="Constant current discharge",
-       kind="capacity_check",
-   )
-   test = workspace.test(cell, protocol_ref=protocol, instrument="Landt CT2001A")
-   dataset = workspace.dataset(cell, title="CR2032 baseline", test=test, path="data/run1.csv")
-
-   workspace.save()
-
-All records are saved to ``.battinfo/demo/`` with cross-references validated automatically.
+This validates the record, assigns it a stable BattINFO IRI, and writes the
+canonical JSON file to ``.battinfo/``.
 
 
 CLI quick reference
@@ -94,10 +109,10 @@ BattINFO ships a command-line interface for validation and querying:
    # Query all registered cell specs
    battinfo query cell-spec
 
-   # Save a cell instance from a draft file
+   # Save a cell record from a draft file
    battinfo save cell-instance --input draft.json --source-root examples
 
-See the :doc:`../cli-spec` page for the full CLI reference.
+See the :doc:`CLI reference <cli-reference>` for every command.
 
 
 What to read next
@@ -106,25 +121,25 @@ What to read next
 .. grid:: 2
 
     .. grid-item-card::
-        :link: ../guides/01-concepts.html
+        :link: guides.html
 
-        :octicon:`book;1em;sd-text-info`  Guide notebooks
-        ^^^^^^^^^^^^^^^^
-        Work through the five guide notebooks covering concepts, authoring, linking, and the semantic layer.
+        :octicon:`book;1em;sd-text-info`  Tutorials
+        ^^^^^^^^^
+        Six notebooks, one story — concepts, authoring, linked records, the semantic layer, and publishing.
 
     .. grid-item-card::
         :link: ../python-api.html
 
-        :octicon:`code;1em;sd-text-info`  Python API reference
-        ^^^^^^^^^^^^^^^^^^^^^^
-        Full surface documentation for ``Workspace``, ``CellSpec``, ingest helpers, and publishing utilities.
+        :octicon:`code;1em;sd-text-info`  Python API overview
+        ^^^^^^^^^^^^^^^^^^^
+        How the Python surface is organized: models, the workspace, and the ``api`` module.
 
     .. grid-item-card::
-        :link: ../ontology-profile-architecture.html
+        :link: ../how-battinfo-is-built.html
 
-        :octicon:`gear;1em;sd-text-info`  Concepts
-        ^^^^^^^^
-        How BattINFO relates to domain-battery, EMMO, and the Linked Data stack.
+        :octicon:`gear;1em;sd-text-info`  How BattINFO is built
+        ^^^^^^^^^^^^^^^^^^^^^
+        The orientation roadmap: layers, data flow, and where each module fits.
 
     .. grid-item-card::
         :link: ../validation-contract.html

--- a/docs/pages/guides.rst
+++ b/docs/pages/guides.rst
@@ -1,8 +1,18 @@
-Guides
-======
+Tutorials
+=========
 
-These notebooks walk through the full BattINFO authoring flow end to end, from core concepts to
-publishing linked records as Linked Data. Run them locally or read them here.
+Six notebooks, one story: understand the record model, describe a cell, record
+what happened in the lab, look under the semantic hood, go research-deep, and
+publish a real dataset end to end. Work through them in order the first time —
+each builds on the one before.
+
+Tutorials are for **learning**: they take you somewhere, explaining as they go.
+When you already know the basics and just need to get a job done, use the
+:doc:`how-to guides <howto>` instead — short, task-shaped recipes.
+
+*Already have cycler data on disk?* Start with
+:doc:`Tutorial 6 — Publish your first dataset <../guides/06-publish-your-data>`
+— raw export to citable dataset in five stages — then come back for the depth.
 
 .. toctree::
    :maxdepth: 1
@@ -13,3 +23,29 @@ publishing linked records as Linked Data. Run them locally or read them here.
    ../guides/04-semantic-layer
    ../guides/05-descriptors
    ../guides/06-publish-your-data
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 55 15
+
+   * - Tutorial
+     - What you learn
+     - Time
+   * - :doc:`1 — Concepts <../guides/01-concepts>`
+     - The record model, IRIs, the semantic layer, validation layers
+     - 10 min
+   * - :doc:`2 — Describing a cell <../guides/02-first-cell-type>`
+     - Author and publish a cell spec; a taste of material-level depth
+     - 15 min
+   * - :doc:`3 — Linked records <../guides/03-linked-records>`
+     - Cells, test specs, tests, and datasets with the ``workspace``
+     - 20 min
+   * - :doc:`4 — The semantic layer <../guides/04-semantic-layer>`
+     - The JSON-LD BattINFO emits, EMMO typing, RDF tooling
+     - 20 min
+   * - :doc:`5 — Cell descriptors <../guides/05-descriptors>`
+     - Research-grade composition: materials, BOMs, electrodes, electrolyte
+     - 40 min
+   * - :doc:`6 — Publish your first dataset <../guides/06-publish-your-data>`
+     - Raw cycler export → validated records → DOI, in five stages
+     - 15 min

--- a/docs/pages/howto.rst
+++ b/docs/pages/howto.rst
@@ -1,8 +1,12 @@
 How-to guides
 =============
 
-Short, task-shaped recipes. Each one does a single job; the code is executed in
-CI wherever it can run offline.
+Short, task-shaped recipes for people who already know the basics: each one
+does a single job, states its ingredients up front, and gets out of your way.
+The code is executed in CI wherever it can run offline.
+
+New to BattINFO? Start with the :doc:`tutorials <guides>` instead — they teach
+the model that these recipes assume.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1,194 +1,65 @@
 # BattINFO Python API
 
+How the Python surface is organized. For the full symbol-by-symbol reference,
+see the [generated API reference](pages/api-reference.rst); for the layered
+architecture, see [How BattINFO is built](how-battinfo-is-built.md).
+
 ## Where to start
 
 | Goal | Surface to use |
 |------|---------------|
-| Publish a cell spec or build a linked cell→test→dataset chain from Python objects | [`Workspace`](#workspace-release-export) — the primary authoring surface |
-| Turn an existing folder of photos and CSV files into a linked BattINFO submission | [Ingest helpers](#ingest-first-intake) — one-command folder intake |
-| Load, query, or save canonical records from disk | [`battinfo.api` helpers](#query-and-save) |
-| Author records as JSON files and drive the workflow from the CLI | `LocalWorkspace` — disk-first submission scaffold behind `battinfo workspace ...` |
+| Turn lab data into published, linked records | `battinfo.workspace(...)` — the one object for the whole journey |
+| Describe a battery product (a datasheet as data) | The `CellSpec` model + the `publish` shortcut |
+| Author research-grade composition (materials, electrodes, electrolyte) | `battinfo.authoring` — see [Tutorial 5](guides/05-descriptors.ipynb) |
+| Load, query, save, or resolver-publish canonical records | `battinfo.api` helpers |
+| Turn a folder of photos and CSVs into a linked submission | `battinfo.ingest` — one-command folder intake |
+| Drive everything from the shell | The `battinfo` CLI — see the [CLI reference](pages/cli-reference.md) |
 
-If you are new here, start with `Workspace`. The [guide notebooks](guides/01-concepts.ipynb)
-walk through the full authoring flow end to end.
+If you are new here, start with the [tutorials](pages/guides.rst) — six
+notebooks that walk the whole story end to end.
 
-Scope:
-- core: `Workspace`, publication, canonical record save/query/publish/index helpers, and the guide notebooks
-- preview: reusable cell-spec library workflows beyond the guide walkthrough fixtures
+The curated top-level namespace (`import battinfo`) exposes the models, the
+workspace, publishing, and validation — everything else lives in its home
+module (`battinfo.api`, `battinfo.authoring`, `battinfo.materials`, ...) and
+is documented there.
 
-## Install
+## The workspace
 
-```bash
-python -m pip install -e .
-```
+`battinfo.workspace(root)` is the data-first surface: convert raw cycler
+files, register cells, link tests and data, save validated records with
+stable IRIs, and publish — to the registry review queue and, with
+`zenodo=True`, to a citable DOI.
 
-## Ingest-First Intake
-
-Use the ingest helpers when you want one-command registration for a typed
-resource instance plus its evidence files.
-
+<!-- doc-snippet: skip -->
 ```python
-from battinfo import build_ingest_workspace, publish_ingest_workspace, write_ingest_manifest
+import battinfo
 
-write_ingest_manifest(
-    r"D:\cell_phone\novonix\google--g20m7--2025--15qnrp",
-    resource_type="cell-instance",
-    type_record="battinfo-records/records/cell-spec/google--g20m7--2025/record.json",
-    resource_iri="https://w3id.org/battinfo/cell/15qn-rpd4-xhy7-kx2q",
-    publisher_id="demo-lab",
-    license="CC-BY-4.0",
-)
+ws = battinfo.workspace(".")
 
-build = build_ingest_workspace(
-    r"D:\cell_phone\novonix\google--g20m7--2025--15qnrp",
-    resource_type="cell-instance",
-    workspace_id="google-g20m7-instance-demo",
-    source_version="demo-2026-04-09",
-    artifact_base_url="http://127.0.0.1:8040",
-)
-
-published = publish_ingest_workspace(
-    r"D:\cell_phone\novonix\google--g20m7--2025--15qnrp",
-    resource_type="cell-instance",
-    workspace_id="google-g20m7-instance-demo",
-    source_version="demo-2026-04-09",
-    registry_base_url="https://registry.example.org",
-    api_key="...",
-    platform_base_url="https://www.battery-genome.org",
-)
+ws.convert()                              # raw cycler files → tidy BDF tables
+spec = ws.search("samsung inr21700 50e")[0]   # reuse the registry's identity
+ws.add("cell", spec=spec, serial_numbers=["S1", "S2"])
+ws.add("test", type="cycling", cell="S1", data="bdf/S1.bdf.csv")
+ws.save()
+ws.publish(note="My cycling campaign, 2026")
 ```
 
-Behavior today:
+`ws.quickstart()` prints the full recipe, including login and funding
+attribution (`ws.project(...)`, `ws.contributor(...)`).
+[Tutorial 3](guides/03-linked-records.ipynb) builds the chain step by step;
+[Tutorial 6](guides/06-publish-your-data.ipynb) runs it from a raw cycler
+export.
 
-- the folder-local `battinfo.ingest.json` manifest carries stable ingest metadata
-- `resource_type="cell-instance"` is the currently implemented typed ingest subject
-- one photo becomes one standalone photo dataset
-- one CSV becomes one `Test` plus one `Dataset`
-- the first photo dataset becomes the Battery Genome hero image for the cell page
-- the returned payload includes the canonical cell id plus registry/platform URLs
+Drafts and templates: `ws.template("cell-spec", ...)` /
+`ws.template("test-spec", ...)` write skeleton draft files; `ws.load(path)`
+authors them into the session. `ws.load(ws.search(...)[0])` references an
+existing registry record instead (reused, never re-published).
 
-Contract note:
+## Models
 
-- the manifest shape is defined by `docs/ingest-manifest-contract.md`
-- runtime validation uses `assets/schemas/ingest-manifest.schema.json`
-
-## Publication Package
-
-The stable publication path is Schema.org JSON-LD first. Build the core object
-chain, call `build_publication_package(...)`, then reload with
-`load_publication_package(...)`.
-
-```python
-from pathlib import Path
-
-from battinfo import Cell, CellSpec, Dataset, Test, build_publication_package, load_publication_package
-
-dataset_dir = Path("data/cr2032-run")
-dataset_dir.mkdir(parents=True, exist_ok=True)
-(dataset_dir / "capacity.csv").write_text("cycle,capacity_ah\n1,0.225\n")
-
-cell_spec = CellSpec(
-    manufacturer="Energizer",
-    model="CR2032",
-    format="coin",
-    chemistry="Li-primary",
-    size_code="CR2032",
-    nominal_voltage={"value": 3.0, "unit": "V"},
-)
-
-cell = Cell(
-    cell_spec=cell_spec,
-    serial_number="energizer-cr2032-202602-dtjrga",
-)
-
-test = Test(
-    cell=cell,
-    kind="capacity_check",
-    protocol="constant current discharging",
-    instrument="short Landt cycler",
-    status="completed",
-)
-
-dataset = Dataset(
-    path=str(dataset_dir),
-    cell=cell,
-    test=test,
-    name="Energizer CR2032 dataset",
-)
-
-report = build_publication_package(
-    cell_spec=cell_spec,
-    cell_instance=cell,
-    test=test,
-    dataset=dataset,
-)
-
-bundle = load_publication_package(dataset_dir / "battinfo.publish.jsonld")
-```
-
-Notes:
-
-- `battinfo.publish.jsonld` remains the foundational Schema.org JSON-LD artifact.
-- `ro-crate-metadata.json` is emitted alongside it for RO-Crate alignment.
-- `datacite-metadata.json` is emitted alongside it for DataCite-aligned deposit metadata.
-- `battinfo.dcat.jsonld` is available as an optional export.
-- `CellSpec` is optional provenance support, not required core bundle content.
-- `emit_bundle_dir=True` writes the optional debug JSON files under `dataset_dir/battinfo/`.
-- `publish_dataset_metadata(...)` is the generic helper for low-plumbing workflows.
-- `publish_cr2032_dataset_metadata(...)` is kept as a CR2032 convenience wrapper.
-
-## Workspace Release Export
-
-Use `Workspace` directly when you want the primary BattINFO authoring surface and
-also need a disk-backed submission workspace or a registry-ready submission
-package without instantiating `LocalWorkspace` yourself.
-
-```python
-from pathlib import Path
-
-from battinfo import Workspace
-
-workspace = Workspace(root=Path(".battinfo/demo"))
-cell_spec = workspace.cell_spec(...)
-cell = workspace.cell(cell_spec, ...)
-protocol = workspace.test_spec(name="1C Cycle Life at 25 C", kind="cycling", ...)
-test = workspace.test(cell, protocol_ref=protocol, ...)
-dataset = workspace.dataset(cell, title="Cycle life dataset", test=test, path="data/cycle-life.csv")
-
-workspace.save()
-workspace.build_publication_package(dataset)
-
-release = workspace.export_submission_workspace(
-    dataset,
-    registry="digibatt/hello-world",
-    publisher_id="demo-lab",
-    version="1.0.0",
-)
-
-submission = workspace.build_submission_package(
-    dataset,
-    registry="digibatt/hello-world",
-    publisher_id="demo-lab",
-    version="1.0.0",
-    root=Path(".battinfo/demo-release"),
-)
-```
-
-Use `LocalWorkspace` directly only when the disk workspace itself is your source of
-truth or when you are driving the `battinfo workspace ...` CLI.
-
-Submission note:
-
-- BattINFO-generated submission packages are now transport envelopes around canonical BattINFO records.
-- The package still carries workflow and release fields such as `workspace_id`, `publisher_id`, `source_version`, and `publication_intent`.
-- BattINFO no longer duplicates lightweight display metadata inside the submission `semantic_payload`; `battinfo-registry` derives normalized page metadata from `battinfo_records`.
-
-Terminology note:
-
-- The BattINFO authoring surface uses `workspace_id`.
-- `battinfo-registry` now uses `workspace_id` as well, so the publication boundary is vocabulary-aligned end to end.
-
-Cell-spec publish shortcut:
+`CellSpec`, `Cell`, `TestSpec`, `Test`, and `Dataset` are the record types as
+pydantic models — the single source of truth for authoring and for what is on
+disk. For a standalone cell-spec record, `publish` is the shortcut:
 
 ```python
 from battinfo import CellSpec, publish
@@ -214,111 +85,61 @@ registry_result = publish(
 - `destination="local"` writes the canonical BattINFO record and returns its path in `debug_paths`.
 - `destination="registry"` also generates the submission package and submits it to `battinfo-registry`.
 - `destination="battery-genome"` additionally returns the expected Battery Genome page URL when `platform_base_url` is configured.
-- The existing package-oriented dataset publication helper remains available via `publish(cell_spec=..., cell_instance=..., test=..., dataset=...)`.
 
-## Load Cell Specs From JSON
+## Publication package (models path)
 
-If you want to manually define cell specs as JSON first, load them directly into
-`Workspace`:
+When you hold the four core objects in Python and want the local publication
+artifacts without a workspace, build the package directly:
 
 ```python
 from pathlib import Path
 
-from battinfo import Workspace
+from battinfo import Cell, CellSpec, Dataset, Test, build_publication_package, load_publication_package
 
-workspace = Workspace(root=Path(".battinfo/manual-cell-specs"))
+dataset_dir = Path("data/cr2032-run")
+dataset_dir.mkdir(parents=True, exist_ok=True)
+(dataset_dir / "capacity.csv").write_text("cycle,capacity_ah\n1,0.225\n")
 
-cell_spec = workspace.load_cell_spec("examples/cell-spec/A123__ANR26650M1-B.json")
-more_cell_specs = workspace.load_cell_specs(directory="examples/cell-spec")
+cell_spec = CellSpec(manufacturer="Energizer", model="CR2032", format="coin", chemistry="Li-primary")
+cell = Cell(cell_spec=cell_spec, serial_number="energizer-cr2032-202602-dtjrga")
+test = Test(cell=cell, kind="capacity_check", protocol="constant current discharging", status="completed")
+dataset = Dataset(path=str(dataset_dir), cell=cell, test=test, name="Energizer CR2032 dataset")
+
+report = build_publication_package(
+    cell_spec=cell_spec, cell_instance=cell, test=test, dataset=dataset,
+)
+bundle = load_publication_package(dataset_dir / "battinfo.publish.jsonld")
 ```
 
-If you want a starter draft file to fill in first, generate one with the API:
+Notes:
+
+- `battinfo.publish.jsonld` is the foundational Schema.org JSON-LD artifact.
+- `ro-crate-metadata.json` and `datacite-metadata.json` are emitted alongside it.
+- `battinfo.dcat.jsonld` is available as an optional export.
+
+## Query and save (`battinfo.api`)
+
+Canonical-record helpers for scripted workflows:
 
 ```python
-from battinfo import template_cell_spec_draft
-
-draft = template_cell_spec_draft(
-    manufacturer="A123",
-    model_name="ANR26650M1-B",
-    chemistry="Li-ion",
-    format="cylindrical",
-    iec_code="IFpR26650",
-)
-```
-
-These helpers accept either:
-
-- a simple authoring draft with fields like `manufacturer`, `model`, `format`, `chemistry`, and optional `specs`
-- a canonical BattINFO `cell-spec` record with a top-level `cell_spec` object
-
-Draft inputs should omit canonical fields like `id`, `short_id`, and `identifier`.
-`Workspace.save()` canonizes those fields and fills default provenance if you did
-not provide it.
-
-## Reusable Test Specs
-
-If you want to separate reusable procedures from executed test runs, use
-`TestSpec` plus the existing `Test` record:
-
-```python
-from battinfo import Workspace
-
-workspace = Workspace(root=".battinfo/test-spec-demo")
-
-protocol = workspace.test_spec(
-    name="1C Cycle Life at 25 C",
-    kind="cycling",
-    version="1.0",
-    protocol_url="https://example.org/protocols/cycle-life-1c",
-    conditions={"ambient_temperature": {"value": 25.0, "unit": "degC"}},
-    experiment=[
-        "Charge at 1C until 4.2 V",
-        "Discharge at 1C until 2.5 V",
-    ],
-)
-
-cell_spec = workspace.cell_spec(
-    manufacturer="Energizer",
-    model="CR2032",
-    format="coin",
-    chemistry="Li-primary",
-)
-cell = workspace.cell(cell_spec, serial_number="LAB-001")
-test = workspace.test(cell, protocol_ref=protocol, instrument="Biologic VSP-300")
-workspace.save()
-```
-
-You can also hand-author reusable test-spec JSON first with
-`template_test_spec_draft(...)` or load canonical test-spec records with
-`Workspace.load_test_spec(...)`.
-
-## Query And Save
-
-The `battinfo.api` helpers remain useful for canonical record workflows:
-
-```python
-from battinfo import query_cell_specs, save_cell_instance, template_cell_instance
+from battinfo import query_cell_specs, save_cell_instance
+from battinfo.api import template_cell_instance
 
 rows = query_cell_specs(manufacturer="A123", chemistry="LFP", limit=5)
 
 draft = template_cell_instance(cell_spec_id="https://w3id.org/battinfo/spec/3m6k-9t2p-7x4h-9nq8")
 draft["cell_instance"]["serial_number"] = "LAB-001"
 
-result = save_cell_instance(
-    draft,
-    source_root="examples",
-    resolve_references=False,
-)
+result = save_cell_instance(draft, source_root="examples", resolve_references=False)
 ```
 
-Migration note:
-- local canonical record writes now use `save*`
-- local `register*` names were removed and reserved for future registry communication
+Draft inputs omit canonical fields like `id`, `short_id`, and `identifier` —
+saving canonizes them and fills default provenance.
 
-## Index And Resolver Publishing
+## Index and resolver publishing (`battinfo.api`)
 
 ```python
-from battinfo import build_index, index_stats, publish_record
+from battinfo.api import build_index, index_stats, publish_record
 
 publish_record(
     "examples/cell-instance/cell-3m6k-9t2p-7x4h-9nq8.json",
@@ -329,21 +150,34 @@ index = build_index(source_root="examples", out_path=".battinfo/index.json")
 stats = index_stats(".battinfo/index.json")
 ```
 
+## Ingest-first intake (`battinfo.ingest`)
+
+One-command registration for a typed resource instance plus its evidence
+files (photos become photo datasets; CSVs become a `Test` plus a `Dataset`):
+
+```python
+from battinfo.ingest import build_ingest_workspace, publish_ingest_workspace, write_ingest_manifest
+```
+
+The folder-local `battinfo.ingest.json` manifest carries stable ingest
+metadata; its shape is defined by
+[the ingest manifest contract](ingest-manifest-contract.md) and validated
+against `assets/schemas/ingest-manifest.schema.json`.
+`resource_type="cell-instance"` is the currently implemented subject.
+
+## Advanced: the internal engine
+
+`battinfo.workspace(...)` and the models are facades over an internal
+authoring engine (`battinfo._workspace.Workspace`) that also powers
+submission-package export and release workflows. New code should not build on
+the engine directly — its surface is large, uncurated, and free to change;
+everything the tutorials and this page show goes through the stable facades.
+If you maintain older code that imports `Workspace` from `battinfo`, you will
+see a deprecation message pointing at the replacement for each call.
+
 ## Guidance
 
-- Use `build_publication_package(...)` for local publication-package generation.
-- Use `publish(...)` as the compatibility alias for the same operation.
-- Use `Workspace.export_submission_workspace(...)` or `Workspace.build_submission_package(...)` for registry-ready submission handoff from Python workflows.
-- Use `setup_demo_environment(...)` to scaffold a repeatable demo workspace and submission package from Python-authored objects.
-- Use `run_demo_pipeline(...)` to publish the demo through a registry and optionally verify the Battery Genome `/registry/...` page.
-- Use `Workspace.export_release(...)` and `Workspace.build_release(...)` as compatibility aliases.
-- Use `load_publication_package(...)` to reconstruct Python objects from the publication package.
-- Use `load_publication(...)` as the compatibility alias for the same operation.
-- Use `BattinfoBundle.to_directory(...)` only for optional debug inspection bundles.
+- Prefer `battinfo.workspace(...)` for anything that ends in publishing.
 - Prefer opaque BattINFO IRIs under `https://w3id.org/battinfo/`.
-- For validation policy and machine-readable issue output, see `docs/validation-contract.md`.
-
-
-
-
-
+- For validation policy and machine-readable issue output, see [the validation contract](validation-contract.md).
+- For submission-envelope internals, see [the contract explanation page](pages/contract.md).

--- a/docs/test-specs.md
+++ b/docs/test-specs.md
@@ -35,3 +35,70 @@ mode/direction/setpoints/termination); `facets` are derived automatically for fi
 
 > The `kind` enum in `test-protocol.schema.json` is kept in sync with the `BatteryTestType`
 > Python enum (`bundle.py`); the coverage test guards against drift.
+
+## Semantic depth of a test protocol
+
+The current representation types the protocol at the class level and carries a free-text
+`description`. EMMO domain-electrochemistry has richer terms that allow a more explicit,
+machine-replicable representation — here is what is available and when to use it.
+
+### What the ontology provides
+
+| EMMO term | Meaning |
+|---|---|
+| `ConstantCurrentConstantVoltageCycling` | The complete CC-CV cycle-life protocol |
+| `ConstantCurrentConstantVoltageCharging` | A single CC-CV charge step |
+| `ConstantCurrentDischarging` | A single CC discharge step |
+| `Resting` | A rest / OCV hold step |
+| `ElectrochemicalTestingProcedure` | General electrochemical test container |
+| `SerialWorkflow` / `IterativeWorkflow` | Structural containers for step sequences |
+| `hasNext` / `precedes` / `follows` | Step-to-step sequencing predicates |
+| `StepDuration`, `StepSignalCurrent`, `StepSignalVoltage` | Per-step parameters |
+
+A 1C CC-CV cycle-life protocol could therefore be expressed as an `IterativeWorkflow`
+containing a `SerialWorkflow` whose steps are:
+`ConstantCurrentConstantVoltageCharging` → `Resting` → `ConstantCurrentDischarging` →
+`Resting`, each step carrying typed parameters for C-rate, voltage limit, cut-off
+current, rest duration, and temperature.
+
+### Pros of explicit step decomposition
+
+- **Machine-replicable**: the test can be reproduced from the JSON-LD alone without
+  parsing free text.
+- **SPARQL-queryable at step level**: structured queries like *"find all datasets charged
+  to 4.2 V at 1C CC-CV"* become precise rather than text-search-based.
+- **Parameter validation**: step parameters (C-rate, voltage limits, temperatures) can
+  be range-checked against cell specs and standards (IEC 62660, EUCAR) automatically.
+- **Stable protocol identity**: the semantic structure survives even if the free-text
+  description is incomplete or updated.
+
+### Cons and practical limits
+
+- **Authoring burden**: a four-step cycle becomes a graph of ~10 typed nodes. No
+  researcher will author this by hand, so tooling is a prerequisite.
+- **EMMO coverage gaps**: GITT, interspersed EIS, multi-rate formation sequences, and
+  temperature ramps do not yet have first-class EMMO step types. Mixed typed/free-text
+  nodes undermine the value of the graph.
+- **Cycler-file redundancy and false precision**: the ground-truth protocol is usually
+  the binary file in Biologic BT-Lab, Maccor, or Arbin format. A parallel step graph
+  that was hand-authored can silently diverge from what was actually run — which is
+  worse than no graph at all.
+- **Version fragility**: step-graph records couple tightly to specific EMMO term IRIs.
+  An upstream rename invalidates stored records in a way that a text description does
+  not.
+
+### Current recommendation
+
+Type the protocol at the class level (e.g. `ConstantCurrentConstantVoltageCycling`) and
+record protocol-level parameters (C-rate, voltage window, temperature, cut-off
+condition) as typed properties. Keep the free-text `description` as the human-readable
+ground truth. Reserve step-level decomposition for cases where:
+
+1. The protocol is simple enough to express without gaps (standard CC, CC-CV, or rest
+   steps only), **and**
+2. The step graph is generated programmatically from a machine-readable protocol
+   definition (e.g. a cycler script), not authored by hand.
+
+When the cycler file is included as a dataset distribution, it already carries the
+authoritative step definition — the EMMO class typing on the protocol record is
+then sufficient for discovery and filtering.

--- a/src/battinfo/authoring.py
+++ b/src/battinfo/authoring.py
@@ -48,7 +48,7 @@ def construction(
 
     Args:
         assembly_type: How layers are arranged, e.g. ``"wound"`` or ``"stacked"``.
-        layering: Stacking pattern, e.g. ``"jelly-roll"`` or ``"z-fold"``.
+        layering: Stacking pattern: ``"single_layer"``, ``"multilayer"``, ``"not_applicable"``, or ``"unknown"`` (the schema enum); put finer detail (jelly-roll, z-fold, ...) in ``comment``.
         layer_count: Number of electrode layers or winding turns.
         cathode_sheet_count: Number of cathode sheets in the stack.
         anode_sheet_count: Number of anode sheets in the stack.

--- a/src/battinfo/validate/jsonld.py
+++ b/src/battinfo/validate/jsonld.py
@@ -220,6 +220,14 @@ def _collect_bare_terms(value: Any, out: set[str]) -> None:
 def _allowed_type_terms() -> set[str]:
     allowed = set(_EXPLICIT_ALLOWED_TYPE_TERMS)
 
+    # The test-spec method graph emits its vocabulary (workflow/process classes,
+    # control/termination quantities) straight from the bundled context via
+    # battinfo.jsonld.TEST_METHOD_CONTEXT_TERMS — the validator must accept what
+    # the library itself emits, and this shared source cannot drift.
+    from battinfo.jsonld import TEST_METHOD_CONTEXT_TERMS  # noqa: PLC0415
+
+    allowed.update(TEST_METHOD_CONTEXT_TERMS)
+
     entity_map = _load_mapping_json("entity_type_map.json")
     _collect_bare_terms(entity_map.get("mappings", {}), allowed)
 

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -423,12 +423,18 @@ def _bdf_measurement_period(csv_path: "str | Path") -> tuple[int, int] | None:
         return None
 
 
-def _typed_date(value: str) -> dict:
-    """Wrap a date string as a typed JSON-LD value so consumers can parse it.
+def _typed_date(value: "str | int | float") -> dict:
+    """Wrap a date value as a typed JSON-LD value so consumers can parse it.
 
-    Picks the xsd datatype from the string's shape: ``YYYY`` → gYear,
+    Records store dates as Unix timestamps (int); those become xsd:date in UTC.
+    For strings, picks the xsd datatype from the shape: ``YYYY`` → gYear,
     ``YYYY-MM`` → gYearMonth, an ISO timestamp → dateTime, else date.
     """
+    if isinstance(value, (int, float)):
+        import datetime as _dt  # noqa: PLC0415
+
+        day = _dt.datetime.fromtimestamp(value, tz=_dt.timezone.utc).date().isoformat()
+        return {"@value": day, "@type": "xsd:date"}
     v = (value or "").strip()
     if len(v) == 4 and v.isdigit():
         datatype = "xsd:gYear"
@@ -1512,7 +1518,10 @@ class AuthoringWorkspace:
             import bdf.io as _bdf_io
             import bdf.repair as _bdf_repair
         except ImportError:
-            raise ImportError("batterydf not installed.  Run: pip install batterydf")
+            raise ImportError(
+                "convert() needs the BDF converter (module 'bdf' from the batterydf "
+                "package). Run: pip install 'battinfo[processing]'"
+            )
 
         # ── Resolve input files ────────────────────────────────────────────
         if pattern is not None:
@@ -1955,7 +1964,7 @@ class AuthoringWorkspace:
         **Cells** (``"cell"``)::
 
             ws.add("cell", spec=spec,
-                   serial_numbers=["FAC-001", "FAC-002"], production_date="2026-01")
+                   serial_numbers=["FAC-001", "FAC-002"], production_date="2026-01-15")
 
             # Reuse pre-allocated IRIs instead of minting new ones (parallel lists):
             ws.add("cell", spec=spec, serial_numbers=["FAC-001", "FAC-002"],

--- a/tests/test_jsonld_type_guards.py
+++ b/tests/test_jsonld_type_guards.py
@@ -51,3 +51,18 @@ def test_dataset_checksum_as_mapping_is_emitted() -> None:
 def test_test_dataset_ids_with_none_does_not_emit_null_id() -> None:
     out = record_to_jsonld({"test": {"id": "t1", "dataset_ids": ["ds-a", None, ""]}}, "test")
     assert out["battinfo:hasDataset"] == [{"@id": "ds-a"}]
+
+
+def test_test_method_vocabulary_is_allowed() -> None:
+    """The gold-standard checker accepts every @type the method graph emits.
+
+    ws.preview_jsonld() on a workspace with a stepped test spec used to print
+    8 errors (IterativeWorkflow, VoltageHold, Duration, ...) because the
+    validator's allowed set never learned the test-method vocabulary the
+    library itself emits.
+    """
+    from battinfo.jsonld import TEST_METHOD_CONTEXT_TERMS
+    from battinfo.validate.jsonld import _allowed_type_terms
+
+    missing = set(TEST_METHOD_CONTEXT_TERMS) - _allowed_type_terms()
+    assert not missing, f"emitted method terms rejected by validator: {sorted(missing)}"

--- a/tests/test_zenodo_upload.py
+++ b/tests/test_zenodo_upload.py
@@ -496,3 +496,26 @@ class TestUploadZenodoPackage:
         assert DEFAULT_RO_CRATE_METADATA_FILENAME in uploaded_names
         assert "dataset-001.csv" in uploaded_names
         assert "dataset-001.bdf.parquet" in uploaded_names
+
+
+class TestTypedDate:
+    """_typed_date wraps record date values for the publication JSON-LD.
+
+    Records store manufactured_at/expires_at as Unix timestamps (int); the
+    assembler used to crash on them (AttributeError: int has no strip) as soon
+    as a cell carried a production date.
+    """
+
+    def test_unix_timestamp_becomes_utc_xsd_date(self) -> None:
+        from battinfo.ws import _typed_date
+
+        # 2026-01-15T00:00:00Z — must not shift with the local timezone.
+        assert _typed_date(1768435200) == {"@value": "2026-01-15", "@type": "xsd:date"}
+
+    def test_string_shapes_keep_their_datatypes(self) -> None:
+        from battinfo.ws import _typed_date
+
+        assert _typed_date("2026")["@type"] == "xsd:gYear"
+        assert _typed_date("2026-01")["@type"] == "xsd:gYearMonth"
+        assert _typed_date("2026-01-15")["@type"] == "xsd:date"
+        assert _typed_date("2026-01-15T12:00:00Z")["@type"] == "xsd:dateTime"


### PR DESCRIPTION
The docs-narrative phase of the beta review.

- Tutorials: Tutorial 3 (linked records) rewritten on the modern battinfo.workspace() API — the deprecated engine no longer appears in any notebook. Tutorial 2 no longer duplicates Tutorial 5; it teaches the spec-and-instance model for materials instead. Tutorial 5 lifts every embedded material into standalone material-spec records and publishes the descriptor directly.
- Bootstrap: notebooks run from their own folder and write to a gitignored _scratch/; the machine-specific path preamble is gone.
- Structure: Diátaxis naming (Tutorials vs How-to guides, with the difference stated where readers look); getting-started and python-api rewritten around the workspace and models; the protocol-semantics essay moved to the test-specs explanation page.
- Library fixes the rewrite surfaced (with regression tests): ws.preview_jsonld() crashed on cells with a production date; the gold-standard validator rejected the library's own test-method JSON-LD vocabulary; two docstring examples used values their own code rejects.

1311 tests, 6 executed notebooks, 17 executed doc snippets; ruff + mypy clean.