### PR TITLE
Dependency backlog: clear dependabot alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Dependabot backlog (web/)**: `postcss` bumped 8.4.39 → 8.5.16 and pinned
+  via an npm `overrides` entry so Next.js's bundled copy (8.4.31) is forced to
+  the same patched version — closes GHSA-qx2v-qp2m-jg93 (XSS via unescaped
+  `</style>` in stringified CSS output) for both lockfile nodes. The Python
+  lockfile audits clean (`pip-audit` over `uv export`, no known
+  vulnerabilities). **Known remaining**: 14 advisories against `next@14.2.35`
+  (DoS, cache-poisoning, XSS, SSRF, middleware-bypass families; e.g.
+  GHSA-c4j6-fc7j-m34r, GHSA-36qx-fr4f-26g5, GHSA-q4gf-8mx6-v5v3) are only
+  patched in Next >= 15.5.16 — the 14.x line is EOL with no backports, so the
+  fix is a major upgrade (Next 15 + React 19 for App Router apps like this
+  one), deliberately deferred to its own change rather than smuggled into a
+  dependency sweep.
+
 ### Added
 
 - **EMMO label companion (`assets/vocab/emmo-labels.ttl`)**: a generated

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "autoprefixer": "10.4.19",
-        "postcss": "8.4.39",
+        "postcss": "8.5.16",
         "tailwindcss": "3.4.6",
         "tsx": "^4.23.0",
         "typescript": "5.5.3"
@@ -1533,34 +1533,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.47",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
@@ -1658,10 +1630,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
-      "dev": true,
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1678,9 +1649,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/web/package.json
+++ b/web/package.json
@@ -25,9 +25,12 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.19",
-    "postcss": "8.4.39",
+    "postcss": "8.5.16",
     "tailwindcss": "3.4.6",
     "tsx": "^4.23.0",
     "typescript": "5.5.3"
+  },
+  "overrides": {
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
Local audit (gh CLI unavailable; npm audit + pip-audit over uv export) found all open alerts in web/package-lock.json:

Fixed:
- GHSA-qx2v-qp2m-jg93 (postcss <8.5.10, XSS via unescaped </style>): devDependency bumped 8.4.39 -> 8.5.16 plus an npm overrides pin ("postcss": "$postcss") so next's bundled postcss 8.4.31 node is forced to 8.5.16 as well. npm audit no longer reports postcss.

Remaining (deliberate):
- 14 advisories against next@14.2.35 (GHSA-9g9p-9gw9-jx7f, GHSA-h25m-26qc-wcjf, GHSA-ggv3-7p47-pfv8, GHSA-3x4c-7xq6-9pq8, GHSA-q4gf-8mx6-v5v3, GHSA-8h8q-6873-q5fj, GHSA-3g8h-86w9-wvmq, GHSA-ffhc-5mcf-pf4q, GHSA-vfv6-92ff-j949, GHSA-gx5p-jg67-6x7h, GHSA-h64f-5h5j-jqjh, GHSA-c4j6-fc7j-m34r, GHSA-wfc6-r584-vfw7, GHSA-36qx-fr4f-26g5). All are first patched in next >=15.5.16; the 14.x line is EOL with no backports, so the only fix is a major upgrade (Next 15/16 + React 19 for App Router). Out of scope for a dependency sweep; needs its own migration change.

Python lockfile audits clean: pip-audit over `uv export --all-extras` reports no known vulnerabilities (uv.lock untouched).

Gates: web npm ci + sync:schemas --check + check-agreement (109 valid / 5 rejected) + next build all pass; pytest 1372 passed 3 skipped; ruff and mypy clean.