### PR TITLE
IDENTIFIER_POLICY: ratify the no-alias-layer vocabulary policy

### DIFF
--- a/IDENTIFIER_POLICY.md
+++ b/IDENTIFIER_POLICY.md
@@ -162,6 +162,35 @@ Recommended initial scope:
 - `material`
 - `model`
 
+### 6.1 Namespace scheme (ratified 2026-07-08)
+
+The namespace segment encodes exactly ONE distinction — the spec/instance
+duality at the heart of the data model — and nothing else:
+
+- **`spec/` holds every reusable description**: cell specs, test specs,
+  material specs, and all component specs (electrode, separator, electrolyte,
+  current-collector, housing), present and future. Descriptions are one kind
+  of thing; their differences are expressed by `@type`, not by the IRI.
+- **Each kind of concrete thing or event gets a short generic noun**:
+  `cell/`, `test/`, `dataset/`, `material/`, `electrode/`, `separator/`,
+  `electrolyte/`, `current-collector/`, `housing/`, `organization/` (and
+  `twin/` for registered twin instances). Instance identifiers are the ones
+  humans handle physically — the noun is a deliberate affordance.
+
+Rationale: type names have churned three times (cell-type→cell-spec,
+test-protocol→test-spec, coin_hardware→housing) and the generic `spec/`
+segment survived every rename untouched; per-type spec segments demonstrably
+do not. Tooling MUST NOT infer a record's type from its namespace segment —
+`spec/` is shared by design; the type lives in the record and its `@type`.
+
+Superseded segments (`material-spec/`, `electrode-spec/`, `separator-spec/`,
+`electrolyte-spec/`, `current-collector-spec/`, `housing-spec/`, and the
+older `cell-type/`, `cell_type/`, `test_protocol/` forms) remain permanent
+resolver aliases — anything ever minted resolves forever.
+
+Reserved segments (never usable as entity namespaces): `id`, `ontology`,
+`vocab`, `doc`, `context`, `resolver`, `twin`, `w3id`.
+
 ## 7. Resolver and Dereferencing Policy
 
 BattINFO IRIs identify resources and MUST resolve via HTTP.

--- a/IDENTIFIER_POLICY.md
+++ b/IDENTIFIER_POLICY.md
@@ -255,7 +255,43 @@ This policy applies to:
 - Bulk imports MUST run duplicate detection before commit.
 - Registry backups SHOULD support disaster recovery without identifier reassignment.
 
-## 14. Design Principles
+## 14. Vocabulary and Alias Policy (ratified 2026-07-08)
+
+BattINFO **never mints or aliases domain IRIs.** Scientific and battery
+semantics — quantities, battery classes, measurement concepts — are
+identified exclusively by their EMMO IRIs (domain-battery /
+domain-electrochemistry). Terms missing from EMMO are added upstream (the
+working queue is `docs/internal/ontology-additions-needed.md`); while a term
+is missing, the value is preserved in the JSON record and omitted from RDF
+with a `semantic.property_unmapped` warning — never bridged with a
+BattINFO-minted IRI.
+
+In particular, a "thin human-friendly IRI layer" over EMMO (e.g. a readable
+`battinfo:PowerDensity` aliasing an opaque EMMO IRI) is **rejected as
+policy**, not deferred: two IRIs per concept fragment graphs for every
+consumer that does not run an OWL reasoner, and the accidental instances of
+exactly this pattern measurably caused silent data loss (red-team review,
+2026-07). The human-friendly layer is **labels and contexts, not
+identifiers**:
+
+- authoring: snake_case JSON keys mapped by the records JSON-LD context;
+- reading: `skos:prefLabel` annotations emitted alongside every EMMO term in
+  exports, plus the generated property & unit reference;
+- querying: a generated labels-companion file for SPARQL users.
+
+`battinfo.ttl` is an **application ontology** in the strict sense: (a) the
+import/pin manifest for the EMMO modules a release speaks, (b) the small
+record-layer residue of genuinely non-domain terms (after re-homing to
+DCTERMS/PROV/DCAT/schema.org where standard terms exist), and (c) optionally
+the profile constraints (SHACL shapes). Nothing else. The same ruling applies
+to sub-namespaces granted under `w3id.org/battinfo/` (e.g. `/twin`): quantity
+terms resolve to EMMO or go upstream; only structural terms may be minted
+locally, hand-defined.
+
+Reserved namespace segments (never usable as entity types): `id`, `ontology`,
+`vocab`, `doc`, `context`, `resolver`, `twin`, `w3id`.
+
+## 15. Design Principles
 
 The BattINFO identifier system is designed to be:
 
@@ -265,7 +301,7 @@ The BattINFO identifier system is designed to be:
 - Compatible with distributed data generation
 - Independent of any single software platform
 
-## 15. Rationale
+## 16. Rationale
 
 The 16-character Base32 UID:
 


### PR DESCRIPTION
Ratified 2026-07-08 after thorough evaluation (recurring 'thin human-friendly IRI layer over EMMO' proposals): BattINFO never mints or aliases domain IRIs - EMMO identifies all scientific semantics, missing terms go upstream (we control the ontology), and the human-friendly layer is labels and contexts, not identifiers. battinfo.ttl's role is fixed as a strict application ontology (import/pin manifest + record-layer residue + optional SHACL profile). Applies equally to granted sub-namespaces (/twin). Reserved segments enumerated. This section exists so the alias-layer idea stops being re-litigated.