### PR TITLE
IRI namespaces: all specs mint under spec/ (IDENTIFIER_POLICY 6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Namespace consolidation (IDENTIFIER_POLICY 6.1)**: every reusable
+  description now mints under the shared `spec/` namespace — material,
+  electrode, separator, electrolyte, current-collector, and housing specs
+  join cell and test specs there. The namespace segment encodes exactly one
+  distinction (description vs concrete thing); type lives in `@type`, and
+  the generic segment has already survived three type renames that per-type
+  segments would not have. Instance kinds keep their nouns (`cell/`,
+  `material/`, `electrode/`, ...). Superseded `*-spec/` IRIs remain accepted
+  everywhere as input (builders, references, schemas) and become permanent
+  resolver aliases — nothing ever minted breaks. New import-time guard:
+  reserved segments (`id`, `ontology`, `vocab`, `doc`, `context`,
+  `resolver`, `twin`, `w3id`) can never become entity namespaces.
+
+
 ### Fixed
 
 - **The site's own /docs quickstart crashed verbatim** (`cell_format=`, which

--- a/assets/schemas/cell-canonical.schema.json
+++ b/assets/schemas/cell-canonical.schema.json
@@ -487,7 +487,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     }
   }
 }

--- a/assets/schemas/cell-instance.schema.json
+++ b/assets/schemas/cell-instance.schema.json
@@ -320,7 +320,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Funding": {
       "type": "object",

--- a/assets/schemas/cell-spec.schema.json
+++ b/assets/schemas/cell-spec.schema.json
@@ -573,7 +573,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "OrganizationIri": {
       "type": "string",
@@ -581,19 +581,19 @@
     },
     "ElectrodeSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ElectrolyteSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "SeparatorSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "HousingSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Funding": {
       "type": "object",

--- a/assets/schemas/current-collector-spec.schema.json
+++ b/assets/schemas/current-collector-spec.schema.json
@@ -35,7 +35,7 @@
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "property": {
           "$ref": "modules/common/quantitative-properties.schema.json"
@@ -67,7 +67,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/current-collector-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/current-collector.schema.json
+++ b/assets/schemas/current-collector.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/current-collector-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/electrode-spec.schema.json
+++ b/assets/schemas/electrode-spec.schema.json
@@ -82,7 +82,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/electrode.schema.json
+++ b/assets/schemas/electrode.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/electrolyte-spec.schema.json
+++ b/assets/schemas/electrolyte-spec.schema.json
@@ -76,7 +76,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/electrolyte.schema.json
+++ b/assets/schemas/electrolyte.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/housing-spec.schema.json
+++ b/assets/schemas/housing-spec.schema.json
@@ -98,7 +98,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/housing.schema.json
+++ b/assets/schemas/housing.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/material-spec.schema.json
+++ b/assets/schemas/material-spec.schema.json
@@ -185,7 +185,7 @@
     },
     "MaterialSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "OrganizationIri": {
       "type": "string",

--- a/assets/schemas/material.schema.json
+++ b/assets/schemas/material.schema.json
@@ -168,7 +168,7 @@
     },
     "MaterialSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "DatasetIri": {
       "type": "string",

--- a/assets/schemas/modules/components/current-collector.schema.json
+++ b/assets/schemas/modules/components/current-collector.schema.json
@@ -12,7 +12,7 @@
     },
     "material_spec_id": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
       "description": "Optional canonical IRI of a standalone material-spec for the current-collector foil material."
     },
     "manufacturer": {

--- a/assets/schemas/modules/components/electrolyte.schema.json
+++ b/assets/schemas/modules/components/electrolyte.schema.json
@@ -37,7 +37,7 @@
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
           "description": "Optional canonical IRI of a standalone material-spec for the salt."
         },
         "cation": {

--- a/assets/schemas/modules/components/material-component.schema.json
+++ b/assets/schemas/modules/components/material-component.schema.json
@@ -15,7 +15,7 @@
     },
     "material_spec_id": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
       "description": "Optional canonical IRI of a standalone material-spec record this embedded holder realizes. Lets a cell-spec dedup materials by reference instead of/in addition to inlining them."
     },
     "manufacturer": {

--- a/assets/schemas/modules/components/separator.schema.json
+++ b/assets/schemas/modules/components/separator.schema.json
@@ -20,7 +20,7 @@
     },
     "material_spec_id": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
       "description": "Optional canonical IRI of a standalone material-spec for the separator base material."
     },
     "structure": {

--- a/assets/schemas/separator-spec.schema.json
+++ b/assets/schemas/separator-spec.schema.json
@@ -52,7 +52,7 @@
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "property": {
           "$ref": "modules/common/quantitative-properties.schema.json"
@@ -84,7 +84,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/separator.schema.json
+++ b/assets/schemas/separator.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/assets/schemas/test-protocol.schema.json
+++ b/assets/schemas/test-protocol.schema.json
@@ -262,7 +262,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Quantity": {
       "type": "object",

--- a/assets/schemas/test.schema.json
+++ b/assets/schemas/test.schema.json
@@ -364,7 +364,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Funding": {
       "type": "object",

--- a/docs/component-specs.md
+++ b/docs/component-specs.md
@@ -48,7 +48,7 @@ Per family you get `create_<family>_spec`, `save_<family>_spec`, `query_<family>
 ### Naming convention
 
 Family identifiers use **underscores** (`current_collector`); the IRI namespace uses
-**hyphens** (`https://w3id.org/battinfo/current-collector-spec/…`). The generic API derives
+**hyphens** (`https://w3id.org/battinfo/spec/…`). The generic API derives
 the namespace via `family.replace("_", "-")`.
 
 ## Electrolyte assembles material constituents

--- a/docs/guides/01-concepts.ipynb
+++ b/docs/guides/01-concepts.ipynb
@@ -23,10 +23,10 @@
    "id": "d1bde660",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:32.720189Z",
-     "iopub.status.busy": "2026-07-07T20:20:32.720189Z",
-     "iopub.status.idle": "2026-07-07T20:20:32.731398Z",
-     "shell.execute_reply": "2026-07-07T20:20:32.731398Z"
+     "iopub.execute_input": "2026-07-08T08:58:21.406347Z",
+     "iopub.status.busy": "2026-07-08T08:58:21.402704Z",
+     "iopub.status.idle": "2026-07-08T08:58:21.422424Z",
+     "shell.execute_reply": "2026-07-08T08:58:21.420915Z"
     }
    },
    "outputs": [],
@@ -80,10 +80,10 @@
    "id": "af9f7f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:32.731398Z",
-     "iopub.status.busy": "2026-07-07T20:20:32.731398Z",
-     "iopub.status.idle": "2026-07-07T20:20:32.741747Z",
-     "shell.execute_reply": "2026-07-07T20:20:32.741747Z"
+     "iopub.execute_input": "2026-07-08T08:58:21.426434Z",
+     "iopub.status.busy": "2026-07-08T08:58:21.425434Z",
+     "iopub.status.idle": "2026-07-08T08:58:21.433968Z",
+     "shell.execute_reply": "2026-07-08T08:58:21.432961Z"
     }
    },
    "outputs": [
@@ -115,10 +115,10 @@
    "id": "2876af4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:32.741747Z",
-     "iopub.status.busy": "2026-07-07T20:20:32.741747Z",
-     "iopub.status.idle": "2026-07-07T20:20:32.749143Z",
-     "shell.execute_reply": "2026-07-07T20:20:32.749143Z"
+     "iopub.execute_input": "2026-07-08T08:58:21.437848Z",
+     "iopub.status.busy": "2026-07-08T08:58:21.437848Z",
+     "iopub.status.idle": "2026-07-08T08:58:21.445009Z",
+     "shell.execute_reply": "2026-07-08T08:58:21.445009Z"
     }
    },
    "outputs": [
@@ -161,10 +161,10 @@
    "id": "8d47a257",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:32.749143Z",
-     "iopub.status.busy": "2026-07-07T20:20:32.749143Z",
-     "iopub.status.idle": "2026-07-07T20:20:32.757758Z",
-     "shell.execute_reply": "2026-07-07T20:20:32.757758Z"
+     "iopub.execute_input": "2026-07-08T08:58:21.454471Z",
+     "iopub.status.busy": "2026-07-08T08:58:21.452803Z",
+     "iopub.status.idle": "2026-07-08T08:58:21.464001Z",
+     "shell.execute_reply": "2026-07-08T08:58:21.462944Z"
     }
    },
    "outputs": [
@@ -301,10 +301,10 @@
    "id": "e85e0b8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:32.757758Z",
-     "iopub.status.busy": "2026-07-07T20:20:32.757758Z",
-     "iopub.status.idle": "2026-07-07T20:20:32.764433Z",
-     "shell.execute_reply": "2026-07-07T20:20:32.764433Z"
+     "iopub.execute_input": "2026-07-08T08:58:21.466819Z",
+     "iopub.status.busy": "2026-07-08T08:58:21.466007Z",
+     "iopub.status.idle": "2026-07-08T08:58:21.471299Z",
+     "shell.execute_reply": "2026-07-08T08:58:21.470290Z"
     }
    },
    "outputs": [
@@ -354,10 +354,10 @@
    "id": "e670cfbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:32.764433Z",
-     "iopub.status.busy": "2026-07-07T20:20:32.764433Z",
-     "iopub.status.idle": "2026-07-07T20:20:33.477787Z",
-     "shell.execute_reply": "2026-07-07T20:20:33.477787Z"
+     "iopub.execute_input": "2026-07-08T08:58:21.474403Z",
+     "iopub.status.busy": "2026-07-08T08:58:21.474403Z",
+     "iopub.status.idle": "2026-07-08T08:58:22.480634Z",
+     "shell.execute_reply": "2026-07-08T08:58:22.479629Z"
     }
    },
    "outputs": [
@@ -395,10 +395,10 @@
    "id": "0f9bd621",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:33.477787Z",
-     "iopub.status.busy": "2026-07-07T20:20:33.477787Z",
-     "iopub.status.idle": "2026-07-07T20:20:33.833174Z",
-     "shell.execute_reply": "2026-07-07T20:20:33.833174Z"
+     "iopub.execute_input": "2026-07-08T08:58:22.482838Z",
+     "iopub.status.busy": "2026-07-08T08:58:22.482838Z",
+     "iopub.status.idle": "2026-07-08T08:58:22.984752Z",
+     "shell.execute_reply": "2026-07-08T08:58:22.982739Z"
     }
    },
    "outputs": [
@@ -431,10 +431,10 @@
    "id": "50971f8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:33.833174Z",
-     "iopub.status.busy": "2026-07-07T20:20:33.833174Z",
-     "iopub.status.idle": "2026-07-07T20:20:33.840194Z",
-     "shell.execute_reply": "2026-07-07T20:20:33.840194Z"
+     "iopub.execute_input": "2026-07-08T08:58:22.987745Z",
+     "iopub.status.busy": "2026-07-08T08:58:22.986749Z",
+     "iopub.status.idle": "2026-07-08T08:58:22.994766Z",
+     "shell.execute_reply": "2026-07-08T08:58:22.994262Z"
     }
    },
    "outputs": [
@@ -474,10 +474,10 @@
    "id": "4bb41daf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:33.840194Z",
-     "iopub.status.busy": "2026-07-07T20:20:33.840194Z",
-     "iopub.status.idle": "2026-07-07T20:20:33.846769Z",
-     "shell.execute_reply": "2026-07-07T20:20:33.846769Z"
+     "iopub.execute_input": "2026-07-08T08:58:22.997771Z",
+     "iopub.status.busy": "2026-07-08T08:58:22.996771Z",
+     "iopub.status.idle": "2026-07-08T08:58:23.004122Z",
+     "shell.execute_reply": "2026-07-08T08:58:23.003105Z"
     }
    },
    "outputs": [
@@ -561,10 +561,10 @@
    "id": "bfc0b477",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:33.846769Z",
-     "iopub.status.busy": "2026-07-07T20:20:33.846769Z",
-     "iopub.status.idle": "2026-07-07T20:20:33.867147Z",
-     "shell.execute_reply": "2026-07-07T20:20:33.867147Z"
+     "iopub.execute_input": "2026-07-08T08:58:23.009111Z",
+     "iopub.status.busy": "2026-07-08T08:58:23.008113Z",
+     "iopub.status.idle": "2026-07-08T08:58:23.034380Z",
+     "shell.execute_reply": "2026-07-08T08:58:23.032374Z"
     }
    },
    "outputs": [

--- a/docs/guides/02-first-cell-type.ipynb
+++ b/docs/guides/02-first-cell-type.ipynb
@@ -23,10 +23,10 @@
    "id": "6aa2a3a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:39.303935Z",
-     "iopub.status.busy": "2026-07-07T20:20:39.303935Z",
-     "iopub.status.idle": "2026-07-07T20:20:39.317537Z",
-     "shell.execute_reply": "2026-07-07T20:20:39.317537Z"
+     "iopub.execute_input": "2026-07-08T08:58:30.764944Z",
+     "iopub.status.busy": "2026-07-08T08:58:30.764944Z",
+     "iopub.status.idle": "2026-07-08T08:58:30.776733Z",
+     "shell.execute_reply": "2026-07-08T08:58:30.776733Z"
     }
    },
    "outputs": [],
@@ -56,10 +56,10 @@
    "id": "3e2a2bcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:39.319661Z",
-     "iopub.status.busy": "2026-07-07T20:20:39.319661Z",
-     "iopub.status.idle": "2026-07-07T20:20:40.360520Z",
-     "shell.execute_reply": "2026-07-07T20:20:40.360520Z"
+     "iopub.execute_input": "2026-07-08T08:58:30.782452Z",
+     "iopub.status.busy": "2026-07-08T08:58:30.782452Z",
+     "iopub.status.idle": "2026-07-08T08:58:31.733083Z",
+     "shell.execute_reply": "2026-07-08T08:58:31.733083Z"
     }
    },
    "outputs": [
@@ -112,10 +112,10 @@
    "id": "0bd7097b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:40.362525Z",
-     "iopub.status.busy": "2026-07-07T20:20:40.362525Z",
-     "iopub.status.idle": "2026-07-07T20:20:40.367773Z",
-     "shell.execute_reply": "2026-07-07T20:20:40.367773Z"
+     "iopub.execute_input": "2026-07-08T08:58:31.735096Z",
+     "iopub.status.busy": "2026-07-08T08:58:31.735096Z",
+     "iopub.status.idle": "2026-07-08T08:58:31.740900Z",
+     "shell.execute_reply": "2026-07-08T08:58:31.740900Z"
     }
    },
    "outputs": [
@@ -191,7 +191,7 @@
       "    \"source_type\": \"datasheet\",\n",
       "    \"source_name\": \"INR21700-50E Product Specification Rev 1.0\",\n",
       "    \"source_url\": \"https://example.com/samsung-inr21700-50e.pdf\",\n",
-      "    \"retrieved_at\": 1783455639,\n",
+      "    \"retrieved_at\": 1783501111,\n",
       "    \"battinfo_version\": \"0.7.0\"\n",
       "  }\n",
       "}\n"
@@ -210,10 +210,10 @@
    "id": "65e1f16b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:40.369780Z",
-     "iopub.status.busy": "2026-07-07T20:20:40.369780Z",
-     "iopub.status.idle": "2026-07-07T20:20:40.829035Z",
-     "shell.execute_reply": "2026-07-07T20:20:40.829035Z"
+     "iopub.execute_input": "2026-07-08T08:58:31.745234Z",
+     "iopub.status.busy": "2026-07-08T08:58:31.745234Z",
+     "iopub.status.idle": "2026-07-08T08:58:32.280840Z",
+     "shell.execute_reply": "2026-07-08T08:58:32.279835Z"
     }
    },
    "outputs": [
@@ -284,10 +284,10 @@
    "id": "bb91e73d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:40.829035Z",
-     "iopub.status.busy": "2026-07-07T20:20:40.829035Z",
-     "iopub.status.idle": "2026-07-07T20:20:40.839045Z",
-     "shell.execute_reply": "2026-07-07T20:20:40.839045Z"
+     "iopub.execute_input": "2026-07-08T08:58:32.284352Z",
+     "iopub.status.busy": "2026-07-08T08:58:32.283352Z",
+     "iopub.status.idle": "2026-07-08T08:58:32.291037Z",
+     "shell.execute_reply": "2026-07-08T08:58:32.289958Z"
     }
    },
    "outputs": [
@@ -333,10 +333,10 @@
    "id": "795996e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:40.843618Z",
-     "iopub.status.busy": "2026-07-07T20:20:40.841611Z",
-     "iopub.status.idle": "2026-07-07T20:20:40.848802Z",
-     "shell.execute_reply": "2026-07-07T20:20:40.848802Z"
+     "iopub.execute_input": "2026-07-08T08:58:32.293550Z",
+     "iopub.status.busy": "2026-07-08T08:58:32.293550Z",
+     "iopub.status.idle": "2026-07-08T08:58:32.299667Z",
+     "shell.execute_reply": "2026-07-08T08:58:32.298661Z"
     }
    },
    "outputs": [
@@ -344,8 +344,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Material-spec IRI: https://w3id.org/battinfo/material-spec/xcv1-hpy1-b0bw-z5s2\n",
-      "Component reference: https://w3id.org/battinfo/material-spec/xcv1-hpy1-b0bw-z5s2\n"
+      "Material-spec IRI: https://w3id.org/battinfo/spec/xcv1-hpy1-b0bw-z5s2\n",
+      "Component reference: https://w3id.org/battinfo/spec/xcv1-hpy1-b0bw-z5s2\n"
      ]
     }
    ],

--- a/docs/guides/03-linked-records.ipynb
+++ b/docs/guides/03-linked-records.ipynb
@@ -31,10 +31,10 @@
    "id": "49487b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.122083Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.122083Z",
-     "iopub.status.idle": "2026-07-07T20:20:47.438600Z",
-     "shell.execute_reply": "2026-07-07T20:20:47.438600Z"
+     "iopub.execute_input": "2026-07-08T08:58:48.832223Z",
+     "iopub.status.busy": "2026-07-08T08:58:48.832223Z",
+     "iopub.status.idle": "2026-07-08T08:58:49.425794Z",
+     "shell.execute_reply": "2026-07-08T08:58:49.425794Z"
     }
    },
    "outputs": [],
@@ -74,10 +74,10 @@
    "id": "d5e7a580",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.438600Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.438600Z",
-     "iopub.status.idle": "2026-07-07T20:20:47.446450Z",
-     "shell.execute_reply": "2026-07-07T20:20:47.446450Z"
+     "iopub.execute_input": "2026-07-08T08:58:49.429495Z",
+     "iopub.status.busy": "2026-07-08T08:58:49.429495Z",
+     "iopub.status.idle": "2026-07-08T08:58:49.436146Z",
+     "shell.execute_reply": "2026-07-08T08:58:49.436146Z"
     }
    },
    "outputs": [
@@ -125,10 +125,10 @@
    "id": "05b87289",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.446450Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.446450Z",
-     "iopub.status.idle": "2026-07-07T20:20:47.456155Z",
-     "shell.execute_reply": "2026-07-07T20:20:47.456155Z"
+     "iopub.execute_input": "2026-07-08T08:58:49.436146Z",
+     "iopub.status.busy": "2026-07-08T08:58:49.436146Z",
+     "iopub.status.idle": "2026-07-08T08:58:49.449135Z",
+     "shell.execute_reply": "2026-07-08T08:58:49.449135Z"
     }
    },
    "outputs": [
@@ -173,10 +173,10 @@
    "id": "3f90949f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.456155Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.456155Z",
-     "iopub.status.idle": "2026-07-07T20:20:47.477491Z",
-     "shell.execute_reply": "2026-07-07T20:20:47.477491Z"
+     "iopub.execute_input": "2026-07-08T08:58:49.452287Z",
+     "iopub.status.busy": "2026-07-08T08:58:49.452287Z",
+     "iopub.status.idle": "2026-07-08T08:58:49.478212Z",
+     "shell.execute_reply": "2026-07-08T08:58:49.478212Z"
     }
    },
    "outputs": [
@@ -250,10 +250,10 @@
    "id": "0ae05fc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.477491Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.477491Z",
-     "iopub.status.idle": "2026-07-07T20:20:47.489361Z",
-     "shell.execute_reply": "2026-07-07T20:20:47.489361Z"
+     "iopub.execute_input": "2026-07-08T08:58:49.482472Z",
+     "iopub.status.busy": "2026-07-08T08:58:49.482472Z",
+     "iopub.status.idle": "2026-07-08T08:58:49.504128Z",
+     "shell.execute_reply": "2026-07-08T08:58:49.504128Z"
     }
    },
    "outputs": [
@@ -306,10 +306,10 @@
    "id": "f739b75c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.492631Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.492631Z",
-     "iopub.status.idle": "2026-07-07T20:20:47.904194Z",
-     "shell.execute_reply": "2026-07-07T20:20:47.904194Z"
+     "iopub.execute_input": "2026-07-08T08:58:49.507314Z",
+     "iopub.status.busy": "2026-07-08T08:58:49.507314Z",
+     "iopub.status.idle": "2026-07-08T08:58:50.393473Z",
+     "shell.execute_reply": "2026-07-08T08:58:50.393473Z"
     }
    },
    "outputs": [
@@ -364,10 +364,10 @@
    "id": "b1bde293",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.907267Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.904194Z",
-     "iopub.status.idle": "2026-07-07T20:20:47.913096Z",
-     "shell.execute_reply": "2026-07-07T20:20:47.913096Z"
+     "iopub.execute_input": "2026-07-08T08:58:50.395869Z",
+     "iopub.status.busy": "2026-07-08T08:58:50.395869Z",
+     "iopub.status.idle": "2026-07-08T08:58:50.412438Z",
+     "shell.execute_reply": "2026-07-08T08:58:50.411364Z"
     }
    },
    "outputs": [
@@ -382,9 +382,9 @@
       "  \"name\": \"1C cycle life, cell A001 data\",\n",
       "  \"license\": \"CC-BY-4.0\",\n",
       "  \"access_url\": \"file:///<repo>/docs/guides/_scratch/guide-03/inputs/sdi-a001-cycle-life.csv\",\n",
-      "  \"created_at\": 1783455647,\n",
-      "  \"modified_at\": 1783455647,\n",
-      "  \"published_at\": 1783455647,\n",
+      "  \"created_at\": 1783501129,\n",
+      "  \"modified_at\": 1783501129,\n",
+      "  \"published_at\": 1783501129,\n",
       "  \"about\": [\n",
       "    \"https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7\",\n",
       "    \"https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt\"\n",
@@ -432,10 +432,10 @@
    "id": "bac15f6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:47.913096Z",
-     "iopub.status.busy": "2026-07-07T20:20:47.913096Z",
-     "iopub.status.idle": "2026-07-07T20:20:48.199720Z",
-     "shell.execute_reply": "2026-07-07T20:20:48.199720Z"
+     "iopub.execute_input": "2026-07-08T08:58:50.412438Z",
+     "iopub.status.busy": "2026-07-08T08:58:50.412438Z",
+     "iopub.status.idle": "2026-07-08T08:58:50.997513Z",
+     "shell.execute_reply": "2026-07-08T08:58:50.997513Z"
     }
    },
    "outputs": [
@@ -491,10 +491,10 @@
    "id": "17b1abe0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:48.199720Z",
-     "iopub.status.busy": "2026-07-07T20:20:48.199720Z",
-     "iopub.status.idle": "2026-07-07T20:20:48.207205Z",
-     "shell.execute_reply": "2026-07-07T20:20:48.207205Z"
+     "iopub.execute_input": "2026-07-08T08:58:51.002085Z",
+     "iopub.status.busy": "2026-07-08T08:58:51.002085Z",
+     "iopub.status.idle": "2026-07-08T08:58:51.008075Z",
+     "shell.execute_reply": "2026-07-08T08:58:51.008075Z"
     }
    },
    "outputs": [
@@ -532,10 +532,10 @@
    "id": "2647bdf5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:48.207205Z",
-     "iopub.status.busy": "2026-07-07T20:20:48.207205Z",
-     "iopub.status.idle": "2026-07-07T20:20:48.221577Z",
-     "shell.execute_reply": "2026-07-07T20:20:48.221577Z"
+     "iopub.execute_input": "2026-07-08T08:58:51.012294Z",
+     "iopub.status.busy": "2026-07-08T08:58:51.012294Z",
+     "iopub.status.idle": "2026-07-08T08:58:51.029007Z",
+     "shell.execute_reply": "2026-07-08T08:58:51.027987Z"
     }
    },
    "outputs": [

--- a/docs/guides/04-semantic-layer.ipynb
+++ b/docs/guides/04-semantic-layer.ipynb
@@ -19,10 +19,10 @@
    "id": "b9975261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:52.776677Z",
-     "iopub.status.busy": "2026-07-07T20:20:52.776677Z",
-     "iopub.status.idle": "2026-07-07T20:20:53.690018Z",
-     "shell.execute_reply": "2026-07-07T20:20:53.689012Z"
+     "iopub.execute_input": "2026-07-08T08:59:01.073994Z",
+     "iopub.status.busy": "2026-07-08T08:59:01.072305Z",
+     "iopub.status.idle": "2026-07-08T08:59:03.386624Z",
+     "shell.execute_reply": "2026-07-08T08:59:03.386624Z"
     }
    },
    "outputs": [
@@ -90,10 +90,10 @@
    "id": "df15cfe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:53.692038Z",
-     "iopub.status.busy": "2026-07-07T20:20:53.692038Z",
-     "iopub.status.idle": "2026-07-07T20:20:53.696019Z",
-     "shell.execute_reply": "2026-07-07T20:20:53.696019Z"
+     "iopub.execute_input": "2026-07-08T08:59:03.390140Z",
+     "iopub.status.busy": "2026-07-08T08:59:03.390140Z",
+     "iopub.status.idle": "2026-07-08T08:59:03.396795Z",
+     "shell.execute_reply": "2026-07-08T08:59:03.396795Z"
     }
    },
    "outputs": [
@@ -238,10 +238,10 @@
    "id": "310d641b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:53.696019Z",
-     "iopub.status.busy": "2026-07-07T20:20:53.696019Z",
-     "iopub.status.idle": "2026-07-07T20:20:53.702244Z",
-     "shell.execute_reply": "2026-07-07T20:20:53.702244Z"
+     "iopub.execute_input": "2026-07-08T08:59:03.400818Z",
+     "iopub.status.busy": "2026-07-08T08:59:03.398812Z",
+     "iopub.status.idle": "2026-07-08T08:59:03.405114Z",
+     "shell.execute_reply": "2026-07-08T08:59:03.405114Z"
     }
    },
    "outputs": [
@@ -318,10 +318,10 @@
    "id": "idf-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:53.702244Z",
-     "iopub.status.busy": "2026-07-07T20:20:53.702244Z",
-     "iopub.status.idle": "2026-07-07T20:20:53.710262Z",
-     "shell.execute_reply": "2026-07-07T20:20:53.710262Z"
+     "iopub.execute_input": "2026-07-08T08:59:03.409563Z",
+     "iopub.status.busy": "2026-07-08T08:59:03.409563Z",
+     "iopub.status.idle": "2026-07-08T08:59:03.420059Z",
+     "shell.execute_reply": "2026-07-08T08:59:03.418477Z"
     }
    },
    "outputs": [
@@ -356,10 +356,10 @@
    "id": "117501cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:53.710262Z",
-     "iopub.status.busy": "2026-07-07T20:20:53.710262Z",
-     "iopub.status.idle": "2026-07-07T20:20:53.716527Z",
-     "shell.execute_reply": "2026-07-07T20:20:53.716527Z"
+     "iopub.execute_input": "2026-07-08T08:59:03.424461Z",
+     "iopub.status.busy": "2026-07-08T08:59:03.422416Z",
+     "iopub.status.idle": "2026-07-08T08:59:03.436390Z",
+     "shell.execute_reply": "2026-07-08T08:59:03.433367Z"
     }
    },
    "outputs": [
@@ -413,10 +413,10 @@
    "id": "cfe8dd30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:53.716527Z",
-     "iopub.status.busy": "2026-07-07T20:20:53.716527Z",
-     "iopub.status.idle": "2026-07-07T20:20:53.780968Z",
-     "shell.execute_reply": "2026-07-07T20:20:53.780968Z"
+     "iopub.execute_input": "2026-07-08T08:59:03.446908Z",
+     "iopub.status.busy": "2026-07-08T08:59:03.445911Z",
+     "iopub.status.idle": "2026-07-08T08:59:03.684065Z",
+     "shell.execute_reply": "2026-07-08T08:59:03.683055Z"
     }
    },
    "outputs": [
@@ -457,10 +457,10 @@
    "id": "8b6bd11a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:53.780968Z",
-     "iopub.status.busy": "2026-07-07T20:20:53.780968Z",
-     "iopub.status.idle": "2026-07-07T20:20:54.643173Z",
-     "shell.execute_reply": "2026-07-07T20:20:54.643173Z"
+     "iopub.execute_input": "2026-07-08T08:59:03.692066Z",
+     "iopub.status.busy": "2026-07-08T08:59:03.691063Z",
+     "iopub.status.idle": "2026-07-08T08:59:05.012105Z",
+     "shell.execute_reply": "2026-07-08T08:59:05.011088Z"
     }
    },
    "outputs": [
@@ -489,10 +489,10 @@
    "id": "efb494cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:54.644926Z",
-     "iopub.status.busy": "2026-07-07T20:20:54.644926Z",
-     "iopub.status.idle": "2026-07-07T20:20:54.651350Z",
-     "shell.execute_reply": "2026-07-07T20:20:54.651350Z"
+     "iopub.execute_input": "2026-07-08T08:59:05.012105Z",
+     "iopub.status.busy": "2026-07-08T08:59:05.012105Z",
+     "iopub.status.idle": "2026-07-08T08:59:05.022382Z",
+     "shell.execute_reply": "2026-07-08T08:59:05.022382Z"
     }
    },
    "outputs": [
@@ -500,68 +500,68 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  N0631f39e8aaa443cbef1df569cfa6fa9  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N0631f39e8aaa443cbef1df569cfa6fa9  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
-      "  N46439ed9f692478ca697a9aeb8a6c523  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N46439ed9f692478ca697a9aeb8a6c523  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
-      "  N46439ed9f692478ca697a9aeb8a6c523  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Nda0e8beda51b4bb7b2b2c9e0f372e8f3\n",
-      "  N46439ed9f692478ca697a9aeb8a6c523  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
-      "  N51fe4b69d25f4cffbb5fa25b3b0f5065  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N51fe4b69d25f4cffbb5fa25b3b0f5065  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
-      "  N5984d1133567479ea1c41b34b2fd39c3  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N5984d1133567479ea1c41b34b2fd39c3  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
-      "  N68425bec5ba449b182240be09cb0b317  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N68425bec5ba449b182240be09cb0b317  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
-      "  N700e8ffea0d242fa8356c43d0e4014b1  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N700e8ffea0d242fa8356c43d0e4014b1  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
-      "  N7a350655081a4aaba43ff5afa4c1160f  →  type  →  Organization\n",
-      "  N7a350655081a4aaba43ff5afa4c1160f  →  name  →  A123 Systems\n",
-      "  N8e22e49ddd52441eb3fbae73fcf3bde0  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N8e22e49ddd52441eb3fbae73fcf3bde0  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
-      "  N8e22e49ddd52441eb3fbae73fcf3bde0  →  value  →  >1000\n",
-      "  N8e22e49ddd52441eb3fbae73fcf3bde0  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
-      "  N9fc18146ec944a8db954e8bb23d95d32  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N9fc18146ec944a8db954e8bb23d95d32  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
-      "  N9fc18146ec944a8db954e8bb23d95d32  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N0631f39e8aaa443cbef1df569cfa6fa9\n",
-      "  N9fc18146ec944a8db954e8bb23d95d32  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
-      "  Nade0742a5fea4b7ba75338638c8e5e20  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nade0742a5fea4b7ba75338638c8e5e20  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
-      "  Nade0742a5fea4b7ba75338638c8e5e20  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N68425bec5ba449b182240be09cb0b317\n",
-      "  Nade0742a5fea4b7ba75338638c8e5e20  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
-      "  Nd7a574e052b0422384c64b1985f5ec6f  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nd7a574e052b0422384c64b1985f5ec6f  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
-      "  Nd7a574e052b0422384c64b1985f5ec6f  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N700e8ffea0d242fa8356c43d0e4014b1\n",
-      "  Nd7a574e052b0422384c64b1985f5ec6f  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
-      "  Nda0e8beda51b4bb7b2b2c9e0f372e8f3  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  Nda0e8beda51b4bb7b2b2c9e0f372e8f3  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
-      "  Ndbfb68ecd2d64f11b7afa6f16ab2ffd2  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
-      "  Ndbfb68ecd2d64f11b7afa6f16ab2ffd2  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Ndbfb68ecd2d64f11b7afa6f16ab2ffd2  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N51fe4b69d25f4cffbb5fa25b3b0f5065\n",
-      "  Ndbfb68ecd2d64f11b7afa6f16ab2ffd2  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
-      "  Ne1403ca04e404332a48e48871c718259  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Ne1403ca04e404332a48e48871c718259  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
-      "  Ne1403ca04e404332a48e48871c718259  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Ne3ec09a905104f4eb70541e35d19aa83\n",
-      "  Ne1403ca04e404332a48e48871c718259  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
-      "  Ne3ec09a905104f4eb70541e35d19aa83  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  Ne3ec09a905104f4eb70541e35d19aa83  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
-      "  Nfdb8e8e287f145ff851824b453788364  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
-      "  Nfdb8e8e287f145ff851824b453788364  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nfdb8e8e287f145ff851824b453788364  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N5984d1133567479ea1c41b34b2fd39c3\n",
-      "  Nfdb8e8e287f145ff851824b453788364  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
+      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N305e542159ae4789966521c41269ee2f\n",
+      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
+      "  N28e0a161800143c981375372093718b6  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
+      "  N28e0a161800143c981375372093718b6  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N28e0a161800143c981375372093718b6  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N3a8c1a6039db45fda464b3115dba3f00\n",
+      "  N28e0a161800143c981375372093718b6  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  N305e542159ae4789966521c41269ee2f  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N305e542159ae4789966521c41269ee2f  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
+      "  N33b5d583f88a4d65a4e93a71d09f081e  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N33b5d583f88a4d65a4e93a71d09f081e  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
+      "  N33b5d583f88a4d65a4e93a71d09f081e  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Na317129623cd43f18bdba8ccfea6c8f8\n",
+      "  N33b5d583f88a4d65a4e93a71d09f081e  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
+      "  N3a8c1a6039db45fda464b3115dba3f00  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N3a8c1a6039db45fda464b3115dba3f00  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
+      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
+      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  value  →  >1000\n",
+      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
+      "  N44979483946e425f887cef5e3f9134f2  →  type  →  Organization\n",
+      "  N44979483946e425f887cef5e3f9134f2  →  name  →  A123 Systems\n",
+      "  N818c9380674d434dbeb54534e36da9a4  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N818c9380674d434dbeb54534e36da9a4  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
+      "  N8c21edfdd69d4fc0b121af62ed297a71  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N8c21edfdd69d4fc0b121af62ed297a71  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
+      "  Na317129623cd43f18bdba8ccfea6c8f8  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Na317129623cd43f18bdba8ccfea6c8f8  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
+      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
+      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Nc1d98de687264a80af4cf7369a3c7db7\n",
+      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
+      "  Nc1d98de687264a80af4cf7369a3c7db7  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Nc1d98de687264a80af4cf7369a3c7db7  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
+      "  Nd0a9944c9fe84a3e877b508ab141e4a9  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Nd0a9944c9fe84a3e877b508ab141e4a9  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
+      "  Nd126b9badbd84f6d965e2d3a4374566e  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nd126b9badbd84f6d965e2d3a4374566e  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
+      "  Nd126b9badbd84f6d965e2d3a4374566e  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N8c21edfdd69d4fc0b121af62ed297a71\n",
+      "  Nd126b9badbd84f6d965e2d3a4374566e  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
+      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
+      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N818c9380674d434dbeb54534e36da9a4\n",
+      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
+      "  Nffaf996e61ce486cb4deebda0a828514  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
+      "  Nffaf996e61ce486cb4deebda0a828514  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nffaf996e61ce486cb4deebda0a828514  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Nd0a9944c9fe84a3e877b508ab141e4a9\n",
+      "  Nffaf996e61ce486cb4deebda0a828514  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  CreativeWork\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  battery_1cfbba6c_8824_4932_a23e_2141483acef7\n",
       "  wckm-y5a4-he0k-2scd  →  identifier  →  wckm-y5a4-he0k-2scd\n",
-      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  N7a350655081a4aaba43ff5afa4c1160f\n",
+      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  N44979483946e425f887cef5e3f9134f2\n",
       "  wckm-y5a4-he0k-2scd  →  name  →  A123 Systems ANR26650M1-B\n",
       "  wckm-y5a4-he0k-2scd  →  size  →  R26650\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N46439ed9f692478ca697a9aeb8a6c523\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N8e22e49ddd52441eb3fbae73fcf3bde0\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N9fc18146ec944a8db954e8bb23d95d32\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nade0742a5fea4b7ba75338638c8e5e20\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nd7a574e052b0422384c64b1985f5ec6f\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ndbfb68ecd2d64f11b7afa6f16ab2ffd2\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ne1403ca04e404332a48e48871c718259\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nfdb8e8e287f145ff851824b453788364\n"
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N07cdc0617df84fbe9e02d1cff8d9e701\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N28e0a161800143c981375372093718b6\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N33b5d583f88a4d65a4e93a71d09f081e\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N435d98ae0cc64ecc8b665a1444ad5fe3\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Na934dcb544974fbdad44fcd67e1e0ff9\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nd126b9badbd84f6d965e2d3a4374566e\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ne23472f95c9641cc8f621daeaa2d48dc\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nffaf996e61ce486cb4deebda0a828514\n"
      ]
     }
    ],
@@ -588,10 +588,10 @@
    "id": "f05bb577",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:54.653354Z",
-     "iopub.status.busy": "2026-07-07T20:20:54.653354Z",
-     "iopub.status.idle": "2026-07-07T20:20:55.985931Z",
-     "shell.execute_reply": "2026-07-07T20:20:55.985931Z"
+     "iopub.execute_input": "2026-07-08T08:59:05.027155Z",
+     "iopub.status.busy": "2026-07-08T08:59:05.027155Z",
+     "iopub.status.idle": "2026-07-08T08:59:07.414035Z",
+     "shell.execute_reply": "2026-07-08T08:59:07.414035Z"
     }
    },
    "outputs": [
@@ -669,10 +669,10 @@
    "id": "97dfdfc6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:20:55.985931Z",
-     "iopub.status.busy": "2026-07-07T20:20:55.985931Z",
-     "iopub.status.idle": "2026-07-07T20:20:55.998484Z",
-     "shell.execute_reply": "2026-07-07T20:20:55.998484Z"
+     "iopub.execute_input": "2026-07-08T08:59:07.419792Z",
+     "iopub.status.busy": "2026-07-08T08:59:07.417781Z",
+     "iopub.status.idle": "2026-07-08T08:59:07.427731Z",
+     "shell.execute_reply": "2026-07-08T08:59:07.427731Z"
     }
    },
    "outputs": [
@@ -681,16 +681,16 @@
      "output_type": "stream",
      "text": [
       "Property map version: 0.3.0\n",
-      "Curated entries: 63\n",
+      "Curated entries: 66\n",
       "\n",
-      "  nominal_capacity                           → NominalCapacity\n",
-      "  minimum_capacity                           → MinimumCapacity\n",
-      "  min_capacity                               → MinimumCapacity\n",
-      "  rated_capacity                             → RatedCapacity\n",
-      "  nominal_voltage                            → NominalVoltage\n",
-      "  charging_voltage                           → ChargingVoltage\n",
-      "  discharging_cutoff_voltage                 → LowerVoltageLimit\n",
+      "  ac_internal_resistance                     → ACInternalResistance\n",
+      "  available_volume                           → Volume\n",
+      "  calendar_life                              → CalendarLife\n",
+      "  cap_assembly_weight                        → Mass\n",
+      "  capacity_fade                              → CapacityFade\n",
+      "  certified_usable_energy                    → NominalEnergy\n",
       "  charging_cutoff_voltage                    → UpperVoltageLimit\n",
+      "  charging_temperature_max                   → MaximumChargingTemperature\n",
       "  ...\n"
      ]
     }

--- a/docs/guides/05-descriptors.ipynb
+++ b/docs/guides/05-descriptors.ipynb
@@ -21,10 +21,10 @@
    "id": "1cf55ef0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:01.581621Z",
-     "iopub.status.busy": "2026-07-07T20:21:01.581621Z",
-     "iopub.status.idle": "2026-07-07T20:21:01.597083Z",
-     "shell.execute_reply": "2026-07-07T20:21:01.597083Z"
+     "iopub.execute_input": "2026-07-08T08:59:15.667774Z",
+     "iopub.status.busy": "2026-07-08T08:59:15.666778Z",
+     "iopub.status.idle": "2026-07-08T08:59:15.678309Z",
+     "shell.execute_reply": "2026-07-08T08:59:15.677301Z"
     }
    },
    "outputs": [],
@@ -52,10 +52,10 @@
    "id": "ddcca263",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:01.597083Z",
-     "iopub.status.busy": "2026-07-07T20:21:01.597083Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.013518Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.013518Z"
+     "iopub.execute_input": "2026-07-08T08:59:15.682310Z",
+     "iopub.status.busy": "2026-07-08T08:59:15.682310Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.120436Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.118920Z"
     }
    },
    "outputs": [
@@ -101,10 +101,10 @@
    "id": "4b04c30f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.017035Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.017035Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.023338Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.023338Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.126958Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.125981Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.136698Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.135692Z"
     }
    },
    "outputs": [
@@ -141,10 +141,10 @@
    "id": "38095956",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.027352Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.027352Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.033041Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.033041Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.139698Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.139698Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.146961Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.146961Z"
     }
    },
    "outputs": [
@@ -195,10 +195,10 @@
    "id": "3fcb31b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.036625Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.036625Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.045656Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.045656Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.146961Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.146961Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.157330Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.157330Z"
     }
    },
    "outputs": [
@@ -250,10 +250,10 @@
    "id": "7e673ceb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.048880Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.048880Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.054223Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.053709Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.162055Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.160542Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.168846Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.168846Z"
     }
    },
    "outputs": [
@@ -296,10 +296,10 @@
    "id": "70bef49a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.056237Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.056237Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.060276Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.060276Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.172288Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.172288Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.179433Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.179433Z"
     }
    },
    "outputs": [
@@ -338,10 +338,10 @@
    "id": "b6297d58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.063282Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.062281Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.067164Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.067164Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.182342Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.182342Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.190415Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.190415Z"
     }
    },
    "outputs": [
@@ -383,10 +383,10 @@
    "id": "f9d5ffe7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.067164Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.067164Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.074605Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.074605Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.192430Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.192430Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.202124Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.201093Z"
     }
    },
    "outputs": [
@@ -452,10 +452,10 @@
    "id": "85a1b7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.074605Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.074605Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.082609Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.082609Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.202124Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.202124Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.213149Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.213149Z"
     }
    },
    "outputs": [
@@ -464,20 +464,20 @@
      "output_type": "stream",
      "text": [
       "14 standalone material spec(s):\n",
-      "  LFP            active_material        https://w3id.org/battinfo/material-spec/s6y8-5mne-94gx-e5ve\n",
-      "  PVDF           binder                 https://w3id.org/battinfo/material-spec/fm9p-sqkk-tbx3-rr66\n",
-      "  Carbon black   conductive_additive    https://w3id.org/battinfo/material-spec/xz03-r714-wpa0-bwpb\n",
-      "  Aluminium foil current_collector      https://w3id.org/battinfo/material-spec/92ny-p3qm-6j9n-vrym\n",
-      "  Graphite       active_material        https://w3id.org/battinfo/material-spec/sm7b-n4y5-2hrk-dv6h\n",
-      "  CMC            binder                 https://w3id.org/battinfo/material-spec/t4wz-ff8s-6vp6-af48\n",
-      "  SBR            binder                 https://w3id.org/battinfo/material-spec/7p3d-2e22-7yae-spyb\n",
-      "  Copper foil    current_collector      https://w3id.org/battinfo/material-spec/ftdw-5z5h-mbn7-x13m\n",
-      "  LiPF6          electrolyte_salt       https://w3id.org/battinfo/material-spec/xcv1-hpy1-b0bw-z5s2\n",
-      "  EC             electrolyte_solvent    https://w3id.org/battinfo/material-spec/z6sr-a9yw-gryf-3q55\n",
-      "  DMC            electrolyte_solvent    https://w3id.org/battinfo/material-spec/va82-gnpn-v0bt-3qed\n",
-      "  VC             electrolyte_additive   https://w3id.org/battinfo/material-spec/nbz6-pn8h-4458-dh91\n",
-      "  FEC            electrolyte_additive   https://w3id.org/battinfo/material-spec/t59c-yz22-48as-tdkx\n",
-      "  Polypropylene  separator_material     https://w3id.org/battinfo/material-spec/n24p-ymxz-gj1j-q6pb\n"
+      "  LFP            active_material        https://w3id.org/battinfo/spec/s6y8-5mne-94gx-e5ve\n",
+      "  PVDF           binder                 https://w3id.org/battinfo/spec/fm9p-sqkk-tbx3-rr66\n",
+      "  Carbon black   conductive_additive    https://w3id.org/battinfo/spec/xz03-r714-wpa0-bwpb\n",
+      "  Aluminium foil current_collector      https://w3id.org/battinfo/spec/92ny-p3qm-6j9n-vrym\n",
+      "  Graphite       active_material        https://w3id.org/battinfo/spec/sm7b-n4y5-2hrk-dv6h\n",
+      "  CMC            binder                 https://w3id.org/battinfo/spec/t4wz-ff8s-6vp6-af48\n",
+      "  SBR            binder                 https://w3id.org/battinfo/spec/7p3d-2e22-7yae-spyb\n",
+      "  Copper foil    current_collector      https://w3id.org/battinfo/spec/ftdw-5z5h-mbn7-x13m\n",
+      "  LiPF6          electrolyte_salt       https://w3id.org/battinfo/spec/xcv1-hpy1-b0bw-z5s2\n",
+      "  EC             electrolyte_solvent    https://w3id.org/battinfo/spec/z6sr-a9yw-gryf-3q55\n",
+      "  DMC            electrolyte_solvent    https://w3id.org/battinfo/spec/va82-gnpn-v0bt-3qed\n",
+      "  VC             electrolyte_additive   https://w3id.org/battinfo/spec/nbz6-pn8h-4458-dh91\n",
+      "  FEC            electrolyte_additive   https://w3id.org/battinfo/spec/t59c-yz22-48as-tdkx\n",
+      "  Polypropylene  separator_material     https://w3id.org/battinfo/spec/n24p-ymxz-gj1j-q6pb\n"
      ]
     }
    ],
@@ -505,10 +505,10 @@
    "id": "0c953dd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.082609Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.082609Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.090965Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.090965Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.213149Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.213149Z",
+     "iopub.status.idle": "2026-07-08T08:59:16.223425Z",
+     "shell.execute_reply": "2026-07-08T08:59:16.223425Z"
     }
    },
    "outputs": [
@@ -546,10 +546,10 @@
    "id": "cc431ddd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.090965Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.090965Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.540187Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.540187Z"
+     "iopub.execute_input": "2026-07-08T08:59:16.227728Z",
+     "iopub.status.busy": "2026-07-08T08:59:16.227728Z",
+     "iopub.status.idle": "2026-07-08T08:59:17.182946Z",
+     "shell.execute_reply": "2026-07-08T08:59:17.182946Z"
     }
    },
    "outputs": [
@@ -585,10 +585,10 @@
    "id": "6cc0a7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.541192Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.541192Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.551463Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.551463Z"
+     "iopub.execute_input": "2026-07-08T08:59:17.182946Z",
+     "iopub.status.busy": "2026-07-08T08:59:17.182946Z",
+     "iopub.status.idle": "2026-07-08T08:59:17.196681Z",
+     "shell.execute_reply": "2026-07-08T08:59:17.196681Z"
     }
    },
    "outputs": [
@@ -1053,10 +1053,10 @@
    "id": "1b0ac8c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.551463Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.551463Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.603186Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.603186Z"
+     "iopub.execute_input": "2026-07-08T08:59:17.200708Z",
+     "iopub.status.busy": "2026-07-08T08:59:17.200708Z",
+     "iopub.status.idle": "2026-07-08T08:59:17.292099Z",
+     "shell.execute_reply": "2026-07-08T08:59:17.290575Z"
     }
    },
    "outputs": [
@@ -1096,10 +1096,10 @@
    "id": "8e638265",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.604699Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.604699Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.880290Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.880290Z"
+     "iopub.execute_input": "2026-07-08T08:59:17.297044Z",
+     "iopub.status.busy": "2026-07-08T08:59:17.297044Z",
+     "iopub.status.idle": "2026-07-08T08:59:17.916811Z",
+     "shell.execute_reply": "2026-07-08T08:59:17.916811Z"
     }
    },
    "outputs": [
@@ -1129,10 +1129,10 @@
    "id": "e7e19b64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:02.880290Z",
-     "iopub.status.busy": "2026-07-07T20:21:02.880290Z",
-     "iopub.status.idle": "2026-07-07T20:21:02.963553Z",
-     "shell.execute_reply": "2026-07-07T20:21:02.963553Z"
+     "iopub.execute_input": "2026-07-08T08:59:17.916811Z",
+     "iopub.status.busy": "2026-07-08T08:59:17.916811Z",
+     "iopub.status.idle": "2026-07-08T08:59:18.036852Z",
+     "shell.execute_reply": "2026-07-08T08:59:18.035335Z"
     }
    },
    "outputs": [

--- a/docs/guides/06-publish-your-data.ipynb
+++ b/docs/guides/06-publish-your-data.ipynb
@@ -30,10 +30,10 @@
    "id": "e43cee13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:07.894956Z",
-     "iopub.status.busy": "2026-07-07T20:21:07.894956Z",
-     "iopub.status.idle": "2026-07-07T20:21:08.197487Z",
-     "shell.execute_reply": "2026-07-07T20:21:08.197487Z"
+     "iopub.execute_input": "2026-07-08T08:59:27.288959Z",
+     "iopub.status.busy": "2026-07-08T08:59:27.285873Z",
+     "iopub.status.idle": "2026-07-08T08:59:28.063271Z",
+     "shell.execute_reply": "2026-07-08T08:59:28.063271Z"
     }
    },
    "outputs": [],
@@ -75,10 +75,10 @@
    "id": "e2c1ddca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:08.197487Z",
-     "iopub.status.busy": "2026-07-07T20:21:08.197487Z",
-     "iopub.status.idle": "2026-07-07T20:21:09.331659Z",
-     "shell.execute_reply": "2026-07-07T20:21:09.331659Z"
+     "iopub.execute_input": "2026-07-08T08:59:28.067209Z",
+     "iopub.status.busy": "2026-07-08T08:59:28.067209Z",
+     "iopub.status.idle": "2026-07-08T08:59:30.713245Z",
+     "shell.execute_reply": "2026-07-08T08:59:30.713245Z"
     }
    },
    "outputs": [
@@ -120,10 +120,10 @@
    "id": "c7d97399",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:09.331659Z",
-     "iopub.status.busy": "2026-07-07T20:21:09.331659Z",
-     "iopub.status.idle": "2026-07-07T20:21:10.833093Z",
-     "shell.execute_reply": "2026-07-07T20:21:10.832577Z"
+     "iopub.execute_input": "2026-07-08T08:59:30.718093Z",
+     "iopub.status.busy": "2026-07-08T08:59:30.717095Z",
+     "iopub.status.idle": "2026-07-08T08:59:32.402197Z",
+     "shell.execute_reply": "2026-07-08T08:59:32.400551Z"
     }
    },
    "outputs": [
@@ -173,10 +173,10 @@
    "id": "d9a22b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:10.835678Z",
-     "iopub.status.busy": "2026-07-07T20:21:10.833093Z",
-     "iopub.status.idle": "2026-07-07T20:21:10.844674Z",
-     "shell.execute_reply": "2026-07-07T20:21:10.844674Z"
+     "iopub.execute_input": "2026-07-08T08:59:32.405381Z",
+     "iopub.status.busy": "2026-07-08T08:59:32.405381Z",
+     "iopub.status.idle": "2026-07-08T08:59:32.420581Z",
+     "shell.execute_reply": "2026-07-08T08:59:32.420581Z"
     }
    },
    "outputs": [
@@ -221,10 +221,10 @@
    "id": "241ee167",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:10.844674Z",
-     "iopub.status.busy": "2026-07-07T20:21:10.844674Z",
-     "iopub.status.idle": "2026-07-07T20:21:11.117448Z",
-     "shell.execute_reply": "2026-07-07T20:21:11.117448Z"
+     "iopub.execute_input": "2026-07-08T08:59:32.424103Z",
+     "iopub.status.busy": "2026-07-08T08:59:32.424103Z",
+     "iopub.status.idle": "2026-07-08T08:59:33.089708Z",
+     "shell.execute_reply": "2026-07-08T08:59:33.088689Z"
     }
    },
    "outputs": [
@@ -260,10 +260,10 @@
    "id": "03b2dfb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:11.117448Z",
-     "iopub.status.busy": "2026-07-07T20:21:11.117448Z",
-     "iopub.status.idle": "2026-07-07T20:21:11.126020Z",
-     "shell.execute_reply": "2026-07-07T20:21:11.126020Z"
+     "iopub.execute_input": "2026-07-08T08:59:33.092239Z",
+     "iopub.status.busy": "2026-07-08T08:59:33.092239Z",
+     "iopub.status.idle": "2026-07-08T08:59:33.100650Z",
+     "shell.execute_reply": "2026-07-08T08:59:33.100145Z"
     }
    },
    "outputs": [
@@ -281,7 +281,7 @@
       "...\n",
       "provenance: {\n",
       "  \"source_type\": \"measurement\",\n",
-      "  \"retrieved_at\": 1783455670,\n",
+      "  \"retrieved_at\": 1783501172,\n",
       "  \"battinfo_version\": \"0.7.0\"\n",
       "}\n"
      ]
@@ -320,10 +320,10 @@
    "id": "5e115f9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:21:11.126020Z",
-     "iopub.status.busy": "2026-07-07T20:21:11.126020Z",
-     "iopub.status.idle": "2026-07-07T20:21:11.132113Z",
-     "shell.execute_reply": "2026-07-07T20:21:11.132113Z"
+     "iopub.execute_input": "2026-07-08T08:59:33.103163Z",
+     "iopub.status.busy": "2026-07-08T08:59:33.103163Z",
+     "iopub.status.idle": "2026-07-08T08:59:33.109129Z",
+     "shell.execute_reply": "2026-07-08T08:59:33.108122Z"
     }
    },
    "outputs": [

--- a/docs/material-spec.md
+++ b/docs/material-spec.md
@@ -23,7 +23,7 @@ A reusable material specification. Top-level key `material_spec`.
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `id` | ✓ | `https://w3id.org/battinfo/material-spec/{uid}` |
+| `id` | ✓ | `https://w3id.org/battinfo/spec/{uid}` |
 | `name` | ✓ | Material grade, e.g. `"LFP"`, `"Graphite"`, `"NMC811"` |
 | `material_class` | | `active_material`, `binder`, `conductive_additive`, `current_collector`, `separator_material`, `electrolyte_salt`, `electrolyte_solvent`, `electrolyte_additive`, `metal_electrode`, `coating`, `other` |
 | `electrode_polarity` | | `positive` / `negative` / `none` (for active materials) |
@@ -65,8 +65,8 @@ For derived/blended grades, `composition` references other material-specs by IRI
 
 ```json
 "composition": {
-  "base_material_id": "https://w3id.org/battinfo/material-spec/<NMC811>",
-  "coatings": [{"material_spec_id": "https://w3id.org/battinfo/material-spec/<Al2O3>",
+  "base_material_id": "https://w3id.org/battinfo/spec/<NMC811>",
+  "coatings": [{"material_spec_id": "https://w3id.org/battinfo/spec/<Al2O3>",
                 "name": "Al2O3", "property": {"thickness": {"value": 5, "unit": "nm"}}}],
   "dopants": [{"element": "Al", "fraction": {"value": 0.01, "unit": "1"}}],
   "constituents": []

--- a/examples/cell-spec/cell-spec-0hpw-gkhk-gcg8-23x1.json
+++ b/examples/cell-spec/cell-spec-0hpw-gkhk-gcg8-23x1.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/f75a-tq2f-4tey-nba7",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/f75a-tq2f-4tey-nba7",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery NMC622-Graphite coin cell."
   ]

--- a/examples/cell-spec/cell-spec-77tx-95x5-8tvd-n33a.json
+++ b/examples/cell-spec/cell-spec-77tx-95x5-8tvd-n33a.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/a86t-cxgj-c8h4-2y7b",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/a86t-cxgj-c8h4-2y7b",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery LFP-Graphite coin cell."
   ]

--- a/examples/cell-spec/cell-spec-86k6-6tzd-c4sf-5s01.json
+++ b/examples/cell-spec/cell-spec-86k6-6tzd-c4sf-5s01.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/a86t-cxgj-c8h4-2y7b",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/ypyh-v38v-r276-snmk",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/a86t-cxgj-c8h4-2y7b",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/ypyh-v38v-r276-snmk",
   "notes": [
     "LFP 100 Ah prismatic engineering cell (Cell_Design_Tool)."
   ]

--- a/examples/cell-spec/cell-spec-944g-byr3-afdy-vha5.json
+++ b/examples/cell-spec/cell-spec-944g-byr3-afdy-vha5.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/kewv-75y9-kqz5-8ty6",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/kewv-75y9-kqz5-8ty6",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery LMFP-Graphite coin cell."
   ]

--- a/examples/cell-spec/cell-spec-jgyy-x3h5-drmv-5tn5.json
+++ b/examples/cell-spec/cell-spec-jgyy-x3h5-drmv-5tn5.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/8pdh-vrd3-tjar-8mgq",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/znwy-gmhg-34rb-qs1j",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gzt2-hrqq-gsfn-sp94",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/8pdh-vrd3-tjar-8mgq",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/znwy-gmhg-34rb-qs1j",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gzt2-hrqq-gsfn-sp94",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Non-Li-ion alkaline Zn-MnO2 coin cell (7M KOH)."
   ]

--- a/examples/cell-spec/cell-spec-st13-tf1d-z9b3-k1hf.json
+++ b/examples/cell-spec/cell-spec-st13-tf1d-z9b3-k1hf.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/3e43-kbz8-ptjn-szs9",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/3e43-kbz8-ptjn-szs9",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery LCO-Graphite coin cell."
   ]

--- a/examples/cell-spec/cell-spec-tme2-0sy6-q89b-8m92.json
+++ b/examples/cell-spec/cell-spec-tme2-0sy6-q89b-8m92.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772766
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/t947-yem5-73n7-beb7",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/t947-yem5-73n7-beb7",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery NMC811-Graphite coin cell."
   ]

--- a/examples/cell-spec/cell-spec-venv-ff8p-nbk3-bxcn.json
+++ b/examples/cell-spec/cell-spec-venv-ff8p-nbk3-bxcn.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/ck8b-r1dz-h8my-3k05",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/ck8b-r1dz-h8my-3k05",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "High-voltage LNMO-Graphite coin cell."
   ]

--- a/examples/current-collector-spec/current-collector-spec-vkaf-f5bv-fwt2-e6yz.json
+++ b/examples/current-collector-spec/current-collector-spec-vkaf-f5bv-fwt2-e6yz.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "current_collector_spec": {
-    "id": "https://w3id.org/battinfo/current-collector-spec/vkaf-f5bv-fwt2-e6yz",
+    "id": "https://w3id.org/battinfo/spec/vkaf-f5bv-fwt2-e6yz",
     "short_id": "vkaff5",
     "name": "Aluminium foil",
     "property": {

--- a/examples/current-collector-spec/current-collector-spec-z25y-gab5-hd3n-qfpr.json
+++ b/examples/current-collector-spec/current-collector-spec-z25y-gab5-hd3n-qfpr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "current_collector_spec": {
-    "id": "https://w3id.org/battinfo/current-collector-spec/z25y-gab5-hd3n-qfpr",
+    "id": "https://w3id.org/battinfo/spec/z25y-gab5-hd3n-qfpr",
     "short_id": "z25yga",
     "name": "Copper foil",
     "property": {

--- a/examples/current-collector/current-collector-dwnd-tyk8-be76-1a3j.json
+++ b/examples/current-collector/current-collector-dwnd-tyk8-be76-1a3j.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "current_collector": {
     "id": "https://w3id.org/battinfo/current-collector/dwnd-tyk8-be76-1a3j",
-    "current_collector_spec_id": "https://w3id.org/battinfo/current-collector-spec/vkaf-f5bv-fwt2-e6yz",
+    "current_collector_spec_id": "https://w3id.org/battinfo/spec/vkaf-f5bv-fwt2-e6yz",
     "short_id": "dwndty",
     "property": {
       "thickness": {

--- a/examples/current-collector/current-collector-e7bq-z754-er6f-e561.json
+++ b/examples/current-collector/current-collector-e7bq-z754-er6f-e561.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "current_collector": {
     "id": "https://w3id.org/battinfo/current-collector/e7bq-z754-er6f-e561",
-    "current_collector_spec_id": "https://w3id.org/battinfo/current-collector-spec/z25y-gab5-hd3n-qfpr",
+    "current_collector_spec_id": "https://w3id.org/battinfo/spec/z25y-gab5-hd3n-qfpr",
     "short_id": "e7bqz7",
     "property": {
       "thickness": {

--- a/examples/electrode-spec/electrode-spec-3e43-kbz8-ptjn-szs9.json
+++ b/examples/electrode-spec/electrode-spec-3e43-kbz8-ptjn-szs9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/3e43-kbz8-ptjn-szs9",
+    "id": "https://w3id.org/battinfo/spec/3e43-kbz8-ptjn-szs9",
     "short_id": "3e43kb",
     "name": "LCO cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LCO",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/shzh-t2jt-wwqv-k54m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/shzh-t2jt-wwqv-k54m",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/examples/electrode-spec/electrode-spec-8pdh-vrd3-tjar-8mgq.json
+++ b/examples/electrode-spec/electrode-spec-8pdh-vrd3-tjar-8mgq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/8pdh-vrd3-tjar-8mgq",
+    "id": "https://w3id.org/battinfo/spec/8pdh-vrd3-tjar-8mgq",
     "short_id": "8pdhvr",
     "name": "MnO2 cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "MnO2",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/fwnh-2wkq-n9wm-fdab",
+            "material_spec_id": "https://w3id.org/battinfo/spec/fwnh-2wkq-n9wm-fdab",
             "property": {
               "mass_fraction": {
                 "value": 0.9,
@@ -21,7 +21,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.1,

--- a/examples/electrode-spec/electrode-spec-a86t-cxgj-c8h4-2y7b.json
+++ b/examples/electrode-spec/electrode-spec-a86t-cxgj-c8h4-2y7b.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/a86t-cxgj-c8h4-2y7b",
+    "id": "https://w3id.org/battinfo/spec/a86t-cxgj-c8h4-2y7b",
     "short_id": "a86tcx",
     "name": "LFP cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LFP",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/5ms1-9jv8-hr54-mn4e",
+            "material_spec_id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/examples/electrode-spec/electrode-spec-ck8b-r1dz-h8my-3k05.json
+++ b/examples/electrode-spec/electrode-spec-ck8b-r1dz-h8my-3k05.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/ck8b-r1dz-h8my-3k05",
+    "id": "https://w3id.org/battinfo/spec/ck8b-r1dz-h8my-3k05",
     "short_id": "ck8br1",
     "name": "LNMO cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LNMO",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/83bd-jmk7-2x47-s04a",
+            "material_spec_id": "https://w3id.org/battinfo/spec/83bd-jmk7-2x47-s04a",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/examples/electrode-spec/electrode-spec-f75a-tq2f-4tey-nba7.json
+++ b/examples/electrode-spec/electrode-spec-f75a-tq2f-4tey-nba7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/f75a-tq2f-4tey-nba7",
+    "id": "https://w3id.org/battinfo/spec/f75a-tq2f-4tey-nba7",
     "short_id": "f75atq",
     "name": "NMC622 cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "NMC622",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/s2m9-ksma-nb61-8tpa",
+            "material_spec_id": "https://w3id.org/battinfo/spec/s2m9-ksma-nb61-8tpa",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/examples/electrode-spec/electrode-spec-fvwx-7fq1-wwfs-fn3g.json
+++ b/examples/electrode-spec/electrode-spec-fvwx-7fq1-wwfs-fn3g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
+    "id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
     "short_id": "fvwx7f",
     "name": "Graphite anode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "Graphite",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/gwck-k5kf-ae1f-gfgc",
+            "material_spec_id": "https://w3id.org/battinfo/spec/gwck-k5kf-ae1f-gfgc",
             "property": {
               "mass_fraction": {
                 "value": 0.95,
@@ -32,7 +32,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.01,

--- a/examples/electrode-spec/electrode-spec-kewv-75y9-kqz5-8ty6.json
+++ b/examples/electrode-spec/electrode-spec-kewv-75y9-kqz5-8ty6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/kewv-75y9-kqz5-8ty6",
+    "id": "https://w3id.org/battinfo/spec/kewv-75y9-kqz5-8ty6",
     "short_id": "kewv75",
     "name": "LMFP cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LMFP",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/qwae-x6cg-c61k-njw7",
+            "material_spec_id": "https://w3id.org/battinfo/spec/qwae-x6cg-c61k-njw7",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/examples/electrode-spec/electrode-spec-t947-yem5-73n7-beb7.json
+++ b/examples/electrode-spec/electrode-spec-t947-yem5-73n7-beb7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/t947-yem5-73n7-beb7",
+    "id": "https://w3id.org/battinfo/spec/t947-yem5-73n7-beb7",
     "short_id": "t947ye",
     "name": "NMC811 cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "NMC811",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+            "material_spec_id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/examples/electrode-spec/electrode-spec-znwy-gmhg-34rb-qs1j.json
+++ b/examples/electrode-spec/electrode-spec-znwy-gmhg-34rb-qs1j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/znwy-gmhg-34rb-qs1j",
+    "id": "https://w3id.org/battinfo/spec/znwy-gmhg-34rb-qs1j",
     "short_id": "znwygm",
     "name": "Zn anode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "Zinc",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/kg0e-vqce-3439-bnfk",
+            "material_spec_id": "https://w3id.org/battinfo/spec/kg0e-vqce-3439-bnfk",
             "property": {
               "mass_fraction": {
                 "value": 0.95,

--- a/examples/electrode/electrode-d0jr-dyky-y31a-3gcr.json
+++ b/examples/electrode/electrode-d0jr-dyky-y31a-3gcr.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "electrode": {
     "id": "https://w3id.org/battinfo/electrode/d0jr-dyky-y31a-3gcr",
-    "electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/t947-yem5-73n7-beb7",
+    "electrode_spec_id": "https://w3id.org/battinfo/spec/t947-yem5-73n7-beb7",
     "short_id": "d0jrdy",
     "property": {
       "diameter": {

--- a/examples/electrode/electrode-svnh-5a39-fjrz-em1a.json
+++ b/examples/electrode/electrode-svnh-5a39-fjrz-em1a.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "electrode": {
     "id": "https://w3id.org/battinfo/electrode/svnh-5a39-fjrz-em1a",
-    "electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
+    "electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
     "short_id": "svnh5a",
     "property": {
       "diameter": {

--- a/examples/electrolyte-spec/electrolyte-spec-gpkh-74nj-6sdb-vcsc.json
+++ b/examples/electrolyte-spec/electrolyte-spec-gpkh-74nj-6sdb-vcsc.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "0.1.0",
   "electrolyte_spec": {
-    "id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
+    "id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
     "short_id": "gpkh74",
     "name": "1M LiPF6 in EC:EMC 3:7",
     "family": "organic",
     "salt": {
       "name": "LiPF6",
-      "material_spec_id": "https://w3id.org/battinfo/material-spec/fpeg-3wg8-e6cs-2vn1",
+      "material_spec_id": "https://w3id.org/battinfo/spec/fpeg-3wg8-e6cs-2vn1",
       "cation": "Li+",
       "anion": "PF6-",
       "property": {
@@ -21,7 +21,7 @@
       "component": [
         {
           "name": "EC",
-          "material_spec_id": "https://w3id.org/battinfo/material-spec/efxx-b9yg-wh00-d23a",
+          "material_spec_id": "https://w3id.org/battinfo/spec/efxx-b9yg-wh00-d23a",
           "property": {
             "volume_fraction": {
               "value": 0.3,
@@ -31,7 +31,7 @@
         },
         {
           "name": "EMC",
-          "material_spec_id": "https://w3id.org/battinfo/material-spec/hy9g-22sd-czdb-nmm4",
+          "material_spec_id": "https://w3id.org/battinfo/spec/hy9g-22sd-czdb-nmm4",
           "property": {
             "volume_fraction": {
               "value": 0.7,

--- a/examples/electrolyte-spec/electrolyte-spec-gzt2-hrqq-gsfn-sp94.json
+++ b/examples/electrolyte-spec/electrolyte-spec-gzt2-hrqq-gsfn-sp94.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "0.1.0",
   "electrolyte_spec": {
-    "id": "https://w3id.org/battinfo/electrolyte-spec/gzt2-hrqq-gsfn-sp94",
+    "id": "https://w3id.org/battinfo/spec/gzt2-hrqq-gsfn-sp94",
     "short_id": "gzt2hr",
     "name": "7M KOH in H2O",
     "family": "aqueous",
     "salt": {
       "name": "KOH",
-      "material_spec_id": "https://w3id.org/battinfo/material-spec/s9h8-dfbw-zs4k-2qk8",
+      "material_spec_id": "https://w3id.org/battinfo/spec/s9h8-dfbw-zs4k-2qk8",
       "cation": "K+",
       "anion": "OH-",
       "property": {

--- a/examples/electrolyte/electrolyte-mk4y-6azc-r6j5-h0dg.json
+++ b/examples/electrolyte/electrolyte-mk4y-6azc-r6j5-h0dg.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "electrolyte": {
     "id": "https://w3id.org/battinfo/electrolyte/mk4y-6azc-r6j5-h0dg",
-    "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
+    "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
     "short_id": "mk4y6a",
     "property": {
       "conductivity": {

--- a/examples/housing-spec/housing-spec-38af-bpnv-1zmm-32hs.json
+++ b/examples/housing-spec/housing-spec-38af-bpnv-1zmm-32hs.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "housing_spec": {
-    "id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+    "id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
     "short_id": "38afbp",
     "name": "CR2032 coin housing",
     "cell_format": "coin",

--- a/examples/housing-spec/housing-spec-ypyh-v38v-r276-snmk.json
+++ b/examples/housing-spec/housing-spec-ypyh-v38v-r276-snmk.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "housing_spec": {
-    "id": "https://w3id.org/battinfo/housing-spec/ypyh-v38v-r276-snmk",
+    "id": "https://w3id.org/battinfo/spec/ypyh-v38v-r276-snmk",
     "short_id": "ypyhv3",
     "name": "LFP 100Ah prismatic housing",
     "cell_format": "prismatic",

--- a/examples/housing/housing-kdc9-hph3-2a7j-hfrd.json
+++ b/examples/housing/housing-kdc9-hph3-2a7j-hfrd.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "housing": {
     "id": "https://w3id.org/battinfo/housing/kdc9-hph3-2a7j-hfrd",
-    "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+    "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
     "short_id": "kdc9hp",
     "lot_id": "CR2032-LOT-001"
   },

--- a/examples/material-spec/material-spec-5ms1-9jv8-hr54-mn4e.json
+++ b/examples/material-spec/material-spec-5ms1-9jv8-hr54-mn4e.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/5ms1-9jv8-hr54-mn4e",
+    "id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
     "short_id": "5ms19j",
     "name": "LFP",
     "material_class": "active_material",

--- a/examples/material-spec/material-spec-83bd-jmk7-2x47-s04a.json
+++ b/examples/material-spec/material-spec-83bd-jmk7-2x47-s04a.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/83bd-jmk7-2x47-s04a",
+    "id": "https://w3id.org/battinfo/spec/83bd-jmk7-2x47-s04a",
     "short_id": "83bdjm",
     "name": "LNMO",
     "material_class": "active_material",

--- a/examples/material-spec/material-spec-8y74-2v75-76kr-t9by.json
+++ b/examples/material-spec/material-spec-8y74-2v75-76kr-t9by.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/8y74-2v75-76kr-t9by",
+    "id": "https://w3id.org/battinfo/spec/8y74-2v75-76kr-t9by",
     "short_id": "8y742v",
     "name": "Al2O3-coated NMC811",
     "material_class": "active_material",
@@ -14,10 +14,10 @@
       "id": "https://w3id.org/battinfo/organization/9rfa-w6b3-dv1x-vj4z"
     },
     "composition": {
-      "base_material_id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+      "base_material_id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
       "coatings": [
         {
-          "material_spec_id": "https://w3id.org/battinfo/material-spec/k0dr-c32c-yrvy-bbfr",
+          "material_spec_id": "https://w3id.org/battinfo/spec/k0dr-c32c-yrvy-bbfr",
           "name": "Al2O3",
           "property": {
             "thickness": {

--- a/examples/material-spec/material-spec-bkrw-7shb-tzbm-j664.json
+++ b/examples/material-spec/material-spec-bkrw-7shb-tzbm-j664.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+    "id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
     "short_id": "bkrw7s",
     "name": "PVDF",
     "material_class": "binder",

--- a/examples/material-spec/material-spec-efxx-b9yg-wh00-d23a.json
+++ b/examples/material-spec/material-spec-efxx-b9yg-wh00-d23a.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/efxx-b9yg-wh00-d23a",
+    "id": "https://w3id.org/battinfo/spec/efxx-b9yg-wh00-d23a",
     "short_id": "efxxb9",
     "name": "EC",
     "material_class": "electrolyte_solvent",

--- a/examples/material-spec/material-spec-fpeg-3wg8-e6cs-2vn1.json
+++ b/examples/material-spec/material-spec-fpeg-3wg8-e6cs-2vn1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/fpeg-3wg8-e6cs-2vn1",
+    "id": "https://w3id.org/battinfo/spec/fpeg-3wg8-e6cs-2vn1",
     "short_id": "fpeg3w",
     "name": "LiPF6",
     "material_class": "electrolyte_salt",

--- a/examples/material-spec/material-spec-fwnh-2wkq-n9wm-fdab.json
+++ b/examples/material-spec/material-spec-fwnh-2wkq-n9wm-fdab.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/fwnh-2wkq-n9wm-fdab",
+    "id": "https://w3id.org/battinfo/spec/fwnh-2wkq-n9wm-fdab",
     "short_id": "fwnh2w",
     "name": "MnO2",
     "material_class": "active_material",

--- a/examples/material-spec/material-spec-gwck-k5kf-ae1f-gfgc.json
+++ b/examples/material-spec/material-spec-gwck-k5kf-ae1f-gfgc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/gwck-k5kf-ae1f-gfgc",
+    "id": "https://w3id.org/battinfo/spec/gwck-k5kf-ae1f-gfgc",
     "short_id": "gwckk5",
     "name": "Graphite",
     "material_class": "active_material",

--- a/examples/material-spec/material-spec-hy9g-22sd-czdb-nmm4.json
+++ b/examples/material-spec/material-spec-hy9g-22sd-czdb-nmm4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/hy9g-22sd-czdb-nmm4",
+    "id": "https://w3id.org/battinfo/spec/hy9g-22sd-czdb-nmm4",
     "short_id": "hy9g22",
     "name": "EMC",
     "material_class": "electrolyte_solvent",

--- a/examples/material-spec/material-spec-k0dr-c32c-yrvy-bbfr.json
+++ b/examples/material-spec/material-spec-k0dr-c32c-yrvy-bbfr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/k0dr-c32c-yrvy-bbfr",
+    "id": "https://w3id.org/battinfo/spec/k0dr-c32c-yrvy-bbfr",
     "short_id": "k0drc3",
     "name": "Alumina",
     "material_class": "coating",

--- a/examples/material-spec/material-spec-kg0e-vqce-3439-bnfk.json
+++ b/examples/material-spec/material-spec-kg0e-vqce-3439-bnfk.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/kg0e-vqce-3439-bnfk",
+    "id": "https://w3id.org/battinfo/spec/kg0e-vqce-3439-bnfk",
     "short_id": "kg0evq",
     "name": "Zinc",
     "material_class": "metal_electrode",

--- a/examples/material-spec/material-spec-npa4-0dnw-evyh-hhdm.json
+++ b/examples/material-spec/material-spec-npa4-0dnw-evyh-hhdm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+    "id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
     "short_id": "npa40d",
     "name": "NMC811",
     "material_class": "active_material",

--- a/examples/material-spec/material-spec-qwae-x6cg-c61k-njw7.json
+++ b/examples/material-spec/material-spec-qwae-x6cg-c61k-njw7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/qwae-x6cg-c61k-njw7",
+    "id": "https://w3id.org/battinfo/spec/qwae-x6cg-c61k-njw7",
     "short_id": "qwaex6",
     "name": "LMFP",
     "material_class": "active_material",

--- a/examples/material-spec/material-spec-r5xt-4hrh-jm2k-yg4m.json
+++ b/examples/material-spec/material-spec-r5xt-4hrh-jm2k-yg4m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+    "id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
     "short_id": "r5xt4h",
     "name": "Carbon black",
     "material_class": "conductive_additive",

--- a/examples/material-spec/material-spec-s2m9-ksma-nb61-8tpa.json
+++ b/examples/material-spec/material-spec-s2m9-ksma-nb61-8tpa.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/s2m9-ksma-nb61-8tpa",
+    "id": "https://w3id.org/battinfo/spec/s2m9-ksma-nb61-8tpa",
     "short_id": "s2m9ks",
     "name": "NMC622",
     "material_class": "active_material",

--- a/examples/material-spec/material-spec-s9h8-dfbw-zs4k-2qk8.json
+++ b/examples/material-spec/material-spec-s9h8-dfbw-zs4k-2qk8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/s9h8-dfbw-zs4k-2qk8",
+    "id": "https://w3id.org/battinfo/spec/s9h8-dfbw-zs4k-2qk8",
     "short_id": "s9h8df",
     "name": "KOH",
     "material_class": "electrolyte_salt",

--- a/examples/material-spec/material-spec-shzh-t2jt-wwqv-k54m.json
+++ b/examples/material-spec/material-spec-shzh-t2jt-wwqv-k54m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/shzh-t2jt-wwqv-k54m",
+    "id": "https://w3id.org/battinfo/spec/shzh-t2jt-wwqv-k54m",
     "short_id": "shzht2",
     "name": "LCO",
     "material_class": "active_material",

--- a/examples/material/material-4azv-ppez-1aeg-14yv.json
+++ b/examples/material/material-4azv-ppez-1aeg-14yv.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "material": {
     "id": "https://w3id.org/battinfo/material/4azv-ppez-1aeg-14yv",
-    "material_spec_id": "https://w3id.org/battinfo/material-spec/5ms1-9jv8-hr54-mn4e",
+    "material_spec_id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
     "short_id": "4azvpp",
     "lot_id": "CANRUD-LFP-2026-03",
     "supplier": {

--- a/examples/material/material-syzh-8sbd-ygb1-kfgg.json
+++ b/examples/material/material-syzh-8sbd-ygb1-kfgg.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "material": {
     "id": "https://w3id.org/battinfo/material/syzh-8sbd-ygb1-kfgg",
-    "material_spec_id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+    "material_spec_id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
     "short_id": "syzh8s",
     "lot_id": "CANRUD-NMC811-2026-04",
     "supplier": {

--- a/examples/separator-spec/separator-spec-v94j-jm2h-t8d1-t5a6.json
+++ b/examples/separator-spec/separator-spec-v94j-jm2h-t8d1-t5a6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "separator_spec": {
-    "id": "https://w3id.org/battinfo/separator-spec/v94j-jm2h-t8d1-t5a6",
+    "id": "https://w3id.org/battinfo/spec/v94j-jm2h-t8d1-t5a6",
     "short_id": "v94jjm",
     "name": "Ceramic-coated PE",
     "material": "polyethylene",

--- a/examples/separator-spec/separator-spec-wgym-4xfa-pws1-ek1b.json
+++ b/examples/separator-spec/separator-spec-wgym-4xfa-pws1-ek1b.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "separator_spec": {
-    "id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
+    "id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
     "short_id": "wgym4x",
     "name": "Celgard 2400",
     "material": "polypropylene",

--- a/examples/separator/separator-q4th-js57-e60p-ws1e.json
+++ b/examples/separator/separator-q4th-js57-e60p-ws1e.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "separator": {
     "id": "https://w3id.org/battinfo/separator/q4th-js57-e60p-ws1e",
-    "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
+    "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
     "short_id": "q4thjs",
     "property": {
       "diameter": {

--- a/examples/separator/separator-qvaq-v01t-axzz-a6sq.json
+++ b/examples/separator/separator-qvaq-v01t-axzz-a6sq.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "separator": {
     "id": "https://w3id.org/battinfo/separator/qvaq-v01t-axzz-a6sq",
-    "separator_spec_id": "https://w3id.org/battinfo/separator-spec/v94j-jm2h-t8d1-t5a6",
+    "separator_spec_id": "https://w3id.org/battinfo/spec/v94j-jm2h-t8d1-t5a6",
     "short_id": "qvaqv0",
     "property": {
       "diameter": {

--- a/src/battinfo/api/_components.py
+++ b/src/battinfo/api/_components.py
@@ -32,6 +32,7 @@ from battinfo.api._shared import (
     _normalized_dashed_uid,
     _paginate,
     _resolved_retrieved_at,
+    _spec_iri_re,
     _str_eq,
     _to_unix_time,
     _validate_canonical_record,
@@ -117,14 +118,14 @@ def _org_value(value: str | dict[str, Any] | None) -> dict[str, Any] | None:
 def _record_from_material_spec(draft: MaterialSpecInput) -> dict[str, Any]:
     if draft.id is not None:
         if not MATERIAL_SPEC_IRI_RE.fullmatch(draft.id):
-            raise ValueError("material spec id must match https://w3id.org/battinfo/material-spec/{uid}.")
+            raise ValueError("material spec id must match https://w3id.org/battinfo/spec/{uid}.")
         if draft.uid is not None:
             _assert_id_matches_uid(draft.id, _normalized_dashed_uid(draft.uid))
         entity_id = draft.id
         _, dashed_uid = _iri_tail(entity_id)
     else:
         dashed_uid = _normalized_dashed_uid(draft.uid)
-        entity_id = f"https://w3id.org/battinfo/material-spec/{dashed_uid}"
+        entity_id = f"https://w3id.org/battinfo/spec/{dashed_uid}"
 
     spec: dict[str, Any] = {
         "id": entity_id,
@@ -173,7 +174,7 @@ def _record_from_material_spec(draft: MaterialSpecInput) -> dict[str, Any]:
 
 def _record_from_material(draft: MaterialInput) -> dict[str, Any]:
     if not MATERIAL_SPEC_IRI_RE.fullmatch(draft.material_spec_id):
-        raise ValueError("material_spec_id must match https://w3id.org/battinfo/material-spec/{uid}.")
+        raise ValueError("material_spec_id must match https://w3id.org/battinfo/spec/{uid}.")
     if draft.id is not None:
         if not MATERIAL_IRI_RE.fullmatch(draft.id):
             raise ValueError("material id must match https://w3id.org/battinfo/material/{uid}.")
@@ -239,7 +240,7 @@ def template_material_spec(*, name: str = "Example Material", uid: str | None = 
 
 def template_material(
     *,
-    material_spec_id: str = "https://w3id.org/battinfo/material-spec/0000-0000-0000-0000",
+    material_spec_id: str = "https://w3id.org/battinfo/spec/0000-0000-0000-0000",
     uid: str | None = TEMPLATE_UID,
 ) -> dict[str, Any]:
     """Build a starter canonical material (instance) document for save workflows."""
@@ -475,17 +476,19 @@ def _record_from_component_spec(
     notes: list[str] | None = None,
     **extra: Any,
 ) -> dict[str, Any]:
-    namespace = f"{family.replace('_', '-')}-spec"
+    legacy_namespace = f"{family.replace('_', '-')}-spec"
     if id is not None:
-        if not _component_iri_re(namespace).fullmatch(id):
-            raise ValueError(f"{namespace} id must match https://w3id.org/battinfo/{namespace}/{{uid}}.")
+        # Canonical spec/ form; the superseded per-family form is accepted so
+        # pre-consolidation records keep their identity (never break an IRI).
+        if not _spec_iri_re(legacy_namespace).fullmatch(id):
+            raise ValueError(f"{legacy_namespace} id must match https://w3id.org/battinfo/spec/{{uid}}.")
         if uid is not None:
             _assert_id_matches_uid(id, _normalized_dashed_uid(uid))
         entity_id = id
         _, dashed_uid = _iri_tail(entity_id)
     else:
         dashed_uid = _normalized_dashed_uid(uid)
-        entity_id = f"https://w3id.org/battinfo/{namespace}/{dashed_uid}"
+        entity_id = f"https://w3id.org/battinfo/spec/{dashed_uid}"
 
     spec: dict[str, Any] = {"id": entity_id, "short_id": dashed_uid.replace("-", "")[:6], "name": name}
     spec.update(body or {})
@@ -531,8 +534,8 @@ def _record_from_component_instance(
 ) -> dict[str, Any]:
     base_namespace = family.replace("_", "-")
     spec_namespace = f"{base_namespace}-spec"
-    if not _component_iri_re(spec_namespace).fullmatch(spec_id):
-        raise ValueError(f"{family}_spec_id must match https://w3id.org/battinfo/{spec_namespace}/{{uid}}.")
+    if not _spec_iri_re(spec_namespace).fullmatch(spec_id):
+        raise ValueError(f"{family}_spec_id must match https://w3id.org/battinfo/spec/{{uid}}.")
     if id is not None:
         if not _component_iri_re(base_namespace).fullmatch(id):
             raise ValueError(f"{family} id must match https://w3id.org/battinfo/{base_namespace}/{{uid}}.")
@@ -726,7 +729,7 @@ def template_component_instance(
 ) -> dict[str, Any]:
     """Build a starter component (instance) document for a family."""
     return _record_from_component_instance(
-        family, spec_id=spec_id or f"https://w3id.org/battinfo/{family}-spec/0000-0000-0000-0000", uid=uid,
+        family, spec_id=spec_id or "https://w3id.org/battinfo/spec/0000-0000-0000-0000", uid=uid,
         notes=[f"Template-generated {family} instance. Set {family}_spec_id before saving."],
     )
 

--- a/src/battinfo/api/_records.py
+++ b/src/battinfo/api/_records.py
@@ -40,7 +40,6 @@ from battinfo.api._shared import (
     TEST_IRI_RE,
     TEST_PROTOCOL_IRI_RE,
     PathLike,
-    _component_iri_re,
     _entity_id,
     _in_range,
     _iri_tail,
@@ -52,6 +51,7 @@ from battinfo.api._shared import (
     _resolved_retrieved_at,
     _resolved_time,
     _short_id_from_iri,
+    _spec_iri_re,
     _spec_numeric_value,
     _str_contains,
     _str_eq,
@@ -947,11 +947,13 @@ _COMPONENT_SPEC_REF_NAMESPACES = {
 
 
 def _record_from_cell_spec(spec: CellSpec) -> dict[str, Any]:
-    # Validate component-spec reference IRIs at the input boundary.
+    # Validate component-spec reference IRIs at the input boundary. Canonical
+    # form is spec/ (IDENTIFIER_POLICY 6.1); the superseded per-family form is
+    # accepted so pre-consolidation references keep loading.
     for field_name, namespace in _COMPONENT_SPEC_REF_NAMESPACES.items():
         value = getattr(spec, field_name)
-        if value is not None and not _component_iri_re(namespace).fullmatch(value):
-            raise ValueError(f"{field_name} must match https://w3id.org/battinfo/{namespace}/{{uid}}.")
+        if value is not None and not _spec_iri_re(namespace).fullmatch(value):
+            raise ValueError(f"{field_name} must match https://w3id.org/battinfo/spec/{{uid}}.")
     # Mint / validate the canonical IRI — the one piece of canonicalization the model does not do.
     return _mint_cell_spec_record(spec)
 

--- a/src/battinfo/api/_shared.py
+++ b/src/battinfo/api/_shared.py
@@ -50,8 +50,10 @@ DATASET_IRI_RE = re.compile(
 TEST_IRI_RE = re.compile(
     r"^https://w3id\.org/battinfo/test/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
 )
+# spec/ is canonical; the superseded material-spec/ form stays accepted as
+# input so pre-consolidation records keep loading (IDENTIFIER_POLICY 6.1).
 MATERIAL_SPEC_IRI_RE = re.compile(
-    r"^https://w3id\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+    r"^https://w3id\.org/battinfo/(?:spec|material-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
 )
 MATERIAL_IRI_RE = re.compile(
     r"^https://w3id\.org/battinfo/material/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
@@ -385,3 +387,12 @@ _UID_TAIL = r"[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}"
 
 def _component_iri_re(namespace: str) -> re.Pattern[str]:
     return re.compile(rf"^https://w3id\.org/battinfo/{re.escape(namespace)}/{_UID_TAIL}$")
+
+
+def _spec_iri_re(family_namespace: str) -> re.Pattern[str]:
+    """Spec IRIs mint under the shared spec/ namespace (IDENTIFIER_POLICY 6.1);
+    the superseded per-family '{family}-spec/' form stays accepted as input so
+    records minted before the consolidation keep loading (never break an IRI)."""
+    return re.compile(
+        rf"^https://w3id\.org/battinfo/(?:spec|{re.escape(family_namespace)})/{_UID_TAIL}$"
+    )

--- a/src/battinfo/data/examples/cell-spec/cell-spec-0hpw-gkhk-gcg8-23x1.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-0hpw-gkhk-gcg8-23x1.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/f75a-tq2f-4tey-nba7",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/f75a-tq2f-4tey-nba7",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery NMC622-Graphite coin cell."
   ]

--- a/src/battinfo/data/examples/cell-spec/cell-spec-77tx-95x5-8tvd-n33a.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-77tx-95x5-8tvd-n33a.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/a86t-cxgj-c8h4-2y7b",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/a86t-cxgj-c8h4-2y7b",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery LFP-Graphite coin cell."
   ]

--- a/src/battinfo/data/examples/cell-spec/cell-spec-86k6-6tzd-c4sf-5s01.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-86k6-6tzd-c4sf-5s01.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/a86t-cxgj-c8h4-2y7b",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/ypyh-v38v-r276-snmk",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/a86t-cxgj-c8h4-2y7b",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/ypyh-v38v-r276-snmk",
   "notes": [
     "LFP 100 Ah prismatic engineering cell (Cell_Design_Tool)."
   ]

--- a/src/battinfo/data/examples/cell-spec/cell-spec-944g-byr3-afdy-vha5.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-944g-byr3-afdy-vha5.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/kewv-75y9-kqz5-8ty6",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/kewv-75y9-kqz5-8ty6",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery LMFP-Graphite coin cell."
   ]

--- a/src/battinfo/data/examples/cell-spec/cell-spec-jgyy-x3h5-drmv-5tn5.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-jgyy-x3h5-drmv-5tn5.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/8pdh-vrd3-tjar-8mgq",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/znwy-gmhg-34rb-qs1j",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gzt2-hrqq-gsfn-sp94",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/8pdh-vrd3-tjar-8mgq",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/znwy-gmhg-34rb-qs1j",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gzt2-hrqq-gsfn-sp94",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Non-Li-ion alkaline Zn-MnO2 coin cell (7M KOH)."
   ]

--- a/src/battinfo/data/examples/cell-spec/cell-spec-st13-tf1d-z9b3-k1hf.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-st13-tf1d-z9b3-k1hf.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/3e43-kbz8-ptjn-szs9",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/3e43-kbz8-ptjn-szs9",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery LCO-Graphite coin cell."
   ]

--- a/src/battinfo/data/examples/cell-spec/cell-spec-tme2-0sy6-q89b-8m92.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-tme2-0sy6-q89b-8m92.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772766
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/t947-yem5-73n7-beb7",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/t947-yem5-73n7-beb7",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "Discovery NMC811-Graphite coin cell."
   ]

--- a/src/battinfo/data/examples/cell-spec/cell-spec-venv-ff8p-nbk3-bxcn.json
+++ b/src/battinfo/data/examples/cell-spec/cell-spec-venv-ff8p-nbk3-bxcn.json
@@ -32,11 +32,11 @@
     "source_url": null,
     "retrieved_at": 1781772767
   },
-  "positive_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/ck8b-r1dz-h8my-3k05",
-  "negative_electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
-  "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
-  "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
-  "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+  "positive_electrode_spec_id": "https://w3id.org/battinfo/spec/ck8b-r1dz-h8my-3k05",
+  "negative_electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
+  "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
+  "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
+  "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
   "notes": [
     "High-voltage LNMO-Graphite coin cell."
   ]

--- a/src/battinfo/data/examples/current-collector-spec/current-collector-spec-vkaf-f5bv-fwt2-e6yz.json
+++ b/src/battinfo/data/examples/current-collector-spec/current-collector-spec-vkaf-f5bv-fwt2-e6yz.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "current_collector_spec": {
-    "id": "https://w3id.org/battinfo/current-collector-spec/vkaf-f5bv-fwt2-e6yz",
+    "id": "https://w3id.org/battinfo/spec/vkaf-f5bv-fwt2-e6yz",
     "short_id": "vkaff5",
     "name": "Aluminium foil",
     "property": {

--- a/src/battinfo/data/examples/current-collector-spec/current-collector-spec-z25y-gab5-hd3n-qfpr.json
+++ b/src/battinfo/data/examples/current-collector-spec/current-collector-spec-z25y-gab5-hd3n-qfpr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "current_collector_spec": {
-    "id": "https://w3id.org/battinfo/current-collector-spec/z25y-gab5-hd3n-qfpr",
+    "id": "https://w3id.org/battinfo/spec/z25y-gab5-hd3n-qfpr",
     "short_id": "z25yga",
     "name": "Copper foil",
     "property": {

--- a/src/battinfo/data/examples/current-collector/current-collector-dwnd-tyk8-be76-1a3j.json
+++ b/src/battinfo/data/examples/current-collector/current-collector-dwnd-tyk8-be76-1a3j.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "current_collector": {
     "id": "https://w3id.org/battinfo/current-collector/dwnd-tyk8-be76-1a3j",
-    "current_collector_spec_id": "https://w3id.org/battinfo/current-collector-spec/vkaf-f5bv-fwt2-e6yz",
+    "current_collector_spec_id": "https://w3id.org/battinfo/spec/vkaf-f5bv-fwt2-e6yz",
     "short_id": "dwndty",
     "property": {
       "thickness": {

--- a/src/battinfo/data/examples/current-collector/current-collector-e7bq-z754-er6f-e561.json
+++ b/src/battinfo/data/examples/current-collector/current-collector-e7bq-z754-er6f-e561.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "current_collector": {
     "id": "https://w3id.org/battinfo/current-collector/e7bq-z754-er6f-e561",
-    "current_collector_spec_id": "https://w3id.org/battinfo/current-collector-spec/z25y-gab5-hd3n-qfpr",
+    "current_collector_spec_id": "https://w3id.org/battinfo/spec/z25y-gab5-hd3n-qfpr",
     "short_id": "e7bqz7",
     "property": {
       "thickness": {

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-3e43-kbz8-ptjn-szs9.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-3e43-kbz8-ptjn-szs9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/3e43-kbz8-ptjn-szs9",
+    "id": "https://w3id.org/battinfo/spec/3e43-kbz8-ptjn-szs9",
     "short_id": "3e43kb",
     "name": "LCO cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LCO",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/shzh-t2jt-wwqv-k54m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/shzh-t2jt-wwqv-k54m",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-8pdh-vrd3-tjar-8mgq.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-8pdh-vrd3-tjar-8mgq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/8pdh-vrd3-tjar-8mgq",
+    "id": "https://w3id.org/battinfo/spec/8pdh-vrd3-tjar-8mgq",
     "short_id": "8pdhvr",
     "name": "MnO2 cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "MnO2",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/fwnh-2wkq-n9wm-fdab",
+            "material_spec_id": "https://w3id.org/battinfo/spec/fwnh-2wkq-n9wm-fdab",
             "property": {
               "mass_fraction": {
                 "value": 0.9,
@@ -21,7 +21,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.1,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-a86t-cxgj-c8h4-2y7b.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-a86t-cxgj-c8h4-2y7b.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/a86t-cxgj-c8h4-2y7b",
+    "id": "https://w3id.org/battinfo/spec/a86t-cxgj-c8h4-2y7b",
     "short_id": "a86tcx",
     "name": "LFP cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LFP",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/5ms1-9jv8-hr54-mn4e",
+            "material_spec_id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-ck8b-r1dz-h8my-3k05.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-ck8b-r1dz-h8my-3k05.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/ck8b-r1dz-h8my-3k05",
+    "id": "https://w3id.org/battinfo/spec/ck8b-r1dz-h8my-3k05",
     "short_id": "ck8br1",
     "name": "LNMO cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LNMO",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/83bd-jmk7-2x47-s04a",
+            "material_spec_id": "https://w3id.org/battinfo/spec/83bd-jmk7-2x47-s04a",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-f75a-tq2f-4tey-nba7.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-f75a-tq2f-4tey-nba7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/f75a-tq2f-4tey-nba7",
+    "id": "https://w3id.org/battinfo/spec/f75a-tq2f-4tey-nba7",
     "short_id": "f75atq",
     "name": "NMC622 cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "NMC622",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/s2m9-ksma-nb61-8tpa",
+            "material_spec_id": "https://w3id.org/battinfo/spec/s2m9-ksma-nb61-8tpa",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-fvwx-7fq1-wwfs-fn3g.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-fvwx-7fq1-wwfs-fn3g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
+    "id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
     "short_id": "fvwx7f",
     "name": "Graphite anode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "Graphite",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/gwck-k5kf-ae1f-gfgc",
+            "material_spec_id": "https://w3id.org/battinfo/spec/gwck-k5kf-ae1f-gfgc",
             "property": {
               "mass_fraction": {
                 "value": 0.95,
@@ -32,7 +32,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.01,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-kewv-75y9-kqz5-8ty6.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-kewv-75y9-kqz5-8ty6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/kewv-75y9-kqz5-8ty6",
+    "id": "https://w3id.org/battinfo/spec/kewv-75y9-kqz5-8ty6",
     "short_id": "kewv75",
     "name": "LMFP cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "LMFP",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/qwae-x6cg-c61k-njw7",
+            "material_spec_id": "https://w3id.org/battinfo/spec/qwae-x6cg-c61k-njw7",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-t947-yem5-73n7-beb7.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-t947-yem5-73n7-beb7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/t947-yem5-73n7-beb7",
+    "id": "https://w3id.org/battinfo/spec/t947-yem5-73n7-beb7",
     "short_id": "t947ye",
     "name": "NMC811 cathode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "NMC811",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+            "material_spec_id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
             "property": {
               "mass_fraction": {
                 "value": 0.96,
@@ -21,7 +21,7 @@
         "binder": [
           {
             "name": "PVDF",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+            "material_spec_id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
             "property": {
               "mass_fraction": {
                 "value": 0.02,
@@ -33,7 +33,7 @@
         "additive": [
           {
             "name": "Carbon black",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+            "material_spec_id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
             "property": {
               "mass_fraction": {
                 "value": 0.02,

--- a/src/battinfo/data/examples/electrode-spec/electrode-spec-znwy-gmhg-34rb-qs1j.json
+++ b/src/battinfo/data/examples/electrode-spec/electrode-spec-znwy-gmhg-34rb-qs1j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "electrode_spec": {
-    "id": "https://w3id.org/battinfo/electrode-spec/znwy-gmhg-34rb-qs1j",
+    "id": "https://w3id.org/battinfo/spec/znwy-gmhg-34rb-qs1j",
     "short_id": "znwygm",
     "name": "Zn anode",
     "coating": {
@@ -9,7 +9,7 @@
         "active_material": [
           {
             "name": "Zinc",
-            "material_spec_id": "https://w3id.org/battinfo/material-spec/kg0e-vqce-3439-bnfk",
+            "material_spec_id": "https://w3id.org/battinfo/spec/kg0e-vqce-3439-bnfk",
             "property": {
               "mass_fraction": {
                 "value": 0.95,

--- a/src/battinfo/data/examples/electrode/electrode-d0jr-dyky-y31a-3gcr.json
+++ b/src/battinfo/data/examples/electrode/electrode-d0jr-dyky-y31a-3gcr.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "electrode": {
     "id": "https://w3id.org/battinfo/electrode/d0jr-dyky-y31a-3gcr",
-    "electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/t947-yem5-73n7-beb7",
+    "electrode_spec_id": "https://w3id.org/battinfo/spec/t947-yem5-73n7-beb7",
     "short_id": "d0jrdy",
     "property": {
       "diameter": {

--- a/src/battinfo/data/examples/electrode/electrode-svnh-5a39-fjrz-em1a.json
+++ b/src/battinfo/data/examples/electrode/electrode-svnh-5a39-fjrz-em1a.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "electrode": {
     "id": "https://w3id.org/battinfo/electrode/svnh-5a39-fjrz-em1a",
-    "electrode_spec_id": "https://w3id.org/battinfo/electrode-spec/fvwx-7fq1-wwfs-fn3g",
+    "electrode_spec_id": "https://w3id.org/battinfo/spec/fvwx-7fq1-wwfs-fn3g",
     "short_id": "svnh5a",
     "property": {
       "diameter": {

--- a/src/battinfo/data/examples/electrolyte-spec/electrolyte-spec-gpkh-74nj-6sdb-vcsc.json
+++ b/src/battinfo/data/examples/electrolyte-spec/electrolyte-spec-gpkh-74nj-6sdb-vcsc.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "0.1.0",
   "electrolyte_spec": {
-    "id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
+    "id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
     "short_id": "gpkh74",
     "name": "1M LiPF6 in EC:EMC 3:7",
     "family": "organic",
     "salt": {
       "name": "LiPF6",
-      "material_spec_id": "https://w3id.org/battinfo/material-spec/fpeg-3wg8-e6cs-2vn1",
+      "material_spec_id": "https://w3id.org/battinfo/spec/fpeg-3wg8-e6cs-2vn1",
       "cation": "Li+",
       "anion": "PF6-",
       "property": {
@@ -21,7 +21,7 @@
       "component": [
         {
           "name": "EC",
-          "material_spec_id": "https://w3id.org/battinfo/material-spec/efxx-b9yg-wh00-d23a",
+          "material_spec_id": "https://w3id.org/battinfo/spec/efxx-b9yg-wh00-d23a",
           "property": {
             "volume_fraction": {
               "value": 0.3,
@@ -31,7 +31,7 @@
         },
         {
           "name": "EMC",
-          "material_spec_id": "https://w3id.org/battinfo/material-spec/hy9g-22sd-czdb-nmm4",
+          "material_spec_id": "https://w3id.org/battinfo/spec/hy9g-22sd-czdb-nmm4",
           "property": {
             "volume_fraction": {
               "value": 0.7,

--- a/src/battinfo/data/examples/electrolyte-spec/electrolyte-spec-gzt2-hrqq-gsfn-sp94.json
+++ b/src/battinfo/data/examples/electrolyte-spec/electrolyte-spec-gzt2-hrqq-gsfn-sp94.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "0.1.0",
   "electrolyte_spec": {
-    "id": "https://w3id.org/battinfo/electrolyte-spec/gzt2-hrqq-gsfn-sp94",
+    "id": "https://w3id.org/battinfo/spec/gzt2-hrqq-gsfn-sp94",
     "short_id": "gzt2hr",
     "name": "7M KOH in H2O",
     "family": "aqueous",
     "salt": {
       "name": "KOH",
-      "material_spec_id": "https://w3id.org/battinfo/material-spec/s9h8-dfbw-zs4k-2qk8",
+      "material_spec_id": "https://w3id.org/battinfo/spec/s9h8-dfbw-zs4k-2qk8",
       "cation": "K+",
       "anion": "OH-",
       "property": {

--- a/src/battinfo/data/examples/electrolyte/electrolyte-mk4y-6azc-r6j5-h0dg.json
+++ b/src/battinfo/data/examples/electrolyte/electrolyte-mk4y-6azc-r6j5-h0dg.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "electrolyte": {
     "id": "https://w3id.org/battinfo/electrolyte/mk4y-6azc-r6j5-h0dg",
-    "electrolyte_spec_id": "https://w3id.org/battinfo/electrolyte-spec/gpkh-74nj-6sdb-vcsc",
+    "electrolyte_spec_id": "https://w3id.org/battinfo/spec/gpkh-74nj-6sdb-vcsc",
     "short_id": "mk4y6a",
     "property": {
       "conductivity": {

--- a/src/battinfo/data/examples/housing-spec/housing-spec-38af-bpnv-1zmm-32hs.json
+++ b/src/battinfo/data/examples/housing-spec/housing-spec-38af-bpnv-1zmm-32hs.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "housing_spec": {
-    "id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+    "id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
     "short_id": "38afbp",
     "name": "CR2032 coin housing",
     "cell_format": "coin",

--- a/src/battinfo/data/examples/housing-spec/housing-spec-ypyh-v38v-r276-snmk.json
+++ b/src/battinfo/data/examples/housing-spec/housing-spec-ypyh-v38v-r276-snmk.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "housing_spec": {
-    "id": "https://w3id.org/battinfo/housing-spec/ypyh-v38v-r276-snmk",
+    "id": "https://w3id.org/battinfo/spec/ypyh-v38v-r276-snmk",
     "short_id": "ypyhv3",
     "name": "LFP 100Ah prismatic housing",
     "cell_format": "prismatic",

--- a/src/battinfo/data/examples/housing/housing-kdc9-hph3-2a7j-hfrd.json
+++ b/src/battinfo/data/examples/housing/housing-kdc9-hph3-2a7j-hfrd.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "housing": {
     "id": "https://w3id.org/battinfo/housing/kdc9-hph3-2a7j-hfrd",
-    "housing_spec_id": "https://w3id.org/battinfo/housing-spec/38af-bpnv-1zmm-32hs",
+    "housing_spec_id": "https://w3id.org/battinfo/spec/38af-bpnv-1zmm-32hs",
     "short_id": "kdc9hp",
     "lot_id": "CR2032-LOT-001"
   },

--- a/src/battinfo/data/examples/material-spec/material-spec-5ms1-9jv8-hr54-mn4e.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-5ms1-9jv8-hr54-mn4e.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/5ms1-9jv8-hr54-mn4e",
+    "id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
     "short_id": "5ms19j",
     "name": "LFP",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material-spec/material-spec-83bd-jmk7-2x47-s04a.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-83bd-jmk7-2x47-s04a.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/83bd-jmk7-2x47-s04a",
+    "id": "https://w3id.org/battinfo/spec/83bd-jmk7-2x47-s04a",
     "short_id": "83bdjm",
     "name": "LNMO",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material-spec/material-spec-8y74-2v75-76kr-t9by.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-8y74-2v75-76kr-t9by.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/8y74-2v75-76kr-t9by",
+    "id": "https://w3id.org/battinfo/spec/8y74-2v75-76kr-t9by",
     "short_id": "8y742v",
     "name": "Al2O3-coated NMC811",
     "material_class": "active_material",
@@ -14,10 +14,10 @@
       "id": "https://w3id.org/battinfo/organization/9rfa-w6b3-dv1x-vj4z"
     },
     "composition": {
-      "base_material_id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+      "base_material_id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
       "coatings": [
         {
-          "material_spec_id": "https://w3id.org/battinfo/material-spec/k0dr-c32c-yrvy-bbfr",
+          "material_spec_id": "https://w3id.org/battinfo/spec/k0dr-c32c-yrvy-bbfr",
           "name": "Al2O3",
           "property": {
             "thickness": {

--- a/src/battinfo/data/examples/material-spec/material-spec-bkrw-7shb-tzbm-j664.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-bkrw-7shb-tzbm-j664.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/bkrw-7shb-tzbm-j664",
+    "id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
     "short_id": "bkrw7s",
     "name": "PVDF",
     "material_class": "binder",

--- a/src/battinfo/data/examples/material-spec/material-spec-efxx-b9yg-wh00-d23a.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-efxx-b9yg-wh00-d23a.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/efxx-b9yg-wh00-d23a",
+    "id": "https://w3id.org/battinfo/spec/efxx-b9yg-wh00-d23a",
     "short_id": "efxxb9",
     "name": "EC",
     "material_class": "electrolyte_solvent",

--- a/src/battinfo/data/examples/material-spec/material-spec-fpeg-3wg8-e6cs-2vn1.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-fpeg-3wg8-e6cs-2vn1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/fpeg-3wg8-e6cs-2vn1",
+    "id": "https://w3id.org/battinfo/spec/fpeg-3wg8-e6cs-2vn1",
     "short_id": "fpeg3w",
     "name": "LiPF6",
     "material_class": "electrolyte_salt",

--- a/src/battinfo/data/examples/material-spec/material-spec-fwnh-2wkq-n9wm-fdab.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-fwnh-2wkq-n9wm-fdab.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/fwnh-2wkq-n9wm-fdab",
+    "id": "https://w3id.org/battinfo/spec/fwnh-2wkq-n9wm-fdab",
     "short_id": "fwnh2w",
     "name": "MnO2",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material-spec/material-spec-gwck-k5kf-ae1f-gfgc.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-gwck-k5kf-ae1f-gfgc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/gwck-k5kf-ae1f-gfgc",
+    "id": "https://w3id.org/battinfo/spec/gwck-k5kf-ae1f-gfgc",
     "short_id": "gwckk5",
     "name": "Graphite",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material-spec/material-spec-hy9g-22sd-czdb-nmm4.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-hy9g-22sd-czdb-nmm4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/hy9g-22sd-czdb-nmm4",
+    "id": "https://w3id.org/battinfo/spec/hy9g-22sd-czdb-nmm4",
     "short_id": "hy9g22",
     "name": "EMC",
     "material_class": "electrolyte_solvent",

--- a/src/battinfo/data/examples/material-spec/material-spec-k0dr-c32c-yrvy-bbfr.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-k0dr-c32c-yrvy-bbfr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/k0dr-c32c-yrvy-bbfr",
+    "id": "https://w3id.org/battinfo/spec/k0dr-c32c-yrvy-bbfr",
     "short_id": "k0drc3",
     "name": "Alumina",
     "material_class": "coating",

--- a/src/battinfo/data/examples/material-spec/material-spec-kg0e-vqce-3439-bnfk.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-kg0e-vqce-3439-bnfk.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/kg0e-vqce-3439-bnfk",
+    "id": "https://w3id.org/battinfo/spec/kg0e-vqce-3439-bnfk",
     "short_id": "kg0evq",
     "name": "Zinc",
     "material_class": "metal_electrode",

--- a/src/battinfo/data/examples/material-spec/material-spec-npa4-0dnw-evyh-hhdm.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-npa4-0dnw-evyh-hhdm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+    "id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
     "short_id": "npa40d",
     "name": "NMC811",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material-spec/material-spec-qwae-x6cg-c61k-njw7.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-qwae-x6cg-c61k-njw7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/qwae-x6cg-c61k-njw7",
+    "id": "https://w3id.org/battinfo/spec/qwae-x6cg-c61k-njw7",
     "short_id": "qwaex6",
     "name": "LMFP",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material-spec/material-spec-r5xt-4hrh-jm2k-yg4m.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-r5xt-4hrh-jm2k-yg4m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/r5xt-4hrh-jm2k-yg4m",
+    "id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
     "short_id": "r5xt4h",
     "name": "Carbon black",
     "material_class": "conductive_additive",

--- a/src/battinfo/data/examples/material-spec/material-spec-s2m9-ksma-nb61-8tpa.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-s2m9-ksma-nb61-8tpa.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/s2m9-ksma-nb61-8tpa",
+    "id": "https://w3id.org/battinfo/spec/s2m9-ksma-nb61-8tpa",
     "short_id": "s2m9ks",
     "name": "NMC622",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material-spec/material-spec-s9h8-dfbw-zs4k-2qk8.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-s9h8-dfbw-zs4k-2qk8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/s9h8-dfbw-zs4k-2qk8",
+    "id": "https://w3id.org/battinfo/spec/s9h8-dfbw-zs4k-2qk8",
     "short_id": "s9h8df",
     "name": "KOH",
     "material_class": "electrolyte_salt",

--- a/src/battinfo/data/examples/material-spec/material-spec-shzh-t2jt-wwqv-k54m.json
+++ b/src/battinfo/data/examples/material-spec/material-spec-shzh-t2jt-wwqv-k54m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "material_spec": {
-    "id": "https://w3id.org/battinfo/material-spec/shzh-t2jt-wwqv-k54m",
+    "id": "https://w3id.org/battinfo/spec/shzh-t2jt-wwqv-k54m",
     "short_id": "shzht2",
     "name": "LCO",
     "material_class": "active_material",

--- a/src/battinfo/data/examples/material/material-4azv-ppez-1aeg-14yv.json
+++ b/src/battinfo/data/examples/material/material-4azv-ppez-1aeg-14yv.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "material": {
     "id": "https://w3id.org/battinfo/material/4azv-ppez-1aeg-14yv",
-    "material_spec_id": "https://w3id.org/battinfo/material-spec/5ms1-9jv8-hr54-mn4e",
+    "material_spec_id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
     "short_id": "4azvpp",
     "lot_id": "CANRUD-LFP-2026-03",
     "supplier": {

--- a/src/battinfo/data/examples/material/material-syzh-8sbd-ygb1-kfgg.json
+++ b/src/battinfo/data/examples/material/material-syzh-8sbd-ygb1-kfgg.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "material": {
     "id": "https://w3id.org/battinfo/material/syzh-8sbd-ygb1-kfgg",
-    "material_spec_id": "https://w3id.org/battinfo/material-spec/npa4-0dnw-evyh-hhdm",
+    "material_spec_id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
     "short_id": "syzh8s",
     "lot_id": "CANRUD-NMC811-2026-04",
     "supplier": {

--- a/src/battinfo/data/examples/separator-spec/separator-spec-v94j-jm2h-t8d1-t5a6.json
+++ b/src/battinfo/data/examples/separator-spec/separator-spec-v94j-jm2h-t8d1-t5a6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "separator_spec": {
-    "id": "https://w3id.org/battinfo/separator-spec/v94j-jm2h-t8d1-t5a6",
+    "id": "https://w3id.org/battinfo/spec/v94j-jm2h-t8d1-t5a6",
     "short_id": "v94jjm",
     "name": "Ceramic-coated PE",
     "material": "polyethylene",

--- a/src/battinfo/data/examples/separator-spec/separator-spec-wgym-4xfa-pws1-ek1b.json
+++ b/src/battinfo/data/examples/separator-spec/separator-spec-wgym-4xfa-pws1-ek1b.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1.0",
   "separator_spec": {
-    "id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
+    "id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
     "short_id": "wgym4x",
     "name": "Celgard 2400",
     "material": "polypropylene",

--- a/src/battinfo/data/examples/separator/separator-q4th-js57-e60p-ws1e.json
+++ b/src/battinfo/data/examples/separator/separator-q4th-js57-e60p-ws1e.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "separator": {
     "id": "https://w3id.org/battinfo/separator/q4th-js57-e60p-ws1e",
-    "separator_spec_id": "https://w3id.org/battinfo/separator-spec/wgym-4xfa-pws1-ek1b",
+    "separator_spec_id": "https://w3id.org/battinfo/spec/wgym-4xfa-pws1-ek1b",
     "short_id": "q4thjs",
     "property": {
       "diameter": {

--- a/src/battinfo/data/examples/separator/separator-qvaq-v01t-axzz-a6sq.json
+++ b/src/battinfo/data/examples/separator/separator-qvaq-v01t-axzz-a6sq.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "separator": {
     "id": "https://w3id.org/battinfo/separator/qvaq-v01t-axzz-a6sq",
-    "separator_spec_id": "https://w3id.org/battinfo/separator-spec/v94j-jm2h-t8d1-t5a6",
+    "separator_spec_id": "https://w3id.org/battinfo/spec/v94j-jm2h-t8d1-t5a6",
     "short_id": "qvaqv0",
     "property": {
       "diameter": {

--- a/src/battinfo/data/schemas/cell-canonical.schema.json
+++ b/src/battinfo/data/schemas/cell-canonical.schema.json
@@ -487,7 +487,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     }
   }
 }

--- a/src/battinfo/data/schemas/cell-instance.schema.json
+++ b/src/battinfo/data/schemas/cell-instance.schema.json
@@ -320,7 +320,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Funding": {
       "type": "object",

--- a/src/battinfo/data/schemas/cell-spec.schema.json
+++ b/src/battinfo/data/schemas/cell-spec.schema.json
@@ -573,7 +573,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "OrganizationIri": {
       "type": "string",
@@ -581,19 +581,19 @@
     },
     "ElectrodeSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ElectrolyteSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "SeparatorSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "HousingSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Funding": {
       "type": "object",

--- a/src/battinfo/data/schemas/current-collector-spec.schema.json
+++ b/src/battinfo/data/schemas/current-collector-spec.schema.json
@@ -35,7 +35,7 @@
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "property": {
           "$ref": "modules/common/quantitative-properties.schema.json"
@@ -67,7 +67,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/current-collector-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/current-collector.schema.json
+++ b/src/battinfo/data/schemas/current-collector.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/current-collector-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/electrode-spec.schema.json
+++ b/src/battinfo/data/schemas/electrode-spec.schema.json
@@ -82,7 +82,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/electrode.schema.json
+++ b/src/battinfo/data/schemas/electrode.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/electrolyte-spec.schema.json
+++ b/src/battinfo/data/schemas/electrolyte-spec.schema.json
@@ -76,7 +76,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/electrolyte.schema.json
+++ b/src/battinfo/data/schemas/electrolyte.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/housing-spec.schema.json
+++ b/src/battinfo/data/schemas/housing-spec.schema.json
@@ -98,7 +98,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/housing.schema.json
+++ b/src/battinfo/data/schemas/housing.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/material-spec.schema.json
+++ b/src/battinfo/data/schemas/material-spec.schema.json
@@ -185,7 +185,7 @@
     },
     "MaterialSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "OrganizationIri": {
       "type": "string",

--- a/src/battinfo/data/schemas/material.schema.json
+++ b/src/battinfo/data/schemas/material.schema.json
@@ -168,7 +168,7 @@
     },
     "MaterialSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "DatasetIri": {
       "type": "string",

--- a/src/battinfo/data/schemas/modules/components/current-collector.schema.json
+++ b/src/battinfo/data/schemas/modules/components/current-collector.schema.json
@@ -12,7 +12,7 @@
     },
     "material_spec_id": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
       "description": "Optional canonical IRI of a standalone material-spec for the current-collector foil material."
     },
     "manufacturer": {

--- a/src/battinfo/data/schemas/modules/components/electrolyte.schema.json
+++ b/src/battinfo/data/schemas/modules/components/electrolyte.schema.json
@@ -37,7 +37,7 @@
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
           "description": "Optional canonical IRI of a standalone material-spec for the salt."
         },
         "cation": {

--- a/src/battinfo/data/schemas/modules/components/material-component.schema.json
+++ b/src/battinfo/data/schemas/modules/components/material-component.schema.json
@@ -15,7 +15,7 @@
     },
     "material_spec_id": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
       "description": "Optional canonical IRI of a standalone material-spec record this embedded holder realizes. Lets a cell-spec dedup materials by reference instead of/in addition to inlining them."
     },
     "manufacturer": {

--- a/src/battinfo/data/schemas/modules/components/separator.schema.json
+++ b/src/battinfo/data/schemas/modules/components/separator.schema.json
@@ -20,7 +20,7 @@
     },
     "material_spec_id": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
       "description": "Optional canonical IRI of a standalone material-spec for the separator base material."
     },
     "structure": {

--- a/src/battinfo/data/schemas/separator-spec.schema.json
+++ b/src/battinfo/data/schemas/separator-spec.schema.json
@@ -52,7 +52,7 @@
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "property": {
           "$ref": "modules/common/quantitative-properties.schema.json"
@@ -84,7 +84,7 @@
   "$defs": {
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/separator.schema.json
+++ b/src/battinfo/data/schemas/separator.schema.json
@@ -79,7 +79,7 @@
     },
     "ComponentSpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "ShortId": {
       "type": "string",

--- a/src/battinfo/data/schemas/test-protocol.schema.json
+++ b/src/battinfo/data/schemas/test-protocol.schema.json
@@ -262,7 +262,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Quantity": {
       "type": "object",

--- a/src/battinfo/data/schemas/test.schema.json
+++ b/src/battinfo/data/schemas/test.schema.json
@@ -364,7 +364,7 @@
     },
     "SpecIri": {
       "type": "string",
-      "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+      "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
     },
     "Funding": {
       "type": "object",

--- a/src/battinfo/entities.py
+++ b/src/battinfo/entities.py
@@ -84,7 +84,7 @@ ENTITY_KINDS: tuple[EntityKind, ...] = (
     EntityKind("test-protocol", "test_spec", "test-protocol.schema.json", "test-protocol", "spec"),
     EntityKind("test", "test", "test.schema.json", "test", "test"),
     EntityKind("dataset", "dataset", "dataset.schema.json", "dataset", "dataset"),
-    EntityKind("material-spec", "material_spec", "material-spec.schema.json", "material-spec", "material-spec"),
+    EntityKind("material-spec", "material_spec", "material-spec.schema.json", "material-spec", "spec"),
     EntityKind(
         "material",
         "material",
@@ -94,7 +94,7 @@ ENTITY_KINDS: tuple[EntityKind, ...] = (
         spec_ref_field="material_spec_id",
         spec_entity_type="material-spec",
     ),
-    EntityKind("electrode-spec", "electrode_spec", "electrode-spec.schema.json", "electrode-spec", "electrode-spec"),
+    EntityKind("electrode-spec", "electrode_spec", "electrode-spec.schema.json", "electrode-spec", "spec"),
     EntityKind(
         "electrode",
         "electrode",
@@ -104,26 +104,26 @@ ENTITY_KINDS: tuple[EntityKind, ...] = (
         spec_ref_field="electrode_spec_id",
         spec_entity_type="electrode-spec",
     ),
-    EntityKind("separator-spec", "separator_spec", "separator-spec.schema.json", "separator-spec", "separator-spec"),
+    EntityKind("separator-spec", "separator_spec", "separator-spec.schema.json", "separator-spec", "spec"),
     EntityKind(
         "separator", "separator", "separator.schema.json", "separator", "separator",
         spec_ref_field="separator_spec_id", spec_entity_type="separator-spec",
     ),
     EntityKind(
         "current-collector-spec", "current_collector_spec", "current-collector-spec.schema.json",
-        "current-collector-spec", "current-collector-spec",
+        "current-collector-spec", "spec",
     ),
     EntityKind(
         "current-collector", "current_collector", "current-collector.schema.json",
         "current-collector", "current-collector",
         spec_ref_field="current_collector_spec_id", spec_entity_type="current-collector-spec",
     ),
-    EntityKind("electrolyte-spec", "electrolyte_spec", "electrolyte-spec.schema.json", "electrolyte-spec", "electrolyte-spec"),
+    EntityKind("electrolyte-spec", "electrolyte_spec", "electrolyte-spec.schema.json", "electrolyte-spec", "spec"),
     EntityKind(
         "electrolyte", "electrolyte", "electrolyte.schema.json", "electrolyte", "electrolyte",
         spec_ref_field="electrolyte_spec_id", spec_entity_type="electrolyte-spec",
     ),
-    EntityKind("housing-spec", "housing_spec", "housing-spec.schema.json", "housing-spec", "housing-spec"),
+    EntityKind("housing-spec", "housing_spec", "housing-spec.schema.json", "housing-spec", "spec"),
     EntityKind(
         "housing", "housing", "housing.schema.json", "housing", "housing",
         spec_ref_field="housing_spec_id", spec_entity_type="housing-spec",
@@ -162,6 +162,14 @@ def kind_for_type(entity_type: str) -> Optional[EntityKind]:
 def record_set_dirs() -> tuple[str, ...]:
     """On-disk subdirectory names for every registered record type."""
     return tuple(kind.subdir for kind in ENTITY_KINDS)
+
+
+RESERVED_NAMESPACE_SEGMENTS = frozenset(
+    {"id", "ontology", "vocab", "doc", "context", "resolver", "twin", "w3id"}
+)
+_reserved_clash = RESERVED_NAMESPACE_SEGMENTS & {k.iri_namespace for k in ENTITY_KINDS}
+if _reserved_clash:  # fail at import: a reserved segment can never become an entity namespace
+    raise RuntimeError(f"reserved namespace segment(s) used by ENTITY_KINDS: {sorted(_reserved_clash)}")
 
 
 def iri_namespace_map() -> dict[str, str]:

--- a/tests/test_cell_fleet.py
+++ b/tests/test_cell_fleet.py
@@ -66,7 +66,7 @@ def test_missing_component_reference_is_flagged(tmp_path):
     from battinfo import api
     rec = api._record_from_cell_spec(CellSpec(
         uid="cmiss123456789ab", model_name="X", manufacturer="Y", format="coin", chemistry="Li-ion",
-        electrolyte_spec_id="https://w3id.org/battinfo/electrolyte-spec/0000-0000-0000-0000"))
+        electrolyte_spec_id="https://w3id.org/battinfo/spec/0000-0000-0000-0000"))
     result = validate_record(rec, source_root=tmp_path)
     assert any(i.code == "reference.missing" for i in result.issues)
 

--- a/tests/test_cell_spec_input_routing.py
+++ b/tests/test_cell_spec_input_routing.py
@@ -20,14 +20,14 @@ def test_routed_builder_preserves_all_fields_and_validates() -> None:
         uid="1c4m-7p9q-2k6t-8v3r", model_name="CR2032",
         manufacturer={"name": "Energizer", "id": "https://w3id.org/battinfo/organization/1111-2222-3333-4444"},
         format="coin", chemistry="Li-primary", product_type="commercial", size_code="R2032",
-        positive_electrode_spec_id="https://w3id.org/battinfo/electrode-spec/5555-6666-7777-8888",
+        positive_electrode_spec_id="https://w3id.org/battinfo/spec/5555-6666-7777-8888",
         specs={"nominal_capacity": {"value": 0.24, "unit": "Ah"}}, notes=["note"],
     ))
     assert validate_record(rec).ok, [str(e) for e in validate_record(rec).errors][:3]
     cs = rec["cell_spec"]
     assert cs["manufacturer"]["id"] == "https://w3id.org/battinfo/organization/1111-2222-3333-4444"
     assert cs["product_type"] == "commercial"  # regression: the hand-builder dropped product_type
-    assert rec["positive_electrode_spec_id"] == "https://w3id.org/battinfo/electrode-spec/5555-6666-7777-8888"
+    assert rec["positive_electrode_spec_id"] == "https://w3id.org/battinfo/spec/5555-6666-7777-8888"
     assert rec["notes"] == ["note"]
 
 

--- a/tests/test_component_contract.py
+++ b/tests/test_component_contract.py
@@ -111,7 +111,39 @@ def test_electrolyte_assembles_material_specs(tmp_path):
     spec = bi.create_electrolyte_spec(
         uid="elye23456789abcd", name="1M LiPF6 EC:EMC",
         body={"family": "organic",
-              "salt": {"name": "LiPF6", "material_spec_id": "https://w3id.org/battinfo/material-spec/0000-0000-0000-0000"}},
+              "salt": {"name": "LiPF6", "material_spec_id": "https://w3id.org/battinfo/spec/0000-0000-0000-0000"}},
         validate=False)
     result = validate_record(spec, source_root=tmp_path)
     assert any(i.code == "reference.missing" for i in result.issues)
+
+
+def test_superseded_spec_namespaces_still_load(tmp_path) -> None:
+    """IDENTIFIER_POLICY 6.1: specs mint under spec/, but records and
+    references minted under the superseded per-family namespaces must keep
+    working forever - alias, never break."""
+    from battinfo.api import create_separator, create_separator_spec
+    from battinfo.validate.record import validate_record_report
+
+    spec = create_separator_spec(
+        uid="sepa23456789abcd", name="Celgard 2400",
+        id="https://w3id.org/battinfo/separator-spec/sepa-2345-6789-abcd",
+    )
+    assert spec["separator_spec"]["id"].startswith("https://w3id.org/battinfo/separator-spec/")
+    report = validate_record_report(spec)
+    assert report.ok
+
+    inst = create_separator(
+        uid="seps23456789abcd",
+        spec_id="https://w3id.org/battinfo/separator-spec/sepa-2345-6789-abcd",
+        lot_id="L1",
+    )
+    # New instance minted under the canonical noun namespace; legacy reference kept.
+    assert inst["separator"]["id"].startswith("https://w3id.org/battinfo/separator/")
+    assert inst["separator"]["separator_spec_id"].startswith("https://w3id.org/battinfo/separator-spec/")
+
+
+def test_new_specs_mint_under_shared_spec_namespace() -> None:
+    from battinfo.api import create_electrolyte_spec
+
+    spec = create_electrolyte_spec(uid="elya23456789abcd", name="LP30", body={"family": "organic"})
+    assert spec["electrolyte_spec"]["id"].startswith("https://w3id.org/battinfo/spec/")

--- a/tests/test_material_contract.py
+++ b/tests/test_material_contract.py
@@ -86,7 +86,7 @@ def test_material_spec_and_instance_roundtrip(tmp_path: Path) -> None:
         property={"specific_capacity": {"value": 160, "unit": "mAh/g"}},
     )
     spec_id = spec["material_spec"]["id"]
-    assert spec_id.startswith("https://w3id.org/battinfo/material-spec/")
+    assert spec_id.startswith("https://w3id.org/battinfo/spec/")
 
     saved_spec = api.save_material_spec(spec, source_root=tmp_path)
     assert saved_spec["status"] == "created"
@@ -108,7 +108,7 @@ def test_material_instance_missing_spec_reference_is_flagged(tmp_path: Path) -> 
     from battinfo.validate.record import validate_record
 
     material = api.create_material(
-        material_spec_id="https://w3id.org/battinfo/material-spec/0000-0000-0000-0000",
+        material_spec_id="https://w3id.org/battinfo/spec/0000-0000-0000-0000",
         lot_id="ORPHAN",
         validate=False,
     )

--- a/tests/test_record_roundtrip.py
+++ b/tests/test_record_roundtrip.py
@@ -81,8 +81,8 @@ def test_manufacturer_id_provenance_and_component_refs_round_trip() -> None:
         name="Acme X", manufacturer="Acme", model="X", format="coin", chemistry="Li-ion",
         size_code="R2032",
         manufacturer_id="https://w3id.org/battinfo/organization/1111-2222-3333-4444",
-        positive_electrode_spec_id="https://w3id.org/battinfo/electrode-spec/5555-6666-7777-8888",
-        electrolyte_spec_id="https://w3id.org/battinfo/electrolyte-spec/9999-aaaa-bbbb-cccc",
+        positive_electrode_spec_id="https://w3id.org/battinfo/spec/5555-6666-7777-8888",
+        electrolyte_spec_id="https://w3id.org/battinfo/spec/9999-aaaa-bbbb-cccc",
         source=ProvenanceInfo(type="converter-jsonld", name="BattINFO Converter",
                               workflow_version="app=1.1.17", comment="blended salt note"),
     )

--- a/tests/test_salt_as_material.py
+++ b/tests/test_salt_as_material.py
@@ -25,7 +25,7 @@ def test_salt_accepts_the_material_component_form() -> None:
 
 
 def test_salt_material_keeps_its_materialspec_link() -> None:
-    spec_iri = "https://w3id.org/battinfo/material-spec/7d9k-2m4p-8t3x-6nq5"
+    spec_iri = "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5"
     component = material("LiPF6", concentration={"value": 1.0, "unit": "mol/L"})
     component.material_spec_id = spec_iri
     e = electrolyte_recipe(family="organic", salt=component)

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -736,7 +736,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "SpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         }
       }
     }
@@ -1065,7 +1065,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "SpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "Funding": {
           "type": "object",
@@ -1764,7 +1764,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "SpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "OrganizationIri": {
           "type": "string",
@@ -1772,19 +1772,19 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "ElectrodeSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ElectrolyteSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "SeparatorSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "HousingSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "Funding": {
           "type": "object",
@@ -1921,7 +1921,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
             },
             "material_spec_id": {
               "type": "string",
-              "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+              "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
             },
             "property": {
               "$ref": "modules/common/quantitative-properties.schema.json"
@@ -1953,7 +1953,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
       "$defs": {
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/current-collector-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -2140,7 +2140,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/current-collector-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -3271,7 +3271,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
       "$defs": {
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -3458,7 +3458,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/electrode-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -3678,7 +3678,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
       "$defs": {
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -3865,7 +3865,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/electrolyte-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -4107,7 +4107,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
       "$defs": {
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -4417,7 +4417,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/housing-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -4876,7 +4876,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "MaterialSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "OrganizationIri": {
           "type": "string",
@@ -5166,7 +5166,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "MaterialSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "DatasetIri": {
           "type": "string",
@@ -5470,7 +5470,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
           "description": "Optional canonical IRI of a standalone material-spec for the current-collector foil material."
         },
         "manufacturer": {
@@ -5643,7 +5643,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
             },
             "material_spec_id": {
               "type": "string",
-              "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+              "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
               "description": "Optional canonical IRI of a standalone material-spec for the salt."
             },
             "cation": {
@@ -5712,7 +5712,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
           "description": "Optional canonical IRI of a standalone material-spec record this embedded holder realizes. Lets a cell-spec dedup materials by reference instead of/in addition to inlining them."
         },
         "manufacturer": {
@@ -5799,7 +5799,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "material_spec_id": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
+          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$",
           "description": "Optional canonical IRI of a standalone material-spec for the separator base material."
         },
         "structure": {
@@ -6351,7 +6351,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
             },
             "material_spec_id": {
               "type": "string",
-              "pattern": "^https://w3id\\.org/battinfo/material-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+              "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
             },
             "property": {
               "$ref": "modules/common/quantitative-properties.schema.json"
@@ -6383,7 +6383,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
       "$defs": {
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -6570,7 +6570,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "ComponentSpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/separator-spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "ShortId": {
           "type": "string",
@@ -6976,7 +6976,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "SpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "Quantity": {
           "type": "object",
@@ -7645,7 +7645,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
         },
         "SpecIri": {
           "type": "string",
-          "pattern": "^https://w3id\\.org/battinfo/spec/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
+          "pattern": "^https://w3id\\.org/battinfo/(?:spec|material-spec|electrode-spec|separator-spec|electrolyte-spec|current-collector-spec|housing-spec)/[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{4}){3}$"
         },
         "Funding": {
           "type": "object",

--- a/web/lib/showcase.generated.ts
+++ b/web/lib/showcase.generated.ts
@@ -21,7 +21,7 @@ export const showcase: {
     "record": {
       "schema_version": "0.2.0",
       "material_spec": {
-        "id": "https://w3id.org/battinfo/material-spec/7d9k-2m4p-8t3x-6nq5",
+        "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
         "short_id": "7d9k2m",
         "name": "NMC811",
         "material_class": "active_material",


### PR DESCRIPTION
One distinction in the segment, nothing else: spec/ holds every reusable description (material/electrode/separator/electrolyte/ current-collector/housing specs join cell + test specs); each kind of concrete thing keeps its short noun. Type names have churned three times and the generic segment survived every rename - per-type spec segments are now superseded.

Never-break: the six old *-spec/ forms stay accepted as input at every boundary (component builders via _spec_iri_re, cell-spec component references, MATERIAL_SPEC_IRI_RE, and the JSON Schema patterns gain the alternation in both copies) and become permanent resolver aliases. entities.py gains RESERVED_NAMESPACE_SEGMENTS with an import-time clash guard.

Corpus swept (150 files: examples, packaged examples, tests, docs, notebooks); guides re-executed; web artifacts + vendored schemas regenerated. Regression tests: legacy IRIs still load + new specs mint canonical. 1332 tests; ruff + mypy clean; 103-record agreement green.

Registry follow-up rides the open registry PR: 6 legacy aliases + schema re-vendor. [user-op] verify no live-registry/Zenodo rows carry old component-spec IRIs (expected none - the kinds are recent).