### PR TITLE
Emitter convergence 1–3: one canonical cell-spec node, no silent drops, round-trip safe

### DIFF
--- a/docs/guides/01-concepts.ipynb
+++ b/docs/guides/01-concepts.ipynb
@@ -23,10 +23,10 @@
    "id": "d1bde660",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:21.406347Z",
-     "iopub.status.busy": "2026-07-08T08:58:21.402704Z",
-     "iopub.status.idle": "2026-07-08T08:58:21.422424Z",
-     "shell.execute_reply": "2026-07-08T08:58:21.420915Z"
+     "iopub.execute_input": "2026-07-08T19:10:57.401635Z",
+     "iopub.status.busy": "2026-07-08T19:10:57.400629Z",
+     "iopub.status.idle": "2026-07-08T19:10:57.413005Z",
+     "shell.execute_reply": "2026-07-08T19:10:57.411616Z"
     }
    },
    "outputs": [],
@@ -80,10 +80,10 @@
    "id": "af9f7f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:21.426434Z",
-     "iopub.status.busy": "2026-07-08T08:58:21.425434Z",
-     "iopub.status.idle": "2026-07-08T08:58:21.433968Z",
-     "shell.execute_reply": "2026-07-08T08:58:21.432961Z"
+     "iopub.execute_input": "2026-07-08T19:10:57.415988Z",
+     "iopub.status.busy": "2026-07-08T19:10:57.415988Z",
+     "iopub.status.idle": "2026-07-08T19:10:57.425272Z",
+     "shell.execute_reply": "2026-07-08T19:10:57.424262Z"
     }
    },
    "outputs": [
@@ -115,10 +115,10 @@
    "id": "2876af4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:21.437848Z",
-     "iopub.status.busy": "2026-07-08T08:58:21.437848Z",
-     "iopub.status.idle": "2026-07-08T08:58:21.445009Z",
-     "shell.execute_reply": "2026-07-08T08:58:21.445009Z"
+     "iopub.execute_input": "2026-07-08T19:10:57.428271Z",
+     "iopub.status.busy": "2026-07-08T19:10:57.428271Z",
+     "iopub.status.idle": "2026-07-08T19:10:57.434572Z",
+     "shell.execute_reply": "2026-07-08T19:10:57.433560Z"
     }
    },
    "outputs": [
@@ -161,10 +161,10 @@
    "id": "8d47a257",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:21.454471Z",
-     "iopub.status.busy": "2026-07-08T08:58:21.452803Z",
-     "iopub.status.idle": "2026-07-08T08:58:21.464001Z",
-     "shell.execute_reply": "2026-07-08T08:58:21.462944Z"
+     "iopub.execute_input": "2026-07-08T19:10:57.436566Z",
+     "iopub.status.busy": "2026-07-08T19:10:57.436566Z",
+     "iopub.status.idle": "2026-07-08T19:10:57.444746Z",
+     "shell.execute_reply": "2026-07-08T19:10:57.443739Z"
     }
    },
    "outputs": [
@@ -301,10 +301,10 @@
    "id": "e85e0b8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:21.466819Z",
-     "iopub.status.busy": "2026-07-08T08:58:21.466007Z",
-     "iopub.status.idle": "2026-07-08T08:58:21.471299Z",
-     "shell.execute_reply": "2026-07-08T08:58:21.470290Z"
+     "iopub.execute_input": "2026-07-08T19:10:57.446746Z",
+     "iopub.status.busy": "2026-07-08T19:10:57.446746Z",
+     "iopub.status.idle": "2026-07-08T19:10:57.451772Z",
+     "shell.execute_reply": "2026-07-08T19:10:57.450767Z"
     }
    },
    "outputs": [
@@ -354,10 +354,10 @@
    "id": "e670cfbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:21.474403Z",
-     "iopub.status.busy": "2026-07-08T08:58:21.474403Z",
-     "iopub.status.idle": "2026-07-08T08:58:22.480634Z",
-     "shell.execute_reply": "2026-07-08T08:58:22.479629Z"
+     "iopub.execute_input": "2026-07-08T19:10:57.454974Z",
+     "iopub.status.busy": "2026-07-08T19:10:57.454974Z",
+     "iopub.status.idle": "2026-07-08T19:10:58.202566Z",
+     "shell.execute_reply": "2026-07-08T19:10:58.201559Z"
     }
    },
    "outputs": [
@@ -395,10 +395,10 @@
    "id": "0f9bd621",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:22.482838Z",
-     "iopub.status.busy": "2026-07-08T08:58:22.482838Z",
-     "iopub.status.idle": "2026-07-08T08:58:22.984752Z",
-     "shell.execute_reply": "2026-07-08T08:58:22.982739Z"
+     "iopub.execute_input": "2026-07-08T19:10:58.205565Z",
+     "iopub.status.busy": "2026-07-08T19:10:58.205565Z",
+     "iopub.status.idle": "2026-07-08T19:10:58.628611Z",
+     "shell.execute_reply": "2026-07-08T19:10:58.627602Z"
     }
    },
    "outputs": [
@@ -431,10 +431,10 @@
    "id": "50971f8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:22.987745Z",
-     "iopub.status.busy": "2026-07-08T08:58:22.986749Z",
-     "iopub.status.idle": "2026-07-08T08:58:22.994766Z",
-     "shell.execute_reply": "2026-07-08T08:58:22.994262Z"
+     "iopub.execute_input": "2026-07-08T19:10:58.631608Z",
+     "iopub.status.busy": "2026-07-08T19:10:58.631608Z",
+     "iopub.status.idle": "2026-07-08T19:10:58.635659Z",
+     "shell.execute_reply": "2026-07-08T19:10:58.635659Z"
     }
    },
    "outputs": [
@@ -474,10 +474,10 @@
    "id": "4bb41daf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:22.997771Z",
-     "iopub.status.busy": "2026-07-08T08:58:22.996771Z",
-     "iopub.status.idle": "2026-07-08T08:58:23.004122Z",
-     "shell.execute_reply": "2026-07-08T08:58:23.003105Z"
+     "iopub.execute_input": "2026-07-08T19:10:58.637668Z",
+     "iopub.status.busy": "2026-07-08T19:10:58.637668Z",
+     "iopub.status.idle": "2026-07-08T19:10:58.641689Z",
+     "shell.execute_reply": "2026-07-08T19:10:58.641689Z"
     }
    },
    "outputs": [
@@ -492,20 +492,33 @@
       "    \"https://w3id.org/emmo/domain/battery/context\",\n",
       "    {\n",
       "      \"schema\": \"https://schema.org/\",\n",
-      "      \"csvw\": \"http://www.w3.org/ns/csvw#\"\n",
+      "      \"csvw\": \"http://www.w3.org/ns/csvw#\",\n",
+      "      \"battinfo\": \"https://w3id.org/battinfo/\"\n",
       "    }\n",
       "  ],\n",
-      "  \"@id\": \"https://w3id.org/battinfo/spec/e4t5-w9re-mpq6-8g7e\",\n",
       "  \"@type\": [\n",
       "    \"BatteryCellSpecification\",\n",
       "    \"schema:CreativeWork\"\n",
       "  ],\n",
+      "  \"@id\": \"https://w3id.org/battinfo/spec/e4t5-w9re-mpq6-8g7e\",\n",
       "  \"schema:identifier\": \"e4t5-w9re-mpq6-8g7e\",\n",
       "  \"schema:name\": \"A123 Systems ANR26650M1-B\",\n",
+      "  \"schema:model\": \"ANR26650M1-B\",\n",
       "  \"schema:manufacturer\": {\n",
       "    \"@type\": \"schema:Organization\",\n",
       "    \"schema:name\": \"A123 Systems\"\n",
       "  },\n",
+      "  \"schema:url\": \"https://www.battery-genome.org/registry/spec/e4t5-w9re-mpq6-8g7e\",\n",
+      "  \"isDescriptionFor\": {\n",
+      "    \"@type\": [\n",
+      "      \"BatteryCell\",\n",
+      "      \"CylindricalBattery\",\n",
+      "      \"LithiumIonBattery\",\n",
+      "      \"LithiumIonIronPhosphateBattery\",\n",
+      "      \"LithiumIonGraphiteBattery\"\n",
+      "    ]\n",
+      "  },\n",
+      "  \"schema:schemaVersion\": \"0.2.0\",\n",
       "  \"hasProperty\": [\n",
       "    {\n",
       "      \"@type\": [\n",
@@ -529,7 +542,12 @@
       "      },\n",
       "      \"hasMeasurementUnit\": \"https://w3id.org/emmo#Volt\"\n",
       "    }\n",
-      "  ]\n",
+      "  ],\n",
+      "  \"dcterms:source\": {\n",
+      "    \"@type\": \"prov:Entity\",\n",
+      "    \"dcterms:type\": \"datasheet\",\n",
+      "    \"prov:generatedAtTime\": \"2026-07-08T19:10:57+00:00\"\n",
+      "  }\n",
       "}\n"
      ]
     }
@@ -561,10 +579,10 @@
    "id": "bfc0b477",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:23.009111Z",
-     "iopub.status.busy": "2026-07-08T08:58:23.008113Z",
-     "iopub.status.idle": "2026-07-08T08:58:23.034380Z",
-     "shell.execute_reply": "2026-07-08T08:58:23.032374Z"
+     "iopub.execute_input": "2026-07-08T19:10:58.645045Z",
+     "iopub.status.busy": "2026-07-08T19:10:58.645045Z",
+     "iopub.status.idle": "2026-07-08T19:10:58.664807Z",
+     "shell.execute_reply": "2026-07-08T19:10:58.664277Z"
     }
    },
    "outputs": [

--- a/docs/guides/02-first-cell-type.ipynb
+++ b/docs/guides/02-first-cell-type.ipynb
@@ -23,10 +23,10 @@
    "id": "6aa2a3a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:30.764944Z",
-     "iopub.status.busy": "2026-07-08T08:58:30.764944Z",
-     "iopub.status.idle": "2026-07-08T08:58:30.776733Z",
-     "shell.execute_reply": "2026-07-08T08:58:30.776733Z"
+     "iopub.execute_input": "2026-07-08T19:11:03.878332Z",
+     "iopub.status.busy": "2026-07-08T19:11:03.878332Z",
+     "iopub.status.idle": "2026-07-08T19:11:03.886336Z",
+     "shell.execute_reply": "2026-07-08T19:11:03.886336Z"
     }
    },
    "outputs": [],
@@ -56,10 +56,10 @@
    "id": "3e2a2bcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:30.782452Z",
-     "iopub.status.busy": "2026-07-08T08:58:30.782452Z",
-     "iopub.status.idle": "2026-07-08T08:58:31.733083Z",
-     "shell.execute_reply": "2026-07-08T08:58:31.733083Z"
+     "iopub.execute_input": "2026-07-08T19:11:03.889345Z",
+     "iopub.status.busy": "2026-07-08T19:11:03.888343Z",
+     "iopub.status.idle": "2026-07-08T19:11:04.571203Z",
+     "shell.execute_reply": "2026-07-08T19:11:04.570194Z"
     }
    },
    "outputs": [
@@ -112,10 +112,10 @@
    "id": "0bd7097b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:31.735096Z",
-     "iopub.status.busy": "2026-07-08T08:58:31.735096Z",
-     "iopub.status.idle": "2026-07-08T08:58:31.740900Z",
-     "shell.execute_reply": "2026-07-08T08:58:31.740900Z"
+     "iopub.execute_input": "2026-07-08T19:11:04.574202Z",
+     "iopub.status.busy": "2026-07-08T19:11:04.574202Z",
+     "iopub.status.idle": "2026-07-08T19:11:04.580453Z",
+     "shell.execute_reply": "2026-07-08T19:11:04.580453Z"
     }
    },
    "outputs": [
@@ -191,7 +191,7 @@
       "    \"source_type\": \"datasheet\",\n",
       "    \"source_name\": \"INR21700-50E Product Specification Rev 1.0\",\n",
       "    \"source_url\": \"https://example.com/samsung-inr21700-50e.pdf\",\n",
-      "    \"retrieved_at\": 1783501111,\n",
+      "    \"retrieved_at\": 1783537864,\n",
       "    \"battinfo_version\": \"0.7.0\"\n",
       "  }\n",
       "}\n"
@@ -210,13 +210,21 @@
    "id": "65e1f16b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:31.745234Z",
-     "iopub.status.busy": "2026-07-08T08:58:31.745234Z",
-     "iopub.status.idle": "2026-07-08T08:58:32.280840Z",
-     "shell.execute_reply": "2026-07-08T08:58:32.279835Z"
+     "iopub.execute_input": "2026-07-08T19:11:04.583506Z",
+     "iopub.status.busy": "2026-07-08T19:11:04.583506Z",
+     "iopub.status.idle": "2026-07-08T19:11:04.993757Z",
+     "shell.execute_reply": "2026-07-08T19:11:04.993757Z"
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<repo>\\src\\battinfo\\transform\\cell_spec_node.py:333: UserWarning: semantic.value_text_only: 'cycle_life' on https://w3id.org/battinfo/spec/03yx-y1kk-q3mq-ck3w carries only value_text - the JSON-LD export emits no numeric quantity value for it.\n",
+      "  property_nodes = cell_spec_property_nodes(\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -284,10 +292,10 @@
    "id": "bb91e73d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:32.284352Z",
-     "iopub.status.busy": "2026-07-08T08:58:32.283352Z",
-     "iopub.status.idle": "2026-07-08T08:58:32.291037Z",
-     "shell.execute_reply": "2026-07-08T08:58:32.289958Z"
+     "iopub.execute_input": "2026-07-08T19:11:04.997765Z",
+     "iopub.status.busy": "2026-07-08T19:11:04.997765Z",
+     "iopub.status.idle": "2026-07-08T19:11:05.005619Z",
+     "shell.execute_reply": "2026-07-08T19:11:05.005112Z"
     }
    },
    "outputs": [
@@ -333,10 +341,10 @@
    "id": "795996e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:32.293550Z",
-     "iopub.status.busy": "2026-07-08T08:58:32.293550Z",
-     "iopub.status.idle": "2026-07-08T08:58:32.299667Z",
-     "shell.execute_reply": "2026-07-08T08:58:32.298661Z"
+     "iopub.execute_input": "2026-07-08T19:11:05.008624Z",
+     "iopub.status.busy": "2026-07-08T19:11:05.007626Z",
+     "iopub.status.idle": "2026-07-08T19:11:05.014134Z",
+     "shell.execute_reply": "2026-07-08T19:11:05.013626Z"
     }
    },
    "outputs": [

--- a/docs/guides/03-linked-records.ipynb
+++ b/docs/guides/03-linked-records.ipynb
@@ -31,10 +31,10 @@
    "id": "49487b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:48.832223Z",
-     "iopub.status.busy": "2026-07-08T08:58:48.832223Z",
-     "iopub.status.idle": "2026-07-08T08:58:49.425794Z",
-     "shell.execute_reply": "2026-07-08T08:58:49.425794Z"
+     "iopub.execute_input": "2026-07-08T19:11:10.242975Z",
+     "iopub.status.busy": "2026-07-08T19:11:10.242975Z",
+     "iopub.status.idle": "2026-07-08T19:11:10.590009Z",
+     "shell.execute_reply": "2026-07-08T19:11:10.589000Z"
     }
    },
    "outputs": [],
@@ -74,10 +74,10 @@
    "id": "d5e7a580",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:49.429495Z",
-     "iopub.status.busy": "2026-07-08T08:58:49.429495Z",
-     "iopub.status.idle": "2026-07-08T08:58:49.436146Z",
-     "shell.execute_reply": "2026-07-08T08:58:49.436146Z"
+     "iopub.execute_input": "2026-07-08T19:11:10.593079Z",
+     "iopub.status.busy": "2026-07-08T19:11:10.592036Z",
+     "iopub.status.idle": "2026-07-08T19:11:10.598234Z",
+     "shell.execute_reply": "2026-07-08T19:11:10.597215Z"
     }
    },
    "outputs": [
@@ -125,10 +125,10 @@
    "id": "05b87289",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:49.436146Z",
-     "iopub.status.busy": "2026-07-08T08:58:49.436146Z",
-     "iopub.status.idle": "2026-07-08T08:58:49.449135Z",
-     "shell.execute_reply": "2026-07-08T08:58:49.449135Z"
+     "iopub.execute_input": "2026-07-08T19:11:10.601243Z",
+     "iopub.status.busy": "2026-07-08T19:11:10.600221Z",
+     "iopub.status.idle": "2026-07-08T19:11:10.610795Z",
+     "shell.execute_reply": "2026-07-08T19:11:10.609786Z"
     }
    },
    "outputs": [
@@ -173,10 +173,10 @@
    "id": "3f90949f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:49.452287Z",
-     "iopub.status.busy": "2026-07-08T08:58:49.452287Z",
-     "iopub.status.idle": "2026-07-08T08:58:49.478212Z",
-     "shell.execute_reply": "2026-07-08T08:58:49.478212Z"
+     "iopub.execute_input": "2026-07-08T19:11:10.613791Z",
+     "iopub.status.busy": "2026-07-08T19:11:10.613791Z",
+     "iopub.status.idle": "2026-07-08T19:11:10.633404Z",
+     "shell.execute_reply": "2026-07-08T19:11:10.632399Z"
     }
    },
    "outputs": [
@@ -250,10 +250,10 @@
    "id": "0ae05fc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:49.482472Z",
-     "iopub.status.busy": "2026-07-08T08:58:49.482472Z",
-     "iopub.status.idle": "2026-07-08T08:58:49.504128Z",
-     "shell.execute_reply": "2026-07-08T08:58:49.504128Z"
+     "iopub.execute_input": "2026-07-08T19:11:10.635403Z",
+     "iopub.status.busy": "2026-07-08T19:11:10.635403Z",
+     "iopub.status.idle": "2026-07-08T19:11:10.654761Z",
+     "shell.execute_reply": "2026-07-08T19:11:10.654761Z"
     }
    },
    "outputs": [
@@ -306,10 +306,10 @@
    "id": "f739b75c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:49.507314Z",
-     "iopub.status.busy": "2026-07-08T08:58:49.507314Z",
-     "iopub.status.idle": "2026-07-08T08:58:50.393473Z",
-     "shell.execute_reply": "2026-07-08T08:58:50.393473Z"
+     "iopub.execute_input": "2026-07-08T19:11:10.658767Z",
+     "iopub.status.busy": "2026-07-08T19:11:10.657768Z",
+     "iopub.status.idle": "2026-07-08T19:11:11.117197Z",
+     "shell.execute_reply": "2026-07-08T19:11:11.117197Z"
     }
    },
    "outputs": [
@@ -364,10 +364,10 @@
    "id": "b1bde293",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:50.395869Z",
-     "iopub.status.busy": "2026-07-08T08:58:50.395869Z",
-     "iopub.status.idle": "2026-07-08T08:58:50.412438Z",
-     "shell.execute_reply": "2026-07-08T08:58:50.411364Z"
+     "iopub.execute_input": "2026-07-08T19:11:11.119203Z",
+     "iopub.status.busy": "2026-07-08T19:11:11.119203Z",
+     "iopub.status.idle": "2026-07-08T19:11:11.125618Z",
+     "shell.execute_reply": "2026-07-08T19:11:11.125618Z"
     }
    },
    "outputs": [
@@ -382,9 +382,9 @@
       "  \"name\": \"1C cycle life, cell A001 data\",\n",
       "  \"license\": \"CC-BY-4.0\",\n",
       "  \"access_url\": \"file:///<repo>/docs/guides/_scratch/guide-03/inputs/sdi-a001-cycle-life.csv\",\n",
-      "  \"created_at\": 1783501129,\n",
-      "  \"modified_at\": 1783501129,\n",
-      "  \"published_at\": 1783501129,\n",
+      "  \"created_at\": 1783537870,\n",
+      "  \"modified_at\": 1783537870,\n",
+      "  \"published_at\": 1783537870,\n",
       "  \"about\": [\n",
       "    \"https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7\",\n",
       "    \"https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt\"\n",
@@ -432,10 +432,10 @@
    "id": "bac15f6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:50.412438Z",
-     "iopub.status.busy": "2026-07-08T08:58:50.412438Z",
-     "iopub.status.idle": "2026-07-08T08:58:50.997513Z",
-     "shell.execute_reply": "2026-07-08T08:58:50.997513Z"
+     "iopub.execute_input": "2026-07-08T19:11:11.128624Z",
+     "iopub.status.busy": "2026-07-08T19:11:11.128624Z",
+     "iopub.status.idle": "2026-07-08T19:11:11.430937Z",
+     "shell.execute_reply": "2026-07-08T19:11:11.430937Z"
     }
    },
    "outputs": [
@@ -491,10 +491,10 @@
    "id": "17b1abe0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:51.002085Z",
-     "iopub.status.busy": "2026-07-08T08:58:51.002085Z",
-     "iopub.status.idle": "2026-07-08T08:58:51.008075Z",
-     "shell.execute_reply": "2026-07-08T08:58:51.008075Z"
+     "iopub.execute_input": "2026-07-08T19:11:11.433943Z",
+     "iopub.status.busy": "2026-07-08T19:11:11.432942Z",
+     "iopub.status.idle": "2026-07-08T19:11:11.437823Z",
+     "shell.execute_reply": "2026-07-08T19:11:11.436815Z"
     }
    },
    "outputs": [
@@ -532,10 +532,10 @@
    "id": "2647bdf5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:58:51.012294Z",
-     "iopub.status.busy": "2026-07-08T08:58:51.012294Z",
-     "iopub.status.idle": "2026-07-08T08:58:51.029007Z",
-     "shell.execute_reply": "2026-07-08T08:58:51.027987Z"
+     "iopub.execute_input": "2026-07-08T19:11:11.440830Z",
+     "iopub.status.busy": "2026-07-08T19:11:11.440830Z",
+     "iopub.status.idle": "2026-07-08T19:11:11.456062Z",
+     "shell.execute_reply": "2026-07-08T19:11:11.455057Z"
     }
    },
    "outputs": [

--- a/docs/guides/04-semantic-layer.ipynb
+++ b/docs/guides/04-semantic-layer.ipynb
@@ -19,13 +19,21 @@
    "id": "b9975261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:01.073994Z",
-     "iopub.status.busy": "2026-07-08T08:59:01.072305Z",
-     "iopub.status.idle": "2026-07-08T08:59:03.386624Z",
-     "shell.execute_reply": "2026-07-08T08:59:03.386624Z"
+     "iopub.execute_input": "2026-07-08T19:11:16.668024Z",
+     "iopub.status.busy": "2026-07-08T19:11:16.668024Z",
+     "iopub.status.idle": "2026-07-08T19:11:17.758919Z",
+     "shell.execute_reply": "2026-07-08T19:11:17.757896Z"
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<repo>\\src\\battinfo\\transform\\cell_spec_node.py:333: UserWarning: semantic.value_text_only: 'cycle_life' on https://w3id.org/battinfo/spec/wckm-y5a4-he0k-2scd carries only value_text - the JSON-LD export emits no numeric quantity value for it.\n",
+      "  property_nodes = cell_spec_property_nodes(\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -90,10 +98,10 @@
    "id": "df15cfe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:03.390140Z",
-     "iopub.status.busy": "2026-07-08T08:59:03.390140Z",
-     "iopub.status.idle": "2026-07-08T08:59:03.396795Z",
-     "shell.execute_reply": "2026-07-08T08:59:03.396795Z"
+     "iopub.execute_input": "2026-07-08T19:11:17.760905Z",
+     "iopub.status.busy": "2026-07-08T19:11:17.760905Z",
+     "iopub.status.idle": "2026-07-08T19:11:17.766056Z",
+     "shell.execute_reply": "2026-07-08T19:11:17.764905Z"
     }
    },
    "outputs": [
@@ -106,21 +114,34 @@
       "    \"https://w3id.org/emmo/domain/battery/context\",\n",
       "    {\n",
       "      \"schema\": \"https://schema.org/\",\n",
-      "      \"csvw\": \"http://www.w3.org/ns/csvw#\"\n",
+      "      \"csvw\": \"http://www.w3.org/ns/csvw#\",\n",
+      "      \"battinfo\": \"https://w3id.org/battinfo/\"\n",
       "    }\n",
       "  ],\n",
-      "  \"@id\": \"https://w3id.org/battinfo/spec/wckm-y5a4-he0k-2scd\",\n",
       "  \"@type\": [\n",
       "    \"BatteryCellSpecification\",\n",
       "    \"schema:CreativeWork\"\n",
       "  ],\n",
+      "  \"@id\": \"https://w3id.org/battinfo/spec/wckm-y5a4-he0k-2scd\",\n",
       "  \"schema:identifier\": \"wckm-y5a4-he0k-2scd\",\n",
       "  \"schema:name\": \"A123 Systems ANR26650M1-B\",\n",
+      "  \"schema:model\": \"ANR26650M1-B\",\n",
       "  \"schema:manufacturer\": {\n",
       "    \"@type\": \"schema:Organization\",\n",
       "    \"schema:name\": \"A123 Systems\"\n",
       "  },\n",
+      "  \"schema:url\": \"https://www.battery-genome.org/registry/spec/wckm-y5a4-he0k-2scd\",\n",
+      "  \"isDescriptionFor\": {\n",
+      "    \"@type\": [\n",
+      "      \"BatteryCell\",\n",
+      "      \"CylindricalBattery\",\n",
+      "      \"LithiumIonBattery\",\n",
+      "      \"LithiumIonIronPhosphateBattery\",\n",
+      "      \"LithiumIonGraphiteBattery\"\n",
+      "    ]\n",
+      "  },\n",
       "  \"schema:size\": \"R26650\",\n",
+      "  \"schema:schemaVersion\": \"0.2.0\",\n",
       "  \"hasProperty\": [\n",
       "    {\n",
       "      \"@type\": [\n",
@@ -207,7 +228,12 @@
       "      \"schema:value\": \">1000\",\n",
       "      \"hasMeasurementUnit\": \"https://w3id.org/emmo#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\"\n",
       "    }\n",
-      "  ]\n",
+      "  ],\n",
+      "  \"dcterms:source\": {\n",
+      "    \"@type\": \"prov:Entity\",\n",
+      "    \"dcterms:type\": \"datasheet\",\n",
+      "    \"prov:generatedAtTime\": \"2026-07-08T19:11:16+00:00\"\n",
+      "  }\n",
       "}\n"
      ]
     }
@@ -238,10 +264,10 @@
    "id": "310d641b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:03.400818Z",
-     "iopub.status.busy": "2026-07-08T08:59:03.398812Z",
-     "iopub.status.idle": "2026-07-08T08:59:03.405114Z",
-     "shell.execute_reply": "2026-07-08T08:59:03.405114Z"
+     "iopub.execute_input": "2026-07-08T19:11:17.768055Z",
+     "iopub.status.busy": "2026-07-08T19:11:17.768055Z",
+     "iopub.status.idle": "2026-07-08T19:11:17.775572Z",
+     "shell.execute_reply": "2026-07-08T19:11:17.774057Z"
     }
    },
    "outputs": [
@@ -318,10 +344,10 @@
    "id": "idf-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:03.409563Z",
-     "iopub.status.busy": "2026-07-08T08:59:03.409563Z",
-     "iopub.status.idle": "2026-07-08T08:59:03.420059Z",
-     "shell.execute_reply": "2026-07-08T08:59:03.418477Z"
+     "iopub.execute_input": "2026-07-08T19:11:17.779569Z",
+     "iopub.status.busy": "2026-07-08T19:11:17.779569Z",
+     "iopub.status.idle": "2026-07-08T19:11:17.786528Z",
+     "shell.execute_reply": "2026-07-08T19:11:17.785516Z"
     }
    },
    "outputs": [
@@ -356,10 +382,10 @@
    "id": "117501cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:03.424461Z",
-     "iopub.status.busy": "2026-07-08T08:59:03.422416Z",
-     "iopub.status.idle": "2026-07-08T08:59:03.436390Z",
-     "shell.execute_reply": "2026-07-08T08:59:03.433367Z"
+     "iopub.execute_input": "2026-07-08T19:11:17.789550Z",
+     "iopub.status.busy": "2026-07-08T19:11:17.788553Z",
+     "iopub.status.idle": "2026-07-08T19:11:17.794762Z",
+     "shell.execute_reply": "2026-07-08T19:11:17.793755Z"
     }
    },
    "outputs": [
@@ -413,10 +439,10 @@
    "id": "cfe8dd30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:03.446908Z",
-     "iopub.status.busy": "2026-07-08T08:59:03.445911Z",
-     "iopub.status.idle": "2026-07-08T08:59:03.684065Z",
-     "shell.execute_reply": "2026-07-08T08:59:03.683055Z"
+     "iopub.execute_input": "2026-07-08T19:11:17.798775Z",
+     "iopub.status.busy": "2026-07-08T19:11:17.797767Z",
+     "iopub.status.idle": "2026-07-08T19:11:17.897173Z",
+     "shell.execute_reply": "2026-07-08T19:11:17.896164Z"
     }
    },
    "outputs": [
@@ -457,10 +483,10 @@
    "id": "8b6bd11a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:03.692066Z",
-     "iopub.status.busy": "2026-07-08T08:59:03.691063Z",
-     "iopub.status.idle": "2026-07-08T08:59:05.012105Z",
-     "shell.execute_reply": "2026-07-08T08:59:05.011088Z"
+     "iopub.execute_input": "2026-07-08T19:11:17.901173Z",
+     "iopub.status.busy": "2026-07-08T19:11:17.900172Z",
+     "iopub.status.idle": "2026-07-08T19:11:18.807599Z",
+     "shell.execute_reply": "2026-07-08T19:11:18.807088Z"
     }
    },
    "outputs": [
@@ -468,7 +494,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Triple count: 62\n"
+      "Triple count: 75\n"
      ]
     }
    ],
@@ -489,10 +515,10 @@
    "id": "efb494cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:05.012105Z",
-     "iopub.status.busy": "2026-07-08T08:59:05.012105Z",
-     "iopub.status.idle": "2026-07-08T08:59:05.022382Z",
-     "shell.execute_reply": "2026-07-08T08:59:05.022382Z"
+     "iopub.execute_input": "2026-07-08T19:11:18.809600Z",
+     "iopub.status.busy": "2026-07-08T19:11:18.809600Z",
+     "iopub.status.idle": "2026-07-08T19:11:18.813825Z",
+     "shell.execute_reply": "2026-07-08T19:11:18.813825Z"
     }
    },
    "outputs": [
@@ -500,68 +526,81 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
-      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N305e542159ae4789966521c41269ee2f\n",
-      "  N07cdc0617df84fbe9e02d1cff8d9e701  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
-      "  N28e0a161800143c981375372093718b6  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
-      "  N28e0a161800143c981375372093718b6  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N28e0a161800143c981375372093718b6  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N3a8c1a6039db45fda464b3115dba3f00\n",
-      "  N28e0a161800143c981375372093718b6  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
-      "  N305e542159ae4789966521c41269ee2f  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N305e542159ae4789966521c41269ee2f  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
-      "  N33b5d583f88a4d65a4e93a71d09f081e  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N33b5d583f88a4d65a4e93a71d09f081e  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
-      "  N33b5d583f88a4d65a4e93a71d09f081e  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Na317129623cd43f18bdba8ccfea6c8f8\n",
-      "  N33b5d583f88a4d65a4e93a71d09f081e  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
-      "  N3a8c1a6039db45fda464b3115dba3f00  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N3a8c1a6039db45fda464b3115dba3f00  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
-      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
-      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  value  →  >1000\n",
-      "  N435d98ae0cc64ecc8b665a1444ad5fe3  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
-      "  N44979483946e425f887cef5e3f9134f2  →  type  →  Organization\n",
-      "  N44979483946e425f887cef5e3f9134f2  →  name  →  A123 Systems\n",
-      "  N818c9380674d434dbeb54534e36da9a4  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N818c9380674d434dbeb54534e36da9a4  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
-      "  N8c21edfdd69d4fc0b121af62ed297a71  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  N8c21edfdd69d4fc0b121af62ed297a71  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
-      "  Na317129623cd43f18bdba8ccfea6c8f8  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  Na317129623cd43f18bdba8ccfea6c8f8  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
-      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
-      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Nc1d98de687264a80af4cf7369a3c7db7\n",
-      "  Na934dcb544974fbdad44fcd67e1e0ff9  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
-      "  Nc1d98de687264a80af4cf7369a3c7db7  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  Nc1d98de687264a80af4cf7369a3c7db7  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
-      "  Nd0a9944c9fe84a3e877b508ab141e4a9  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
-      "  Nd0a9944c9fe84a3e877b508ab141e4a9  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
-      "  Nd126b9badbd84f6d965e2d3a4374566e  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nd126b9badbd84f6d965e2d3a4374566e  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
-      "  Nd126b9badbd84f6d965e2d3a4374566e  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N8c21edfdd69d4fc0b121af62ed297a71\n",
-      "  Nd126b9badbd84f6d965e2d3a4374566e  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
-      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
-      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N818c9380674d434dbeb54534e36da9a4\n",
-      "  Ne23472f95c9641cc8f621daeaa2d48dc  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
-      "  Nffaf996e61ce486cb4deebda0a828514  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
-      "  Nffaf996e61ce486cb4deebda0a828514  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
-      "  Nffaf996e61ce486cb4deebda0a828514  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Nd0a9944c9fe84a3e877b508ab141e4a9\n",
-      "  Nffaf996e61ce486cb4deebda0a828514  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  N11e1035fcf35419db2b2a080290970fe  →  type  →  datasheet\n",
+      "  N11e1035fcf35419db2b2a080290970fe  →  type  →  Entity\n",
+      "  N11e1035fcf35419db2b2a080290970fe  →  generatedAtTime  →  2026-07-08T19:11:16+00:00\n",
+      "  N17512a3d69ce42bc8c8876895f384945  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N17512a3d69ce42bc8c8876895f384945  →  type  →  electrochemistry_9bf40017_3f58_4030_ada7_cb37a3dfda2d\n",
+      "  N17512a3d69ce42bc8c8876895f384945  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N3fc439c38aa5483e97ca546a94eb655f\n",
+      "  N17512a3d69ce42bc8c8876895f384945  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliOhm\n",
+      "  N3c2928aa56964472bc9dc8aa9ce3b028  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N3c2928aa56964472bc9dc8aa9ce3b028  →  type  →  electrochemistry_8abde9d0_84f6_4b4f_a87e_86028a397100\n",
+      "  N3c2928aa56964472bc9dc8aa9ce3b028  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N57360a3e47f345d28d7f1d5362390528\n",
+      "  N3c2928aa56964472bc9dc8aa9ce3b028  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  AmpereHour\n",
+      "  N3fc439c38aa5483e97ca546a94eb655f  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N3fc439c38aa5483e97ca546a94eb655f  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  6.0\n",
+      "  N57360a3e47f345d28d7f1d5362390528  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N57360a3e47f345d28d7f1d5362390528  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  2.5\n",
+      "  N6982a5abba3c442f869dcd8500f835a2  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N6982a5abba3c442f869dcd8500f835a2  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  65.0\n",
+      "  N6ad0ab45ef7747a49487043cedb98b26  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  N6ad0ab45ef7747a49487043cedb98b26  →  type  →  electrochemistry_ae782b14_88ce_4cdd_9418_12aca00be937\n",
+      "  N6ad0ab45ef7747a49487043cedb98b26  →  value  →  >1000\n",
+      "  N6ad0ab45ef7747a49487043cedb98b26  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978\n",
+      "  N7bc9944c1f20491f9ae4fe0c1b97f3cc  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N7bc9944c1f20491f9ae4fe0c1b97f3cc  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  3.3\n",
+      "  N942dc09fee8e4a5080a2c15062a58275  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  N942dc09fee8e4a5080a2c15062a58275  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  8.25\n",
+      "  Na0b9c73e8a504575a7792509d807b51d  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Na0b9c73e8a504575a7792509d807b51d  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  26.0\n",
+      "  Nb149a30267e04993af97e97151321385  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nb149a30267e04993af97e97151321385  →  type  →  EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405\n",
+      "  Nb149a30267e04993af97e97151321385  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Nd503251fa7b14ac688d60fc50d16c5bc\n",
+      "  Nb149a30267e04993af97e97151321385  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Gram\n",
+      "  Nb1e82112708742b6aa9b92682d84bc46  →  type  →  EMMO_08bcf1d6_e719_46c8_bb21_24bc9bf34dba\n",
+      "  Nb1e82112708742b6aa9b92682d84bc46  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nb1e82112708742b6aa9b92682d84bc46  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N6982a5abba3c442f869dcd8500f835a2\n",
+      "  Nb1e82112708742b6aa9b92682d84bc46  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  Nc6a33b982e0340b0a4d014a511271796  →  type  →  EMMO_c1c8ac3c_8a1c_4777_8e0b_14c1f9f9b0c6\n",
+      "  Nc6a33b982e0340b0a4d014a511271796  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nc6a33b982e0340b0a4d014a511271796  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  Na0b9c73e8a504575a7792509d807b51d\n",
+      "  Nc6a33b982e0340b0a4d014a511271796  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  MilliMetre\n",
+      "  Ncf1ad6f58b0b4b0988118f5a3c9886a3  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Ncf1ad6f58b0b4b0988118f5a3c9886a3  →  type  →  electrochemistry_639b844a_e801_436b_985d_28926129ead6\n",
+      "  Ncf1ad6f58b0b4b0988118f5a3c9886a3  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N7bc9944c1f20491f9ae4fe0c1b97f3cc\n",
+      "  Ncf1ad6f58b0b4b0988118f5a3c9886a3  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  Volt\n",
+      "  Nd503251fa7b14ac688d60fc50d16c5bc  →  type  →  EMMO_18d180e4_5e3e_42f7_820c_e08951223486\n",
+      "  Nd503251fa7b14ac688d60fc50d16c5bc  →  EMMO_faf79f53_749d_40b2_807c_d34244c192f4  →  76.0\n",
+      "  Nf28b2a2f9b7047c8a44839a58413b7a2  →  type  →  EMMO_d8aa8e1f_b650_416d_88a0_5118de945456\n",
+      "  Nf28b2a2f9b7047c8a44839a58413b7a2  →  type  →  electrochemistry_19e27aa3_0970_43a6_86d3_e3cdd956134d\n",
+      "  Nf28b2a2f9b7047c8a44839a58413b7a2  →  EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0  →  N942dc09fee8e4a5080a2c15062a58275\n",
+      "  Nf28b2a2f9b7047c8a44839a58413b7a2  →  EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569  →  WattHour\n",
+      "  Nf36ae79fbab44968ad20e859ddab2f52  →  type  →  Organization\n",
+      "  Nf36ae79fbab44968ad20e859ddab2f52  →  name  →  A123 Systems\n",
+      "  Nfc7a667b073a4662adc42655527a4dc6  →  type  →  battery_04a4e5a4_e6fd_43af_b1ca_4a16d5f8886c\n",
+      "  Nfc7a667b073a4662adc42655527a4dc6  →  type  →  battery_2018e0da_4c25_46e9_83db_38431fc81ce0\n",
+      "  Nfc7a667b073a4662adc42655527a4dc6  →  type  →  battery_68ed592a_7924_45d0_a108_94d6275d57f0\n",
+      "  Nfc7a667b073a4662adc42655527a4dc6  →  type  →  battery_96addc62_ea04_449a_8237_4cd541dd8e5f\n",
+      "  Nfc7a667b073a4662adc42655527a4dc6  →  type  →  battery_ac604ecd_cc60_4b98_b57c_74cd5d3ccd40\n",
+      "  wckm-y5a4-he0k-2scd  →  source  →  N11e1035fcf35419db2b2a080290970fe\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  CreativeWork\n",
       "  wckm-y5a4-he0k-2scd  →  type  →  battery_1cfbba6c_8824_4932_a23e_2141483acef7\n",
       "  wckm-y5a4-he0k-2scd  →  identifier  →  wckm-y5a4-he0k-2scd\n",
-      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  N44979483946e425f887cef5e3f9134f2\n",
+      "  wckm-y5a4-he0k-2scd  →  manufacturer  →  Nf36ae79fbab44968ad20e859ddab2f52\n",
+      "  wckm-y5a4-he0k-2scd  →  model  →  ANR26650M1-B\n",
       "  wckm-y5a4-he0k-2scd  →  name  →  A123 Systems ANR26650M1-B\n",
+      "  wckm-y5a4-he0k-2scd  →  schemaVersion  →  0.2.0\n",
       "  wckm-y5a4-he0k-2scd  →  size  →  R26650\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N07cdc0617df84fbe9e02d1cff8d9e701\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N28e0a161800143c981375372093718b6\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N33b5d583f88a4d65a4e93a71d09f081e\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N435d98ae0cc64ecc8b665a1444ad5fe3\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Na934dcb544974fbdad44fcd67e1e0ff9\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nd126b9badbd84f6d965e2d3a4374566e\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ne23472f95c9641cc8f621daeaa2d48dc\n",
-      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nffaf996e61ce486cb4deebda0a828514\n"
+      "  wckm-y5a4-he0k-2scd  →  url  →  wckm-y5a4-he0k-2scd\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N17512a3d69ce42bc8c8876895f384945\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N3c2928aa56964472bc9dc8aa9ce3b028\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  N6ad0ab45ef7747a49487043cedb98b26\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nb149a30267e04993af97e97151321385\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nb1e82112708742b6aa9b92682d84bc46\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nc6a33b982e0340b0a4d014a511271796\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Ncf1ad6f58b0b4b0988118f5a3c9886a3\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_e1097637_70d2_4895_973f_2396f04fa204  →  Nf28b2a2f9b7047c8a44839a58413b7a2\n",
+      "  wckm-y5a4-he0k-2scd  →  EMMO_f702bad4_fc77_41f0_a26d_79f6444fd4f3  →  Nfc7a667b073a4662adc42655527a4dc6\n"
      ]
     }
    ],
@@ -588,10 +627,10 @@
    "id": "f05bb577",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:05.027155Z",
-     "iopub.status.busy": "2026-07-08T08:59:05.027155Z",
-     "iopub.status.idle": "2026-07-08T08:59:07.414035Z",
-     "shell.execute_reply": "2026-07-08T08:59:07.414035Z"
+     "iopub.execute_input": "2026-07-08T19:11:18.816853Z",
+     "iopub.status.busy": "2026-07-08T19:11:18.816853Z",
+     "iopub.status.idle": "2026-07-08T19:11:20.182531Z",
+     "shell.execute_reply": "2026-07-08T19:11:20.181518Z"
     }
    },
    "outputs": [
@@ -612,7 +651,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Combined graph: 20 triples from 2 files\n"
+      "Combined graph: 33 triples from 2 files\n"
      ]
     }
    ],
@@ -669,10 +708,10 @@
    "id": "97dfdfc6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:07.419792Z",
-     "iopub.status.busy": "2026-07-08T08:59:07.417781Z",
-     "iopub.status.idle": "2026-07-08T08:59:07.427731Z",
-     "shell.execute_reply": "2026-07-08T08:59:07.427731Z"
+     "iopub.execute_input": "2026-07-08T19:11:20.184524Z",
+     "iopub.status.busy": "2026-07-08T19:11:20.184524Z",
+     "iopub.status.idle": "2026-07-08T19:11:20.190596Z",
+     "shell.execute_reply": "2026-07-08T19:11:20.190596Z"
     }
    },
    "outputs": [

--- a/docs/guides/05-descriptors.ipynb
+++ b/docs/guides/05-descriptors.ipynb
@@ -21,10 +21,10 @@
    "id": "1cf55ef0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:15.667774Z",
-     "iopub.status.busy": "2026-07-08T08:59:15.666778Z",
-     "iopub.status.idle": "2026-07-08T08:59:15.678309Z",
-     "shell.execute_reply": "2026-07-08T08:59:15.677301Z"
+     "iopub.execute_input": "2026-07-08T19:11:27.986358Z",
+     "iopub.status.busy": "2026-07-08T19:11:27.986358Z",
+     "iopub.status.idle": "2026-07-08T19:11:27.994552Z",
+     "shell.execute_reply": "2026-07-08T19:11:27.993547Z"
     }
    },
    "outputs": [],
@@ -52,10 +52,10 @@
    "id": "ddcca263",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:15.682310Z",
-     "iopub.status.busy": "2026-07-08T08:59:15.682310Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.120436Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.118920Z"
+     "iopub.execute_input": "2026-07-08T19:11:27.997551Z",
+     "iopub.status.busy": "2026-07-08T19:11:27.997551Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.283320Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.283320Z"
     }
    },
    "outputs": [
@@ -101,10 +101,10 @@
    "id": "4b04c30f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.126958Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.125981Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.136698Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.135692Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.285368Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.285368Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.292245Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.291223Z"
     }
    },
    "outputs": [
@@ -141,10 +141,10 @@
    "id": "38095956",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.139698Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.139698Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.146961Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.146961Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.294278Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.294278Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.298637Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.298637Z"
     }
    },
    "outputs": [
@@ -195,10 +195,10 @@
    "id": "3fcb31b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.146961Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.146961Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.157330Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.157330Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.301643Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.301643Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.307906Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.306899Z"
     }
    },
    "outputs": [
@@ -250,10 +250,10 @@
    "id": "7e673ceb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.162055Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.160542Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.168846Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.168846Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.309904Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.309904Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.315240Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.315240Z"
     }
    },
    "outputs": [
@@ -296,10 +296,10 @@
    "id": "70bef49a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.172288Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.172288Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.179433Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.179433Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.318451Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.317450Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.322468Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.322468Z"
     }
    },
    "outputs": [
@@ -338,10 +338,10 @@
    "id": "b6297d58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.182342Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.182342Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.190415Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.190415Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.325494Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.324474Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.328846Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.328846Z"
     }
    },
    "outputs": [
@@ -383,10 +383,10 @@
    "id": "f9d5ffe7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.192430Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.192430Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.202124Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.201093Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.331851Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.331851Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.338317Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.337311Z"
     }
    },
    "outputs": [
@@ -452,10 +452,10 @@
    "id": "85a1b7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.202124Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.202124Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.213149Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.213149Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.340317Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.340317Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.348575Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.347562Z"
     }
    },
    "outputs": [
@@ -505,10 +505,10 @@
    "id": "0c953dd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.213149Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.213149Z",
-     "iopub.status.idle": "2026-07-08T08:59:16.223425Z",
-     "shell.execute_reply": "2026-07-08T08:59:16.223425Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.351568Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.350569Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.358085Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.358085Z"
     }
    },
    "outputs": [
@@ -546,10 +546,10 @@
    "id": "cc431ddd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:16.227728Z",
-     "iopub.status.busy": "2026-07-08T08:59:16.227728Z",
-     "iopub.status.idle": "2026-07-08T08:59:17.182946Z",
-     "shell.execute_reply": "2026-07-08T08:59:17.182946Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.361508Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.361508Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.902387Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.901379Z"
     }
    },
    "outputs": [
@@ -585,10 +585,10 @@
    "id": "6cc0a7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:17.182946Z",
-     "iopub.status.busy": "2026-07-08T08:59:17.182946Z",
-     "iopub.status.idle": "2026-07-08T08:59:17.196681Z",
-     "shell.execute_reply": "2026-07-08T08:59:17.196681Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.906684Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.905687Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.913724Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.912716Z"
     }
    },
    "outputs": [
@@ -1053,10 +1053,10 @@
    "id": "1b0ac8c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:17.200708Z",
-     "iopub.status.busy": "2026-07-08T08:59:17.200708Z",
-     "iopub.status.idle": "2026-07-08T08:59:17.292099Z",
-     "shell.execute_reply": "2026-07-08T08:59:17.290575Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.916723Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.915726Z",
+     "iopub.status.idle": "2026-07-08T19:11:28.985175Z",
+     "shell.execute_reply": "2026-07-08T19:11:28.983166Z"
     }
    },
    "outputs": [
@@ -1096,10 +1096,10 @@
    "id": "8e638265",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:17.297044Z",
-     "iopub.status.busy": "2026-07-08T08:59:17.297044Z",
-     "iopub.status.idle": "2026-07-08T08:59:17.916811Z",
-     "shell.execute_reply": "2026-07-08T08:59:17.916811Z"
+     "iopub.execute_input": "2026-07-08T19:11:28.991174Z",
+     "iopub.status.busy": "2026-07-08T19:11:28.990173Z",
+     "iopub.status.idle": "2026-07-08T19:11:29.404967Z",
+     "shell.execute_reply": "2026-07-08T19:11:29.404462Z"
     }
    },
    "outputs": [
@@ -1129,10 +1129,10 @@
    "id": "e7e19b64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:17.916811Z",
-     "iopub.status.busy": "2026-07-08T08:59:17.916811Z",
-     "iopub.status.idle": "2026-07-08T08:59:18.036852Z",
-     "shell.execute_reply": "2026-07-08T08:59:18.035335Z"
+     "iopub.execute_input": "2026-07-08T19:11:29.407973Z",
+     "iopub.status.busy": "2026-07-08T19:11:29.406973Z",
+     "iopub.status.idle": "2026-07-08T19:11:29.489487Z",
+     "shell.execute_reply": "2026-07-08T19:11:29.489487Z"
     }
    },
    "outputs": [

--- a/docs/guides/06-publish-your-data.ipynb
+++ b/docs/guides/06-publish-your-data.ipynb
@@ -30,10 +30,10 @@
    "id": "e43cee13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:27.288959Z",
-     "iopub.status.busy": "2026-07-08T08:59:27.285873Z",
-     "iopub.status.idle": "2026-07-08T08:59:28.063271Z",
-     "shell.execute_reply": "2026-07-08T08:59:28.063271Z"
+     "iopub.execute_input": "2026-07-08T19:11:34.399431Z",
+     "iopub.status.busy": "2026-07-08T19:11:34.398400Z",
+     "iopub.status.idle": "2026-07-08T19:11:34.762517Z",
+     "shell.execute_reply": "2026-07-08T19:11:34.762517Z"
     }
    },
    "outputs": [],
@@ -75,10 +75,10 @@
    "id": "e2c1ddca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:28.067209Z",
-     "iopub.status.busy": "2026-07-08T08:59:28.067209Z",
-     "iopub.status.idle": "2026-07-08T08:59:30.713245Z",
-     "shell.execute_reply": "2026-07-08T08:59:30.713245Z"
+     "iopub.execute_input": "2026-07-08T19:11:34.765523Z",
+     "iopub.status.busy": "2026-07-08T19:11:34.765523Z",
+     "iopub.status.idle": "2026-07-08T19:11:36.217944Z",
+     "shell.execute_reply": "2026-07-08T19:11:36.216937Z"
     }
    },
    "outputs": [
@@ -120,10 +120,10 @@
    "id": "c7d97399",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:30.718093Z",
-     "iopub.status.busy": "2026-07-08T08:59:30.717095Z",
-     "iopub.status.idle": "2026-07-08T08:59:32.402197Z",
-     "shell.execute_reply": "2026-07-08T08:59:32.400551Z"
+     "iopub.execute_input": "2026-07-08T19:11:36.220986Z",
+     "iopub.status.busy": "2026-07-08T19:11:36.220986Z",
+     "iopub.status.idle": "2026-07-08T19:11:37.723857Z",
+     "shell.execute_reply": "2026-07-08T19:11:37.723857Z"
     }
    },
    "outputs": [
@@ -173,10 +173,10 @@
    "id": "d9a22b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:32.405381Z",
-     "iopub.status.busy": "2026-07-08T08:59:32.405381Z",
-     "iopub.status.idle": "2026-07-08T08:59:32.420581Z",
-     "shell.execute_reply": "2026-07-08T08:59:32.420581Z"
+     "iopub.execute_input": "2026-07-08T19:11:37.726915Z",
+     "iopub.status.busy": "2026-07-08T19:11:37.726915Z",
+     "iopub.status.idle": "2026-07-08T19:11:37.737981Z",
+     "shell.execute_reply": "2026-07-08T19:11:37.736974Z"
     }
    },
    "outputs": [
@@ -191,7 +191,7 @@
     {
      "data": {
       "text/plain": [
-       "[Test(schema_version='0.2.0', kind='Test', id=None, name='S1 cycling', test_type=<BatteryTestType.CYCLING: 'cycling'>, protocol_id=None, cell_instance_id=None, description=None, status='completed', protocol=ProtocolInfo(name='cycling', url=None), instrument=None, started_at=None, ended_at=None, dataset_ids=[], conformance=None, artifacts=[], source=ProvenanceInfo(type='measurement', name=None, file=None, url=None, citation=None, retrieved_at=None, workflow_version=None, file_hash=None, curated_by=None, comment=None, battinfo_version=None), comment=[])]"
+       "[Test(schema_version='0.2.0', kind='Test', id=None, name='S1 cycling', test_type=<BatteryTestType.CYCLING: 'cycling'>, protocol_id=None, cell_instance_id=None, description=None, status='completed', protocol=ProtocolInfo(name='cycling', url=None), instrument=None, equipment_id=None, channel_id=None, started_at=None, ended_at=None, dataset_ids=[], conformance=None, artifacts=[], source=ProvenanceInfo(type='measurement', name=None, file=None, url=None, citation=None, retrieved_at=None, workflow_version=None, file_hash=None, curated_by=None, comment=None, battinfo_version=None), comment=[])]"
       ]
      },
      "execution_count": 4,
@@ -221,10 +221,10 @@
    "id": "241ee167",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:32.424103Z",
-     "iopub.status.busy": "2026-07-08T08:59:32.424103Z",
-     "iopub.status.idle": "2026-07-08T08:59:33.089708Z",
-     "shell.execute_reply": "2026-07-08T08:59:33.088689Z"
+     "iopub.execute_input": "2026-07-08T19:11:37.740011Z",
+     "iopub.status.busy": "2026-07-08T19:11:37.740011Z",
+     "iopub.status.idle": "2026-07-08T19:11:38.040081Z",
+     "shell.execute_reply": "2026-07-08T19:11:38.040081Z"
     }
    },
    "outputs": [
@@ -260,10 +260,10 @@
    "id": "03b2dfb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:33.092239Z",
-     "iopub.status.busy": "2026-07-08T08:59:33.092239Z",
-     "iopub.status.idle": "2026-07-08T08:59:33.100650Z",
-     "shell.execute_reply": "2026-07-08T08:59:33.100145Z"
+     "iopub.execute_input": "2026-07-08T19:11:38.042130Z",
+     "iopub.status.busy": "2026-07-08T19:11:38.042130Z",
+     "iopub.status.idle": "2026-07-08T19:11:38.047458Z",
+     "shell.execute_reply": "2026-07-08T19:11:38.046452Z"
     }
    },
    "outputs": [
@@ -281,7 +281,7 @@
       "...\n",
       "provenance: {\n",
       "  \"source_type\": \"measurement\",\n",
-      "  \"retrieved_at\": 1783501172,\n",
+      "  \"retrieved_at\": 1783537897,\n",
       "  \"battinfo_version\": \"0.7.0\"\n",
       "}\n"
      ]
@@ -320,10 +320,10 @@
    "id": "5e115f9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T08:59:33.103163Z",
-     "iopub.status.busy": "2026-07-08T08:59:33.103163Z",
-     "iopub.status.idle": "2026-07-08T08:59:33.109129Z",
-     "shell.execute_reply": "2026-07-08T08:59:33.108122Z"
+     "iopub.execute_input": "2026-07-08T19:11:38.049459Z",
+     "iopub.status.busy": "2026-07-08T19:11:38.048457Z",
+     "iopub.status.idle": "2026-07-08T19:11:38.052845Z",
+     "shell.execute_reply": "2026-07-08T19:11:38.052845Z"
     }
    },
    "outputs": [

--- a/src/battinfo/api/_resolver.py
+++ b/src/battinfo/api/_resolver.py
@@ -26,7 +26,7 @@ from battinfo.api._shared import (
     _validate_canonical_record,
     _validate_publication_artifact,
 )
-from battinfo.transform.json_to_jsonld import _descriptor_quantity_node as _jsonld_quantity_node
+from battinfo.transform.cell_spec_node import build_cell_spec_node
 from battinfo.validate.core import DEFAULT_POLICY, ValidationPolicy
 
 
@@ -332,49 +332,21 @@ def _resolver_jsonld(doc: dict[str, Any]) -> dict[str, Any]:
     _, uid = _iri_tail(entity_iri)
     entity_type = _logical_entity_type_from_doc(doc)
     # csvw: is used by _schema_main_entity_value helpers called from the dataset block.
+    # battinfo: is the fallback-term prefix used by unmapped-property quantity nodes
+    # (dcterms:/prov: for the provenance node already resolve via the remote context).
     context = [
         "https://w3id.org/emmo/domain/battery/context",
         {
             "schema": "https://schema.org/",
             "csvw": "http://www.w3.org/ns/csvw#",
+            "battinfo": "https://w3id.org/battinfo/",
         },
     ]
 
     if entity_type == "cell-spec":
-        cell = doc.get("cell_spec")
-        if not isinstance(cell, Mapping):
-            cell = doc["cell_spec"]
-        manufacturer = cell.get("manufacturer")
-        if isinstance(manufacturer, Mapping):
-            manufacturer_name = manufacturer.get("name")
-        else:
-            manufacturer_name = manufacturer
-        out: dict[str, Any] = {
-            "@context": context,
-            "@id": entity_iri,
-            "@type": ["BatteryCellSpecification", "schema:CreativeWork"],
-            "schema:identifier": uid,
-            "schema:name": cell.get("name") or cell.get("model") or cell.get("model_name"),
-            "schema:manufacturer": {"@type": "schema:Organization", "schema:name": manufacturer_name},
-        }
-        product_type = cell.get("product_type") or cell.get("product_type")
-        if product_type:
-            out["schema:additionalType"] = str(product_type)
-        size_code = cell.get("size_code") or cell.get("size_code")
-        if size_code:
-            out["schema:size"] = size_code
-        # Quantitative specifications as EMMO ConventionalProperty nodes.
-        # Chemistry and format are already expressed through @type stacking.
-        specs = doc.get("properties") or {}
-        if isinstance(specs, Mapping):
-            prop_nodes = [
-                node
-                for key, value in specs.items()
-                if isinstance(value, Mapping)
-                if (node := _jsonld_quantity_node(key, value)) is not None
-            ]
-            if prop_nodes:
-                out["hasProperty"] = prop_nodes
+        # Shared canonical builder — the same node the Zenodo/local publication
+        # graph emits, so resolver and package spec nodes are byte-identical.
+        out: dict[str, Any] = {"@context": context, **build_cell_spec_node(doc)}
         return out
 
     if entity_type == "cell":

--- a/src/battinfo/transform/cell_spec_node.py
+++ b/src/battinfo/transform/cell_spec_node.py
@@ -1,0 +1,342 @@
+"""Canonical BatteryCellSpecification JSON-LD node builder (emitter convergence).
+
+One builder produces the cell-spec node used by BOTH publication emitters:
+
+- the resolver artifact path (``battinfo.api`` ``publish_record`` -> ``index.jsonld``)
+- the Zenodo / local publication graph (``AuthoringWorkspace._assemble_zenodo_jsonld``
+  and ``publication.build_publication_package``)
+
+so the two paths emit byte-identical spec nodes for the same canonical record.
+
+The node shape is the canonical target shape:
+
+- ``@type: ["BatteryCellSpecification", "schema:CreativeWork"]`` — the spec is an
+  information artifact, not a physical battery.
+- ``isDescriptionFor.@type`` carries the physical EMMO class stack derived from the
+  descriptors (format / chemistry / electrode bases / IEC code / rechargeable) via
+  ``entity_type_map.json`` — chemistry and format are expressed through @type
+  stacking, not as literal predicates.
+- Quantities use the EMMO ``hasProperty`` pattern via
+  :func:`battinfo.transform.json_to_jsonld._descriptor_quantity_node`
+  (list ``@type`` of ``[PropertyClass, co-type]``, ``hasNumericalPart`` typed
+  ``RealData``, ``hasMeasurementUnit`` as a bare unit IRI).
+- Provenance uses standard vocabularies only (dcterms / PROV-O) — no new
+  ``battinfo:`` terms are minted.
+"""
+from __future__ import annotations
+
+import json
+import warnings
+from functools import lru_cache
+from importlib import resources
+from typing import Any, Mapping
+
+from battinfo.transform.json_to_jsonld import (
+    _descriptor_quantity_node,
+    _entity_mapping,
+    _epoch_to_iso8601,
+    _load_mapping_file,
+    _property_type_map,
+    _property_type_term,
+)
+
+# Public registry page for a cell spec (human-resolvable mirror of the IRI).
+REGISTRY_SPEC_URL_BASE = "https://www.battery-genome.org/registry/spec/"
+
+_COMPACT_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("battery:", "https://w3id.org/emmo/domain/battery#"),
+    ("electrochemistry:", "https://w3id.org/emmo/domain/electrochemistry#"),
+    ("emmo:", "https://w3id.org/emmo#"),
+)
+
+
+def compact_iri(iri: str) -> str:
+    """Shorten a full EMMO-family IRI to its compact (prefixed) form."""
+    for prefix, base in _COMPACT_PREFIXES:
+        if iri.startswith(base):
+            return prefix + iri[len(base):]
+    return iri
+
+
+@lru_cache(maxsize=1)
+def _domain_battery_context() -> dict[str, Any]:
+    """The bundled copy of the https://w3id.org/emmo/domain/battery/context terms."""
+    path = resources.files("battinfo").joinpath("data", "context", "domain-battery.context.json")
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    context = data.get("@context", data)
+    return context if isinstance(context, dict) else {}
+
+
+# Core classes emitted by the builders whose prefLabels must resolve in an inline
+# (records) context.  The kept static table mirrors the table formerly maintained
+# inline in AuthoringWorkspace._assemble_zenodo_jsonld.
+_STATIC_LABEL_TO_COMPACT: dict[str, str] = {
+    "BatteryTest":             "battery:battery_dca7729a_421a_4921_90cf_9692bb9eb081",
+    "BatteryCell":             "battery:battery_68ed592a_7924_45d0_a108_94d6275d57f0",
+    "BatteryCellSpecification": "battery:battery_1cfbba6c_8824_4932_a23e_2141483acef7",
+    "CylindricalBattery":      "battery:battery_ac604ecd_cc60_4b98_b57c_74cd5d3ccd40",
+    "PrismaticBattery":        "battery:battery_86c9ca80_de6f_417f_afdc_a7e52fa6322d",
+    "PouchCell":               "battery:battery_392b3f47_d62a_4bd4_a819_b58b09b8843a",
+    "CoinCell":                "battery:battery_b7fdab58_6e91_4c84_b097_b06eff86a124",
+    "LithiumIonBattery":                   "battery:battery_96addc62_ea04_449a_8237_4cd541dd8e5f",
+    "LithiumMetalBattery":                 "battery:battery_ada13509_4eed_4e40_a7b1_4cc488144154",
+    "SodiumIonBattery":                    "battery:battery_42329a95_03fe_4ec1_83cb_b7e8ed52f68a",
+    "AlkalineZincManganeseDioxideBattery": "battery:battery_b572826a_b4e4_4986_b57d_f7b945061f8b",
+    "AlkalineCell":                        "battery:battery_50b911f7_c903_4700_9764_c308d8a95470",
+    "PrimaryBattery":                      "battery:battery_3b0b0d6e_8b0e_4491_885e_8421d3eb3b69",
+    "SecondaryBattery":                    "battery:battery_efc38420_ecbb_42e4_bb3f_208e7c417098",
+    # IEC standard size codes — subclasses already defined in domain-battery
+    "LR03":   "battery:battery_a5299801_2a8d_4d03_a476_ca2c5e9ca702",  # AAA alkaline
+    "LR6":    "battery:battery_6b2540b9_5af6_478a_81ae_583db9636db8",  # AA alkaline
+    "LR14":   "battery:battery_d00e842e_ee0b_4e25_bd17_d64d76d69730",  # C alkaline
+    "LR20":   "battery:battery_0c9979c2_c981_48ea_a8e1_72bdcb58fd58",  # D alkaline
+    "LR1":    "battery:battery_1c0306f5_5698_4874_b6ce_e5cc45a46b91",  # N alkaline
+    "CR2032": "battery:battery_b61b96ac_f2f4_4b74_82d5_565fe3a2d88b",  # coin
+    "CR2025": "battery:battery_9984642f_c9dc_4b98_94f6_6ffe20cfc014",  # coin
+    "LR44":   "battery:battery_d10ff656_f9fd_4b0e_9de9_4812a44ea359",  # button
+    "HR6":    "battery:battery_a71a4bf2_dee6_4aa4_8ad4_9f38c261fb84",  # AA NiMH
+    "KR6":    "battery:battery_ad7c1d81_9a9f_4174_88ea_3ba3e8f4dbe2",  # AA NiCd
+}
+
+# Structure / co-type terms emitted by the shared quantity-node builder that are
+# not part of the records context; resolved from the bundled domain-battery context.
+_EXTRA_CONTEXT_TERMS: tuple[str, ...] = (
+    "RealData",
+    "ConventionalProperty",
+    "MeasuredProperty",
+    "NominalProperty",
+    "hasMeasurementParameter",
+)
+
+
+@lru_cache(maxsize=1)
+def label_to_compact() -> dict[str, Any]:
+    """prefLabel/term -> compact-IRI table for inline JSON-LD contexts.
+
+    Combines (in order): the static core-class table, curated property-class
+    prefLabels, curated unit prefLabels, every ``entity_type_map.json``
+    ``battery_types`` class resolvable in the bundled domain-battery context, and
+    the quantity-node structure terms (``RealData`` etc.).
+
+    Used both to extend the inline publication context and as the "is this class
+    context-mappable?" filter for :func:`physical_type_stack`.
+    """
+    table: dict[str, Any] = dict(_STATIC_LABEL_TO_COMPACT)
+    for m in _load_mapping_file("property_map.curated.json").get("mappings", []):
+        if m.get("class_iri") and m.get("class_pref_label"):
+            table[m["class_pref_label"]] = compact_iri(m["class_iri"])
+    for m in _load_mapping_file("unit_map.curated.json").get("mappings", []):
+        if m.get("symbol") and m.get("unit_iri") and m.get("unit_pref_label"):
+            table[m["unit_pref_label"]] = compact_iri(m["unit_iri"])
+    db_context = _domain_battery_context()
+
+    def _resolve(term: str) -> None:
+        if term in table:
+            return
+        value = db_context.get(term)
+        if isinstance(value, str):
+            table[term] = compact_iri(value)
+        elif isinstance(value, Mapping) and isinstance(value.get("@id"), str):
+            resolved = dict(value)
+            resolved["@id"] = compact_iri(resolved["@id"])
+            table[term] = resolved
+
+    for section in _load_mapping_file("entity_type_map.json").get("mappings", {}).values():
+        if not isinstance(section, Mapping):
+            continue
+        for entry in section.values():
+            if not isinstance(entry, Mapping):
+                continue
+            for battery_type in entry.get("battery_types", []):
+                if isinstance(battery_type, str):
+                    _resolve(battery_type)
+    for term in _EXTRA_CONTEXT_TERMS:
+        _resolve(term)
+    return table
+
+
+def physical_type_stack(cell_spec: Mapping[str, Any]) -> list[str]:
+    """domain-battery class prefLabels describing the physical cell for a spec.
+
+    entity_type_map-driven: format, chemistry, positive/negative electrode basis
+    and IEC code each contribute their ``battery_types``; ``rechargeable`` maps to
+    SecondaryBattery / PrimaryBattery. Only classes that are context-mappable
+    (present in :func:`label_to_compact`) are kept, so every emitted ``@type``
+    resolves in both the remote and the inline publication contexts.
+    """
+    table = label_to_compact()
+    types: list[str] = []
+    for section, key in (
+        ("format", cell_spec.get("cell_format")),
+        ("chemistry", cell_spec.get("chemistry")),
+        ("positive_electrode_basis", cell_spec.get("positive_electrode_basis")),
+        ("negative_electrode_basis", cell_spec.get("negative_electrode_basis")),
+        ("iec_code", cell_spec.get("iec_code")),
+    ):
+        entry = _entity_mapping(section, key) or {}
+        for battery_type in entry.get("battery_types", []):
+            if battery_type not in types and battery_type in table:
+                types.append(battery_type)
+    if not types:
+        types.append("BatteryCell")
+    rechargeable = cell_spec.get("rechargeable")
+    if rechargeable is True and "SecondaryBattery" not in types:
+        types.append("SecondaryBattery")
+    elif rechargeable is False and "PrimaryBattery" not in types:
+        types.append("PrimaryBattery")
+    return types
+
+
+def provenance_node(provenance: Any) -> dict[str, Any] | None:
+    """A record ``provenance`` block -> a standard-vocabulary provenance node.
+
+    Standard terms only (no minted ``battinfo:`` predicates): source_type ->
+    ``dcterms:type``, source_url -> ``prov:hadPrimarySource``, retrieved_at ->
+    ``prov:generatedAtTime`` (ISO-8601), citation -> ``dcterms:bibliographicCitation``.
+    Returns ``None`` when there is nothing to emit.
+    """
+    if not isinstance(provenance, Mapping):
+        return None
+    node: dict[str, Any] = {"@type": "prov:Entity"}
+    if provenance.get("source_type"):
+        node["dcterms:type"] = provenance["source_type"]
+    if provenance.get("source_url"):
+        node["prov:hadPrimarySource"] = {"@id": provenance["source_url"]}
+    retrieved_at = provenance.get("retrieved_at")
+    retrieved_iso = _epoch_to_iso8601(retrieved_at)
+    if retrieved_iso is not None:
+        node["prov:generatedAtTime"] = retrieved_iso
+    elif isinstance(retrieved_at, str) and retrieved_at:
+        node["prov:generatedAtTime"] = retrieved_at
+    if provenance.get("citation"):
+        node["dcterms:bibliographicCitation"] = provenance["citation"]
+    return node if len(node) > 1 else None
+
+
+def cell_spec_property_nodes(
+    properties: Any, *, context_label: str = ""
+) -> list[dict[str, Any]]:
+    """EMMO ``hasProperty`` nodes for a cell-spec ``properties`` mapping.
+
+    Emits the shared quantity-node shape and warns (never silently) at the two
+    lossy edges: a key without a curated EMMO mapping is emitted with a
+    non-canonical ``battinfo:`` fallback term (``semantic.property_unmapped``),
+    and a quantity carrying only ``value_text`` emits no numeric part
+    (``semantic.value_text_only``).
+    """
+    nodes: list[dict[str, Any]] = []
+    if not isinstance(properties, Mapping):
+        return nodes
+    where = f" on {context_label}" if context_label else ""
+    for key, quantity in properties.items():
+        if not isinstance(quantity, Mapping):
+            continue
+        if key not in _property_type_map():
+            warnings.warn(
+                f"semantic.property_unmapped: '{key}'{where} has no curated EMMO "
+                f"mapping - it is emitted with the non-canonical fallback term "
+                f"'{_property_type_term(str(key))}' in the exported JSON-LD and will "
+                "not survive a round-trip import. File a mapping in "
+                "assets/mappings/domain-battery/property_map.curated.json.",
+                stacklevel=2,
+            )
+        has_number = any(
+            isinstance(quantity.get(field), (int, float)) and not isinstance(quantity.get(field), bool)
+            for field in ("value", "typical_value")
+        )
+        if not has_number and isinstance(quantity.get("value_text"), str):
+            warnings.warn(
+                f"semantic.value_text_only: '{key}'{where} carries only value_text - "
+                "the JSON-LD export emits no numeric quantity value for it.",
+                stacklevel=2,
+            )
+        node = _descriptor_quantity_node(
+            str(key), quantity if isinstance(quantity, dict) else dict(quantity)
+        )
+        if node is not None:
+            nodes.append(node)
+    return nodes
+
+
+def _iri_tail(iri: str) -> str:
+    return iri.rstrip("/").split("/")[-1] if iri else ""
+
+
+def build_cell_spec_node(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the canonical BatteryCellSpecification JSON-LD node for a record.
+
+    ``record`` is a canonical on-disk cell-spec record dict (``cell_spec`` +
+    ``properties`` + ``provenance``). Returns the node WITHOUT an ``@context``;
+    callers wrap it (resolver) or place it into a ``@graph`` (publication package).
+    """
+    cell = record.get("cell_spec")
+    if not isinstance(cell, Mapping):
+        cell = {}
+    iri = cell.get("id") or ""
+    tail = _iri_tail(str(iri))
+    manufacturer = cell.get("manufacturer")
+    manufacturer_name = (
+        manufacturer.get("name") if isinstance(manufacturer, Mapping) else manufacturer
+    )
+
+    node: dict[str, Any] = {
+        "@type": ["BatteryCellSpecification", "schema:CreativeWork"],
+    }
+    if iri:
+        node["@id"] = iri
+    if tail:
+        node["schema:identifier"] = tail
+    name = cell.get("name") or cell.get("model") or cell.get("model_name")
+    if name:
+        node["schema:name"] = name
+    if cell.get("model"):
+        node["schema:model"] = cell["model"]
+    if manufacturer_name:
+        node["schema:manufacturer"] = {
+            "@type": "schema:Organization",
+            "schema:name": manufacturer_name,
+        }
+    if tail:
+        node["schema:url"] = f"{REGISTRY_SPEC_URL_BASE}{tail}"
+    # isDescriptionFor links the spec (an information artifact) to an anonymous
+    # individual of the correct physical battery type. Chemistry, format,
+    # electrode bases and rechargeability are expressed through this @type stack.
+    physical_types = physical_type_stack(cell)
+    node["isDescriptionFor"] = {
+        "@type": physical_types if len(physical_types) > 1 else physical_types[0],
+    }
+    if cell.get("size_code"):
+        node["schema:size"] = cell["size_code"]
+    if cell.get("iec_code"):
+        node["schema:productID"] = cell["iec_code"]
+    if cell.get("product_type"):
+        node["schema:additionalType"] = str(cell["product_type"])
+    brand = cell.get("brand")
+    brand_name = brand.get("name") if isinstance(brand, Mapping) else brand
+    if isinstance(brand_name, str) and brand_name:
+        node["schema:brand"] = {"@type": "schema:Brand", "schema:name": brand_name}
+    category = cell.get("battery_category") or cell.get("category")
+    if isinstance(category, str) and category:
+        node["schema:category"] = category
+    if cell.get("country_of_origin"):
+        node["schema:countryOfOrigin"] = {
+            "@type": "schema:Country",
+            "schema:name": cell["country_of_origin"],
+        }
+    if cell.get("year"):
+        node["schema:releaseDate"] = f"{cell['year']}-01-01"
+    schema_version = record.get("schema_version") or cell.get("schema_version")
+    if schema_version:
+        node["schema:schemaVersion"] = schema_version
+
+    property_nodes = cell_spec_property_nodes(
+        record.get("properties"), context_label=str(iri or name or "cell-spec")
+    )
+    if property_nodes:
+        node["hasProperty"] = property_nodes
+
+    prov = provenance_node(record.get("provenance"))
+    if prov is not None:
+        node["dcterms:source"] = prov
+    return node

--- a/src/battinfo/validate/jsonld.py
+++ b/src/battinfo/validate/jsonld.py
@@ -96,6 +96,10 @@ _EXPLICIT_ALLOWED_TYPE_TERMS = {
     "ConstantVoltageDischarging",
     "ElectrochemicalTestingProcedure",
     "Resting",
+    # Rechargeability classes (from the cell-spec `rechargeable` flag; not part of
+    # the entity_type_map sections, so listed explicitly)
+    "PrimaryBattery",
+    "SecondaryBattery",
     # New in domain-battery 0.19.0
     "BatterySpecification",
     "BatteryCellSpecification",

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -2593,6 +2593,18 @@ class AuthoringWorkspace:
                     rev_prop[iri] = key
 
         rev_unit: dict[str, str] = {v: k for k, v in _UNIT_MAP.items()}
+        # The shared quantity-node builder resolves units through the curated /
+        # candidate unit maps as well, so reverse those too (first symbol wins;
+        # _UNIT_MAP symbols take precedence for stability with older files).
+        for _unit_file in ("unit_map.curated.json", "unit_map.candidates.json"):
+            _unit_path = Path(__file__).parent / "data" / "mappings" / "domain-battery" / _unit_file
+            if _unit_path.exists():
+                for m in json.loads(_unit_path.read_text(encoding="utf-8")).get("mappings", []):
+                    if m.get("unit_iri") and m.get("symbol"):
+                        rev_unit.setdefault(m["unit_iri"], m["symbol"])
+        from battinfo.transform.json_to_jsonld import MANUAL_UNIT_TYPES as _MANUAL_UNIT_TYPES
+        for _sym, _iri in _MANUAL_UNIT_TYPES.items():
+            rev_unit.setdefault(_iri, _sym)
 
         # Build chemistry value reverse map (IRI → original-case chemistry string)
         # so the reconstructed records match the source exactly.
@@ -2624,16 +2636,34 @@ class AuthoringWorkspace:
             return d
 
         def _specs_from_property_nodes(nodes: list) -> dict:
-            """Reverse EMMO hasProperty nodes → {key: {value, unit}}."""
+            """Reverse EMMO hasProperty nodes → {key: {value, unit}}.
+
+            Accepts both quantity-node generations: the legacy single-string
+            ``@type`` with a ``{"@id": ...}`` unit reference, and the canonical
+            shape (list ``@type`` of ``[PropertyClass, co-type]`` with the unit
+            as a bare IRI string)."""
             specs: dict = {}
             for node in nodes:
                 type_raw = node.get("@type", "")
-                class_iri = _expand(type_raw) if isinstance(type_raw, str) else ""
-                prop_key = rev_prop.get(class_iri)
+                type_terms = (
+                    [type_raw] if isinstance(type_raw, str)
+                    else [t for t in type_raw if isinstance(t, str)] if isinstance(type_raw, list)
+                    else []
+                )
+                prop_key = next(
+                    (key for term in type_terms if (key := rev_prop.get(_expand(term)))),
+                    None,
+                )
                 if not prop_key:
                     continue
                 value = (node.get("hasNumericalPart") or {}).get("hasNumberValue", (node.get("hasNumericalPart") or {}).get("hasNumericalValue"))
-                unit_term = (node.get("hasMeasurementUnit") or {}).get("@id", "")
+                unit_raw = node.get("hasMeasurementUnit")
+                if isinstance(unit_raw, str):
+                    unit_term = unit_raw
+                elif isinstance(unit_raw, dict):
+                    unit_term = unit_raw.get("@id", "")
+                else:
+                    unit_term = ""
                 unit_iri  = _expand(unit_term)
                 unit_sym  = rev_unit.get(unit_iri, unit_term.split(":")[-1])
                 if value is not None:
@@ -2681,14 +2711,22 @@ class AuthoringWorkspace:
             mfr_name  = mfr_node.get("schema:name", "") if isinstance(mfr_node, dict) else str(mfr_node)
             specs = _specs_from_property_nodes(node.get("hasProperty", []))
 
+            # size_code: the canonical shape emits it as schema:size; older
+            # packages used schema:identifier. In the canonical shape
+            # schema:identifier carries the record uid (the IRI tail) instead,
+            # so ignore it as a size code when it matches the tail.
+            _ident = node.get("schema:identifier")
+            if isinstance(_ident, str) and _ident == iri.rstrip("/").split("/")[-1]:
+                _ident = None
             ct = self._ws.cell_spec(
                 manufacturer=mfr_name,
                 model=node.get("schema:model", ""),
-                # Use verbatim strings if present, else fall back to reverse-mapped values
+                # Use verbatim strings if present (legacy packages), else fall
+                # back to values reverse-mapped from the isDescriptionFor @type stack.
                 format=node.get("battinfo:cellFormat") or descriptors.get("format", ""),
                 chemistry=node.get("battinfo:chemistry") or descriptors.get("chemistry", ""),
                 iec_code=descriptors.get("iec_code") or node.get("schema:productID") or node.get("schema:gtin"),
-                size_code=node.get("schema:identifier"),
+                size_code=node.get("schema:size") or _ident,
                 specs=specs or None,
                 source_type="zenodo",
             )

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -21,6 +21,7 @@ import difflib
 import json
 import os
 import re
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -4350,7 +4351,6 @@ class AuthoringWorkspace:
         any JSON-LD tool that resolves the embedded context.
         """
         from battinfo.jsonld import (
-            _PROP_MAP,
             _UNIT_MAP,
             TEST_CONDITION_CLASS,
             TEST_CONDITION_GENERIC_CLASSES,
@@ -4377,110 +4377,24 @@ class AuthoringWorkspace:
 
         _DATA_DIR = Path(__file__).parent / "data"
 
-        # ── Load entity-type map (format / chemistry / iec_code → class names) ──
-        _entity_map_path = _DATA_DIR / "mappings" / "domain-battery" / "entity_type_map.json"
-        _entity_map: dict = {}
-        if _entity_map_path.exists():
-            _entity_map = json.loads(
-                _entity_map_path.read_text(encoding="utf-8")
-            ).get("mappings", {})
+        # Shared canonical builders (also used by the resolver artifact path, so
+        # both emitters produce byte-identical cell-spec nodes) plus the
+        # prefLabel → compact-IRI table used for inline context terms.
+        from battinfo.transform.cell_spec_node import (  # noqa: PLC0415
+            build_cell_spec_node,
+            label_to_compact,
+        )
+        from battinfo.transform.cell_spec_node import (
+            compact_iri as _compact_iri,
+        )
 
-        def _physical_types(format_val: str, chemistry_val: str, iec_val: str) -> list[str]:
-            """Return domain-battery prefLabel class names for a cell's descriptors."""
-            types: list[str] = []
-            for section, key in (
-                ("format",   format_val.lower()),
-                ("chemistry", chemistry_val.lower()),
-                ("iec_code",  iec_val.lower()),
-            ):
-                entry = _entity_map.get(section, {}).get(key, {})
-                for bt in entry.get("battery_types", []):
-                    if bt not in types and bt in _LABEL_TO_COMPACT:
-                        types.append(bt)
-            return types or ["BatteryCell"]
-
-        # ── Build prefLabel lookup tables from curated mapping files ───────────
-        # {class_iri → prefLabel}  e.g. "https://...#electrochemistry_639b..." → "NominalVoltage"
-        _iri_to_label: dict[str, str] = {}
-        _prop_json = _DATA_DIR / "mappings" / "domain-battery" / "property_map.curated.json"
+        # {unit_symbol → (unit_iri, prefLabel)} for test-condition / method-step units.
         _unit_json = _DATA_DIR / "mappings" / "domain-battery" / "unit_map.curated.json"
-        if _prop_json.exists():
-            for m in json.loads(_prop_json.read_text(encoding="utf-8")).get("mappings", []):
-                if m.get("class_iri") and m.get("class_pref_label"):
-                    _iri_to_label[m["class_iri"]] = m["class_pref_label"]
-        # {unit_symbol → (unit_iri, prefLabel)}
         _unit_label: dict[str, tuple[str, str]] = {}
         if _unit_json.exists():
             for m in json.loads(_unit_json.read_text(encoding="utf-8")).get("mappings", []):
                 if m.get("symbol") and m.get("unit_iri") and m.get("unit_pref_label"):
                     _unit_label[m["symbol"]] = (m["unit_iri"], m["unit_pref_label"])
-
-        # battery type class → prefLabel (from entity_type_map prefLabels)
-        # _FORMAT_LABEL / _CHEM_LABEL removed — now loaded from entity_type_map.json
-        # prefLabel → full compact IRI (for context terms)
-        _LABEL_TO_COMPACT: dict[str, str] = {
-            "BatteryTest":            "battery:battery_dca7729a_421a_4921_90cf_9692bb9eb081",
-            "BatteryCell":            "battery:battery_68ed592a_7924_45d0_a108_94d6275d57f0",
-            "BatteryCellSpecification":"battery:battery_1cfbba6c_8824_4932_a23e_2141483acef7",
-            "CylindricalBattery":     "battery:battery_ac604ecd_cc60_4b98_b57c_74cd5d3ccd40",
-            "PrismaticBattery":       "battery:battery_86c9ca80_de6f_417f_afdc_a7e52fa6322d",
-            "PouchCell":              "battery:battery_392b3f47_d62a_4bd4_a819_b58b09b8843a",
-            "CoinCell":               "battery:battery_b7fdab58_6e91_4c84_b097_b06eff86a124",
-            "LithiumIonBattery":                  "battery:battery_96addc62_ea04_449a_8237_4cd541dd8e5f",
-            "LithiumMetalBattery":                "battery:battery_ada13509_4eed_4e40_a7b1_4cc488144154",
-            "SodiumIonBattery":                   "battery:battery_42329a95_03fe_4ec1_83cb_b7e8ed52f68a",
-            "AlkalineZincManganeseDioxideBattery":"battery:battery_b572826a_b4e4_4986_b57d_f7b945061f8b",
-            "AlkalineCell":                       "battery:battery_50b911f7_c903_4700_9764_c308d8a95470",
-            "PrimaryBattery":                     "battery:battery_3b0b0d6e_8b0e_4491_885e_8421d3eb3b69",
-            "SecondaryBattery":                   "battery:battery_efc38420_ecbb_42e4_bb3f_208e7c417098",
-            # IEC standard size codes — subclasses already defined in domain-battery
-            "LR03":   "battery:battery_a5299801_2a8d_4d03_a476_ca2c5e9ca702",  # AAA alkaline
-            "LR6":    "battery:battery_6b2540b9_5af6_478a_81ae_583db9636db8",  # AA alkaline
-            "LR14":   "battery:battery_d00e842e_ee0b_4e25_bd17_d64d76d69730",  # C alkaline
-            "LR20":   "battery:battery_0c9979c2_c981_48ea_a8e1_72bdcb58fd58",  # D alkaline
-            "LR1":    "battery:battery_1c0306f5_5698_4874_b6ce_e5cc45a46b91",  # N alkaline
-            "CR2032": "battery:battery_b61b96ac_f2f4_4b74_82d5_565fe3a2d88b",  # coin
-            "CR2025": "battery:battery_9984642f_c9dc_4b98_94f6_6ffe20cfc014",  # coin
-            "LR44":   "battery:battery_d10ff656_f9fd_4b0e_9de9_4812a44ea359",  # button
-            "HR6":    "battery:battery_a71a4bf2_dee6_4aa4_8ad4_9f38c261fb84",  # AA NiMH
-            "KR6":    "battery:battery_ad7c1d81_9a9f_4174_88ea_3ba3e8f4dbe2",  # AA NiCd
-        }
-        # Add quantity class prefLabels → compact IRI
-        def _compact_iri(iri: str) -> str:
-            for prefix, base in (
-                ("battery:", "https://w3id.org/emmo/domain/battery#"),
-                ("electrochemistry:", "https://w3id.org/emmo/domain/electrochemistry#"),
-                ("emmo:", "https://w3id.org/emmo#"),
-            ):
-                if iri.startswith(base):
-                    return prefix + iri[len(base):]
-            return iri
-
-        for iri, label in _iri_to_label.items():
-            _LABEL_TO_COMPACT[label] = _compact_iri(iri)
-        # Add unit prefLabels → compact IRI
-        for sym, (unit_iri, unit_label) in _unit_label.items():
-            _LABEL_TO_COMPACT[unit_label] = _compact_iri(unit_iri)
-
-        def _quantity_node(prop_key: str, value: float, unit_symbol: str) -> dict | None:
-            class_iri = _PROP_MAP.get(prop_key)
-            if not class_iri:
-                return None
-            # Use prefLabel as @type (readable) — context maps it to the full IRI
-            label = _iri_to_label.get(class_iri, _compact_iri(class_iri))
-            node: dict = {
-                "@type":            label,
-                "hasNumericalPart": {"hasNumberValue": value},
-            }
-            ul = _unit_label.get(unit_symbol)
-            if ul:
-                unit_iri, _ulabel = ul
-                node["hasMeasurementUnit"] = {"@id": _compact_iri(unit_iri)}
-            elif unit_symbol:
-                mapped_iri = _UNIT_MAP.get(unit_symbol)
-                if mapped_iri:
-                    node["hasMeasurementUnit"] = {"@id": _compact_iri(mapped_iri)}
-            return node
 
         def _resolve_unit_iri(unit_symbol: str) -> str | None:
             """Symbol → compact unit IRI, across curated maps, the records context
@@ -4621,91 +4535,33 @@ class AuthoringWorkspace:
             return node
 
         # ── Load cell specs ────────────────────────────────────────────────────
+        # One canonical builder (shared with the resolver path): the physical
+        # @type stack via isDescriptionFor expresses chemistry/format (no
+        # battinfo: literals), quantities use the shared EMMO quantity-node
+        # shape, and provenance rides along as a standard-vocabulary node.
         spec_nodes: dict[str, dict] = {}
+        # chemistry/format keyword strings, collected from the records (the node
+        # no longer carries the verbatim literals).
+        _spec_keywords: set[str] = set()
         _ct_recs = record_sets.get("cell-spec", [])
         if _ct_recs:
             for raw in _ct_recs:
-                try:
-                    prod = raw.get("cell_spec", {})
-                    iri  = prod.get("id", "")
-                    if not iri:
-                        continue
-                    mfr      = prod.get("manufacturer", {})
-                    mfr_name = mfr.get("name", "") if isinstance(mfr, dict) else str(mfr)
-                    fmt      = (prod.get("cell_format") or "").lower()
-                    chem     = (prod.get("chemistry") or "").lower()
-                    short_id = iri.split("/")[-1]
-
-                    # Physical battery types — loaded from entity_type_map.json
-                    iec_code     = prod.get("iec_code", "")
-                    rechargeable = prod.get("rechargeable")
-                    physical_types = _physical_types(fmt, chem, iec_code)
-                    # rechargeable maps to SecondaryBattery / PrimaryBattery in domain-battery
-                    if rechargeable is True and "SecondaryBattery" not in physical_types:
-                        physical_types.append("SecondaryBattery")
-                    elif rechargeable is False and "PrimaryBattery" not in physical_types:
-                        physical_types.append("PrimaryBattery")
-
-                    node: dict = {
-                        # BatteryCellSpecification = a Description (information artifact),
-                        # not a physical battery — the physical individual is linked via
-                        # isDescriptionFor below, so the schema.org co-type is CreativeWork.
-                        "@type":       ["BatteryCellSpecification", "schema:CreativeWork"],
-                        "@id":         iri,
-                        "schema:name": prod.get("name", ""),
-                        "schema:model":prod.get("model", ""),
-                        "schema:manufacturer": {
-                            "@type":       "schema:Organization",
-                            "schema:name": mfr_name,
-                        },
-                        "schema:url": (
-                            f"https://www.battery-genome.org/registry/spec/{short_id}"
-                        ),
-                        # isDescriptionFor links the spec to an anonymous individual
-                        # of the correct physical battery type
-                        "isDescriptionFor": {
-                            "@type": physical_types if len(physical_types) > 1
-                                     else physical_types[0],
-                        },
-                    }
-                    if prod.get("size_code"):
-                        node["schema:identifier"] = prod["size_code"]
-                    if prod.get("iec_code"):
-                        node["schema:productID"] = prod["iec_code"]
-                    if prod.get("product_type"):
-                        node["schema:additionalType"] = str(prod["product_type"])
-                    if prod.get("country_of_origin"):
-                        node["schema:countryOfOrigin"] = {
-                            "@type":       "schema:Country",
-                            "schema:name": prod["country_of_origin"],
-                        }
-                    if prod.get("year"):
-                        node["schema:releaseDate"] = f"{prod['year']}-01-01"
-                    if prod.get("schema_version"):
-                        node["schema:schemaVersion"] = prod["schema_version"]
-                    # Preserve original chemistry and format strings verbatim
-                    # so the round-trip through JSON-LD is lossless.
-                    if prod.get("chemistry"):
-                        node["battinfo:chemistry"] = prod["chemistry"]
-                    if prod.get("cell_format"):
-                        node["battinfo:cellFormat"] = prod["cell_format"]
-                    # rechargeable is already encoded in @type via PrimaryBattery/SecondaryBattery
-
-                    # Measurements using EMMO hasProperty pattern
-                    specs = raw.get("properties", {})
-                    quantity_nodes = []
-                    for prop_key, qty in (specs or {}).items():
-                        if not isinstance(qty, dict) or qty.get("value") is None:
-                            continue
-                        qn = _quantity_node(prop_key, qty["value"], qty.get("unit", ""))
-                        if qn:
-                            quantity_nodes.append(qn)
-                    if quantity_nodes:
-                        node["hasProperty"] = quantity_nodes
-
-                    spec_nodes[iri] = node
-                except Exception:
+                prod = raw.get("cell_spec", {}) if isinstance(raw, dict) else {}
+                iri = prod.get("id", "") if isinstance(prod, dict) else ""
+                if not iri:
                     continue
+                try:
+                    spec_nodes[iri] = build_cell_spec_node(raw)
+                except Exception as exc:  # noqa: BLE001 - one bad record must not sink the deposit
+                    warnings.warn(
+                        f"cell-spec record '{iri}' could not be converted to "
+                        f"JSON-LD and will be OMITTED from the publication graph: {exc}",
+                        stacklevel=2,
+                    )
+                    continue
+                for _field in ("chemistry", "cell_format"):
+                    if prod.get(_field):
+                        _spec_keywords.add(str(prod[_field]))
 
         # ── Map cell instance IRI → {cell_spec_id, serial_number} ──────────────────
         instances: dict[str, dict] = {}
@@ -5228,10 +5084,8 @@ class AuthoringWorkspace:
         # Auto-derived from the cells, specs and test kinds so every record is
         # discoverable without manual tagging; merged with any explicit keywords.
         _kw: set[str] = {"battery"}
+        _kw |= _spec_keywords  # chemistry/format strings from the cell-spec records
         for _sn in spec_nodes.values():
-            for _k in ("battinfo:chemistry", "battinfo:cellFormat"):
-                if _sn.get(_k):
-                    _kw.add(str(_sn[_k]))
             _mfr = _sn.get("schema:manufacturer")
             if isinstance(_mfr, dict) and _mfr.get("schema:name"):
                 _kw.add(_mfr["schema:name"])
@@ -5259,9 +5113,10 @@ class AuthoringWorkspace:
         # ── Inline context: load from records.context.json + dynamic prefLabel terms ─
         # _RECORDS_CONTEXT is generated by `python scripts/assemble_context.py`
         # from schema/*.yaml (the LinkML single source of truth).
-        # _LABEL_TO_COMPACT adds quantity/unit prefLabels loaded from curated JSON maps.
+        # label_to_compact() adds the core class terms plus quantity/unit
+        # prefLabels loaded from the curated maps and the entity-type map.
         context = dict(_RECORDS_CONTEXT)
-        context.update(_LABEL_TO_COMPACT)
+        context.update(label_to_compact())
         # Test-protocol vocabulary (control/termination parameters + their quantity
         # classes) — only needed when conditions are emitted, but harmless otherwise.
         from battinfo.jsonld import (  # noqa: PLC0415

--- a/tests/test_emitter_convergence.py
+++ b/tests/test_emitter_convergence.py
@@ -1,0 +1,167 @@
+"""Emitter convergence: resolver (B) and publication-package (C) cell-spec nodes.
+
+Covers the three convergence steps:
+
+1. The resolver JSON-LD carries every descriptor the canonical record holds
+   (no silent drops): model, IEC code, country of origin, release year,
+   physical @type stack via isDescriptionFor, and a standard-vocabulary
+   provenance node.
+2. One quantity-node shape everywhere (list @type + RealData + bare-IRI unit),
+   with the round-trip importer accepting both the old and the new shapes.
+3. B and C share one builder: byte-identical spec nodes for the same record.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api._resolver import _resolver_jsonld
+from battinfo.api._shared import _validate_publication_artifact
+from battinfo.transform.cell_spec_node import build_cell_spec_node
+
+
+def _cell_spec_record(**overrides) -> dict:
+    cell_spec = {
+        "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+        "short_id": "7d9k2m",
+        "identifier": "cell-spec:7d9k-2m4p-8t3x-6nq5",
+        "name": "A123 ANR26650M1-B",
+        "model": "ANR26650M1-B",
+        "manufacturer": {"type": "Organization", "name": "A123"},
+        "cell_format": "cylindrical",
+        "chemistry": "Li-ion",
+        "positive_electrode_basis": "LFP",
+        "negative_electrode_basis": "graphite",
+        "size_code": "R26650",
+        "iec_code": "IFpR26650",
+        "country_of_origin": "United States",
+        "rechargeable": True,
+        "year": 2012,
+    }
+    cell_spec.update(overrides.pop("cell_spec", {}))
+    record = {
+        "schema_version": "0.1.0",
+        "cell_spec": cell_spec,
+        "properties": {
+            "nominal_capacity": {"value": 2.5, "unit": "Ah"},
+            "nominal_voltage": {"value": 3.3, "unit": "V"},
+        },
+        "provenance": {
+            "source_type": "datasheet",
+            "source_url": "https://example.org/datasheets/anr26650m1-b.pdf",
+            "citation": "A123 Systems (2012). ANR26650M1-B datasheet.",
+            "retrieved_at": 1769585584,
+        },
+    }
+    record.update(overrides)
+    return record
+
+
+# ── Step 1: resolver enrichment (no silent drops) ────────────────────────────
+
+
+def test_resolver_cell_spec_carries_all_descriptors() -> None:
+    doc = _resolver_jsonld(_cell_spec_record())
+
+    assert doc["@type"] == ["BatteryCellSpecification", "schema:CreativeWork"]
+    assert doc["@id"] == "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5"
+    assert doc["schema:model"] == "ANR26650M1-B"
+    assert doc["schema:productID"] == "IFpR26650"
+    assert doc["schema:size"] == "R26650"
+    assert doc["schema:countryOfOrigin"] == {
+        "@type": "schema:Country",
+        "schema:name": "United States",
+    }
+    assert doc["schema:releaseDate"] == "2012-01-01"
+    assert doc["schema:identifier"] == "7d9k-2m4p-8t3x-6nq5"
+    assert doc["schema:url"].endswith("/registry/spec/7d9k-2m4p-8t3x-6nq5")
+
+
+def test_resolver_cell_spec_expresses_descriptors_via_type_stack() -> None:
+    doc = _resolver_jsonld(_cell_spec_record())
+
+    physical = doc["isDescriptionFor"]["@type"]
+    assert "CylindricalBattery" in physical
+    assert "LithiumIonBattery" in physical
+    # Electrode bases are expressed through the physical @type stack, not literals.
+    assert "LithiumIonIronPhosphateBattery" in physical
+    assert "LithiumIonGraphiteBattery" in physical
+    assert "SecondaryBattery" in physical
+    assert "battinfo:chemistry" not in doc
+    assert "battinfo:cellFormat" not in doc
+    assert "battinfo:positiveElectrodeBasis" not in doc
+    assert "battinfo:negativeElectrodeBasis" not in doc
+
+
+def test_resolver_cell_spec_emits_standard_vocab_provenance() -> None:
+    doc = _resolver_jsonld(_cell_spec_record())
+
+    prov = doc["dcterms:source"]
+    assert prov["@type"] == "prov:Entity"
+    assert prov["dcterms:type"] == "datasheet"
+    assert prov["prov:hadPrimarySource"] == {
+        "@id": "https://example.org/datasheets/anr26650m1-b.pdf"
+    }
+    assert prov["prov:generatedAtTime"].startswith("2026-01-28T")
+    assert prov["dcterms:bibliographicCitation"].startswith("A123 Systems (2012)")
+
+
+def test_resolver_cell_spec_quantity_nodes_use_canonical_shape() -> None:
+    doc = _resolver_jsonld(_cell_spec_record())
+
+    nodes = {node["@type"][0]: node for node in doc["hasProperty"]}
+    capacity = nodes["NominalCapacity"]
+    assert capacity["@type"] == ["NominalCapacity", "ConventionalProperty"]
+    assert capacity["hasNumericalPart"] == {"@type": "RealData", "hasNumberValue": 2.5}
+    assert isinstance(capacity["hasMeasurementUnit"], str)
+
+
+def test_resolver_cell_spec_artifact_passes_publication_validation() -> None:
+    _validate_publication_artifact(_resolver_jsonld(_cell_spec_record()))
+
+
+def test_shipped_example_record_resolves_without_drops() -> None:
+    src = ROOT / "examples" / "cell-spec" / "A123__ANR26650M1-B.json"
+    record = json.loads(src.read_text(encoding="utf-8"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        doc = _resolver_jsonld(record)
+    assert doc["schema:model"] == record["cell_spec"]["model"]
+    assert doc["schema:productID"] == record["cell_spec"]["iec_code"]
+    assert "isDescriptionFor" in doc
+    assert doc["dcterms:source"]["dcterms:type"] == "datasheet"
+    _validate_publication_artifact(doc)
+
+
+# ── Emit-time warnings at the drop sites ─────────────────────────────────────
+
+
+def test_unmapped_property_key_warns_at_emit_time() -> None:
+    record = _cell_spec_record(
+        properties={"frobnication_index": {"value": 42.0, "unit": "V"}}
+    )
+    with pytest.warns(UserWarning, match="semantic.property_unmapped.*frobnication_index"):
+        doc = build_cell_spec_node(record)
+    # Emitted with the non-canonical fallback term rather than silently dropped.
+    assert doc["hasProperty"][0]["@type"][0] == "battinfo:frobnicationIndex"
+
+
+def test_value_text_only_property_warns_at_emit_time() -> None:
+    record = _cell_spec_record(
+        properties={"cycle_life": {"value_text": ">=1000 cycles"}}
+    )
+    with pytest.warns(UserWarning, match="semantic.value_text_only.*cycle_life"):
+        build_cell_spec_node(record)
+
+
+def test_mapped_numeric_properties_do_not_warn() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        build_cell_spec_node(_cell_spec_record())

--- a/tests/test_emitter_convergence.py
+++ b/tests/test_emitter_convergence.py
@@ -263,6 +263,108 @@ def test_import_reads_new_shape_package_with_descriptors_intact(tmp_path: Path) 
     assert spec.properties["nominal_voltage"]["unit"] == "V"
 
 
+# ── Step 3: C shares the builder with B ──────────────────────────────────────
+
+
+def _assemble_package(record: dict) -> dict:
+    from battinfo.ws import AuthoringWorkspace
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return AuthoringWorkspace._assemble_zenodo_jsonld(
+            {"cell-spec": [record]},
+            zenodo_record_id=1,
+            prereserved_doi="10.5281/zenodo.1",
+            record_url="https://zenodo.org/records/1",
+            data_filenames=[],
+            title="Convergence test deposit",
+            license="CC-BY-4.0",
+        )
+
+
+def test_resolver_and_package_spec_nodes_are_byte_identical() -> None:
+    record = _cell_spec_record()
+
+    resolver_doc = _resolver_jsonld(record)
+    resolver_node = {k: v for k, v in resolver_doc.items() if k != "@context"}
+
+    package = _assemble_package(record)
+    package_node = next(
+        n for n in package["@graph"] if n.get("@id") == record["cell_spec"]["id"]
+    )
+
+    assert json.dumps(resolver_node, sort_keys=False) == json.dumps(
+        package_node, sort_keys=False
+    )
+
+
+def test_package_spec_node_drops_battinfo_literals_for_type_stack() -> None:
+    package = _assemble_package(_cell_spec_record())
+    node = next(n for n in package["@graph"] if n.get("@id") == SPEC_IRI)
+
+    assert "battinfo:chemistry" not in node
+    assert "battinfo:cellFormat" not in node
+    physical = node["isDescriptionFor"]["@type"]
+    assert "CylindricalBattery" in physical
+    assert "LithiumIonBattery" in physical
+    capacity = next(p for p in node["hasProperty"] if p["@type"][0] == "NominalCapacity")
+    assert capacity["@type"] == ["NominalCapacity", "ConventionalProperty"]
+    assert capacity["hasNumericalPart"]["@type"] == "RealData"
+    assert isinstance(capacity["hasMeasurementUnit"], str)
+
+
+def test_package_keywords_keep_chemistry_and_format() -> None:
+    package = _assemble_package(_cell_spec_record())
+    catalog = package["@graph"][0]
+    keywords = set(catalog.get("schema:keywords", []))
+    assert {"Li-ion", "cylindrical", "A123"} <= keywords
+
+
+def test_package_round_trips_through_import(tmp_path: Path) -> None:
+    """battinfo.json emitted by the shared builder imports with descriptors intact."""
+    package = _assemble_package(_cell_spec_record())
+    ws, counts = _import_package(tmp_path, package)
+
+    assert counts["properties"] == 1
+    spec = ws._ws.cell_specs[0]
+    assert spec.id == SPEC_IRI
+    assert spec.format == "cylindrical"
+    assert spec.chemistry == "li-ion"
+    assert spec.size_code == "R26650"
+    assert spec.iec_code in ("IFpR26650", "ifpr26650")
+    assert spec.properties["nominal_capacity"] == {"value": 2.5, "unit": "Ah"}
+    assert spec.properties["nominal_voltage"] == {"value": 3.3, "unit": "V"}
+
+
+def test_unconvertible_spec_record_warns_instead_of_silent_skip(monkeypatch) -> None:
+    import battinfo.transform.cell_spec_node as csn
+    from battinfo.ws import AuthoringWorkspace
+
+    real = csn.build_cell_spec_node
+
+    def boom(record):
+        if record.get("cell_spec", {}).get("id", "").endswith("bad-1"):
+            raise ValueError("boom")
+        return real(record)
+
+    monkeypatch.setattr(csn, "build_cell_spec_node", boom)
+    bad = {"cell_spec": {"id": "https://w3id.org/battinfo/spec/bad-1"}}
+    good = _cell_spec_record()
+
+    with pytest.warns(UserWarning, match="spec/bad-1.*OMITTED"):
+        package = AuthoringWorkspace._assemble_zenodo_jsonld(
+            {"cell-spec": [bad, good]},
+            zenodo_record_id=1,
+            prereserved_doi="10.5281/zenodo.1",
+            record_url="https://zenodo.org/records/1",
+            data_filenames=[],
+        )
+
+    ids = {n.get("@id") for n in package["@graph"]}
+    assert good["cell_spec"]["id"] in ids
+    assert "https://w3id.org/battinfo/spec/bad-1" not in ids
+
+
 def test_import_new_shape_does_not_misread_uid_as_size_code(tmp_path: Path) -> None:
     record = _cell_spec_record()
     del record["cell_spec"]["size_code"]

--- a/tests/test_emitter_convergence.py
+++ b/tests/test_emitter_convergence.py
@@ -165,3 +165,116 @@ def test_mapped_numeric_properties_do_not_warn() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         build_cell_spec_node(_cell_spec_record())
+
+
+# ── Step 2: round-trip importer accepts old- and new-shape packages ──────────
+
+SPEC_IRI = "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5"
+
+
+def _import_package(tmp_path: Path, doc: dict):
+    from battinfo.ws import AuthoringWorkspace
+
+    path = tmp_path / "battinfo.json"
+    path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    ws = AuthoringWorkspace(root=tmp_path / "ws", registry_url=None)
+    counts = ws.import_(str(path))
+    return ws, counts
+
+
+def test_import_accepts_legacy_shape_package(tmp_path: Path) -> None:
+    """A package published before the convergence (single-string quantity @type,
+    {"@id": ...} unit refs, battinfo: literals, size code in schema:identifier)
+    must keep importing unchanged."""
+    from battinfo.jsonld import _PROP_MAP, _UNIT_MAP
+
+    doc = {
+        "@context": {
+            "battery": "https://w3id.org/emmo/domain/battery#",
+            "electrochemistry": "https://w3id.org/emmo/domain/electrochemistry#",
+            "emmo": "https://w3id.org/emmo#",
+            "schema": "https://schema.org/",
+            "battinfo": "https://w3id.org/battinfo/",
+            "NominalCapacity": _PROP_MAP["nominal_capacity"],
+        },
+        "@graph": [
+            {
+                "@type": ["BatteryCellSpecification", "schema:CreativeWork"],
+                "@id": SPEC_IRI,
+                "schema:name": "A123 ANR26650M1-B",
+                "schema:model": "ANR26650M1-B",
+                "schema:manufacturer": {"@type": "schema:Organization", "schema:name": "A123"},
+                "schema:identifier": "R26650",
+                "schema:productID": "IFpR26650",
+                "battinfo:chemistry": "Li-ion",
+                "battinfo:cellFormat": "cylindrical",
+                "isDescriptionFor": {"@type": ["BatteryCell", "CylindricalBattery", "LithiumIonBattery"]},
+                "hasProperty": [
+                    {
+                        "@type": "NominalCapacity",
+                        "hasNumericalPart": {"hasNumberValue": 2.5},
+                        "hasMeasurementUnit": {"@id": _UNIT_MAP["Ah"]},
+                    }
+                ],
+            }
+        ],
+    }
+
+    ws, counts = _import_package(tmp_path, doc)
+
+    assert counts["properties"] == 1
+    spec = ws._ws.cell_specs[0]
+    assert spec.id == SPEC_IRI
+    assert spec.format == "cylindrical"       # verbatim battinfo: literal wins
+    assert spec.chemistry == "Li-ion"
+    assert spec.size_code == "R26650"          # legacy schema:identifier slot
+    assert spec.iec_code == "IFpR26650"
+    assert spec.properties["nominal_capacity"]["value"] == 2.5
+    assert spec.properties["nominal_capacity"]["unit"] == "Ah"
+
+
+def _new_shape_package() -> dict:
+    from battinfo.transform.cell_spec_node import label_to_compact
+    from battinfo.ws import _RECORDS_CONTEXT
+
+    context = dict(_RECORDS_CONTEXT)
+    context.update(label_to_compact())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        node = build_cell_spec_node(_cell_spec_record())
+    return {"@context": context, "@graph": [node]}
+
+
+def test_import_reads_new_shape_package_with_descriptors_intact(tmp_path: Path) -> None:
+    """The canonical shape drops the battinfo: literals; format and chemistry
+    must be recovered from the isDescriptionFor physical @type stack, list-@type
+    quantity nodes must be read, and the bare-IRI unit resolved to its symbol."""
+    ws, counts = _import_package(tmp_path, _new_shape_package())
+
+    assert counts["properties"] == 1
+    spec = ws._ws.cell_specs[0]
+    assert spec.id == SPEC_IRI
+    assert spec.format == "cylindrical"        # from CylindricalBattery
+    assert spec.chemistry == "li-ion"          # from LithiumIonBattery
+    assert spec.size_code == "R26650"          # from schema:size
+    assert spec.properties["nominal_capacity"]["value"] == 2.5
+    assert spec.properties["nominal_capacity"]["unit"] == "Ah"
+    assert spec.properties["nominal_voltage"]["value"] == 3.3
+    assert spec.properties["nominal_voltage"]["unit"] == "V"
+
+
+def test_import_new_shape_does_not_misread_uid_as_size_code(tmp_path: Path) -> None:
+    record = _cell_spec_record()
+    del record["cell_spec"]["size_code"]
+    from battinfo.transform.cell_spec_node import label_to_compact
+    from battinfo.ws import _RECORDS_CONTEXT
+
+    context = dict(_RECORDS_CONTEXT)
+    context.update(label_to_compact())
+    doc = {"@context": context, "@graph": [build_cell_spec_node(record)]}
+
+    ws, _ = _import_package(tmp_path, doc)
+
+    spec = ws._ws.cell_specs[0]
+    # schema:identifier now carries the record uid; it must not leak into size_code.
+    assert spec.size_code is None

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -644,7 +644,8 @@ def test_workspace_publish_stages_file_backed_dataset(tmp_path: Path) -> None:
     assert cell_spec_node["schema:countryOfOrigin"]["schema:name"] == "Japan"
     assert cell_spec_node["schema:releaseDate"] == "2022-01-01"
     property_types = {
-        entry.get("@type")
+        # Canonical quantity nodes carry a list @type of [PropertyClass, co-type].
+        entry["@type"][0] if isinstance(entry.get("@type"), list) else entry.get("@type")
         for entry in cell_spec_node.get("hasProperty", [])
         if isinstance(entry, dict)
     }


### PR DESCRIPTION
First half of the emitter unification. A new shared builder (transform/cell_spec_node.py) produces the canonical cell-spec node — BatteryCellSpecification + schema:CreativeWork, physical EMMO classes on isDescriptionFor (now including electrode bases and primary/secondary), full descriptor coverage (model, IEC code, country, year, brand), a standards-vocabulary provenance node (dcterms/PROV — zero battinfo: terms), and quantity nodes that warn instead of silently dropping unmapped or text-only properties.

The resolver adopts it (previously it silently dropped a dozen descriptor fields, including the entire provenance block); the publication/Zenodo graph shares the identical builder, enforced by a byte-identity test, shedding its battinfo:cellFormat/chemistry literals and its exception-swallowing. Between them, the round-trip importer was upgraded first: it reads the new shape (list @type, bare-IRI units, isDescriptionFor-derived format/chemistry) and every legacy package shape forever — covered by both-generation import tests.

record_to_jsonld (the third emitter) is deliberately untouched — it repoints in the follow-up PR together with the web-gallery and SHACL regenerations that must land in the same commit. Tutorials re-executed; 1371 tests (+17 new); ruff + mypy clean.