### PR TITLE
Adapt to batterydf 0.2 (git pin pending PyPI release)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,11 @@ jobs:
         with:
           enable-cache: true
       - name: Export locked dependency graph
-        run: uv export --no-emit-project --all-extras --format requirements-txt > requirements-audit.txt
+        # --no-emit-package batterydf: TEMPORARY while batterydf is a git-source
+        # pin (pip cannot hash-verify VCS requirements, and pip-audit cannot
+        # audit them). Remove together with the [tool.uv.sources] pin once
+        # batterydf 0.2.0 is on PyPI so it re-enters the audit.
+        run: uv export --no-emit-project --no-emit-package batterydf --all-extras --format requirements-txt > requirements-audit.txt
       - name: Audit dependencies (OSV / PyPI advisories)
         run: uvx pip-audit -r requirements-audit.txt
 

--- a/IDENTIFIER_POLICY.md
+++ b/IDENTIFIER_POLICY.md
@@ -192,7 +192,10 @@ older `cell-type/`, `cell_type/`, `test_protocol/` forms) remain permanent
 resolver aliases — anything ever minted resolves forever.
 
 Reserved segments (never usable as entity namespaces): `id`, `ontology`,
-`vocab`, `doc`, `context`, `resolver`, `twin`, `w3id`.
+`vocab`, `doc`, `context`, `resolver`, `twin`, `w3id`, `raw`, `inferred`,
+`turtle`, `latest`, `source`. The last five are claimed by the ontology
+block in the upstream w3id.org `.htaccess`, so requests to those paths can
+never reach the record resolver.
 
 ### 6.2 Equipment and channels (ratified 2026-07-08)
 
@@ -337,7 +340,8 @@ terms resolve to EMMO or go upstream; only structural terms may be minted
 locally, hand-defined.
 
 Reserved namespace segments (never usable as entity types): `id`, `ontology`,
-`vocab`, `doc`, `context`, `resolver`, `twin`, `w3id`.
+`vocab`, `doc`, `context`, `resolver`, `twin`, `w3id`, `raw`, `inferred`,
+`turtle`, `latest`, `source`.
 
 ## 15. Design Principles
 

--- a/docs/guides/06-publish-your-data.ipynb
+++ b/docs/guides/06-publish-your-data.ipynb
@@ -30,10 +30,10 @@
    "id": "e43cee13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T22:02:35.985953Z",
-     "iopub.status.busy": "2026-07-08T22:02:35.985953Z",
-     "iopub.status.idle": "2026-07-08T22:02:36.307231Z",
-     "shell.execute_reply": "2026-07-08T22:02:36.305222Z"
+     "iopub.execute_input": "2026-07-09T17:16:57.320340Z",
+     "iopub.status.busy": "2026-07-09T17:16:57.320340Z",
+     "iopub.status.idle": "2026-07-09T17:16:57.641467Z",
+     "shell.execute_reply": "2026-07-09T17:16:57.639953Z"
     }
    },
    "outputs": [],
@@ -75,10 +75,10 @@
    "id": "e2c1ddca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T22:02:36.309242Z",
-     "iopub.status.busy": "2026-07-08T22:02:36.309242Z",
-     "iopub.status.idle": "2026-07-08T22:02:37.532089Z",
-     "shell.execute_reply": "2026-07-08T22:02:37.530848Z"
+     "iopub.execute_input": "2026-07-09T17:16:57.643467Z",
+     "iopub.status.busy": "2026-07-09T17:16:57.643467Z",
+     "iopub.status.idle": "2026-07-09T17:16:59.326621Z",
+     "shell.execute_reply": "2026-07-09T17:16:59.325614Z"
     }
    },
    "outputs": [
@@ -86,11 +86,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  neware-sample.csv  ->  neware-sample.bdf.csv  (0.0 MB)\n",
+      "  neware-sample.csv  ->  neware-sample.bdf.csv  (0.0 MB, via neware_csv)\n",
       "\n",
       "Converted 1 file(s) -> <repo>\\docs\\guides\\_scratch\\guide-06\\bdf\n",
       "\n",
-      "BDF columns: test_time_second,voltage_volt,current_ampere,step_index,unix_time_second\n"
+      "BDF columns: test_time_second,voltage_volt,current_ampere,unix_time_second,cycle_count,step_id,step_time_second,step_charging_capacity_ah,step_discharging_capacity_ah\n"
      ]
     }
    ],
@@ -120,10 +120,10 @@
    "id": "c7d97399",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T22:02:37.536091Z",
-     "iopub.status.busy": "2026-07-08T22:02:37.536091Z",
-     "iopub.status.idle": "2026-07-08T22:02:39.522904Z",
-     "shell.execute_reply": "2026-07-08T22:02:39.522904Z"
+     "iopub.execute_input": "2026-07-09T17:16:59.328619Z",
+     "iopub.status.busy": "2026-07-09T17:16:59.327619Z",
+     "iopub.status.idle": "2026-07-09T17:17:01.660086Z",
+     "shell.execute_reply": "2026-07-09T17:17:01.660086Z"
     }
    },
    "outputs": [
@@ -173,10 +173,10 @@
    "id": "d9a22b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T22:02:39.526132Z",
-     "iopub.status.busy": "2026-07-08T22:02:39.526132Z",
-     "iopub.status.idle": "2026-07-08T22:02:39.536672Z",
-     "shell.execute_reply": "2026-07-08T22:02:39.535663Z"
+     "iopub.execute_input": "2026-07-09T17:17:01.660086Z",
+     "iopub.status.busy": "2026-07-09T17:17:01.660086Z",
+     "iopub.status.idle": "2026-07-09T17:17:01.676121Z",
+     "shell.execute_reply": "2026-07-09T17:17:01.676121Z"
     }
    },
    "outputs": [
@@ -184,14 +184,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  warning: neware-sample.bdf.csv unix_time_second=1772442 is implausible (outside 2000-2100) - not stamping test/dataset times from it. Known cause: batterydf<0.1.1 wrote epoch/1000; upgrade batterydf and re-run ws.convert().\n",
       "  test [cycling] on S1  +1 dataset(s)  (+1 raw source)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[Test(schema_version='0.2.0', kind='Test', id=None, name='S1 cycling', test_type=<BatteryTestType.CYCLING: 'cycling'>, protocol_id=None, cell_instance_id=None, description=None, status='completed', protocol=ProtocolInfo(name='cycling', url=None), instrument=None, equipment_id=None, channel_id=None, started_at=None, ended_at=None, dataset_ids=[], conformance=None, artifacts=[], source=ProvenanceInfo(type='measurement', name=None, file=None, url=None, citation=None, retrieved_at=None, workflow_version=None, file_hash=None, curated_by=None, comment=None, battinfo_version=None), comment=[])]"
+       "[Test(schema_version='0.2.0', kind='Test', id=None, name='S1 cycling', test_type=<BatteryTestType.CYCLING: 'cycling'>, protocol_id=None, cell_instance_id=None, description=None, status='completed', protocol=ProtocolInfo(name='cycling', url=None), instrument=None, equipment_id=None, channel_id=None, started_at=1772442000, ended_at=1772443380, dataset_ids=[], conformance=None, artifacts=[], source=ProvenanceInfo(type='measurement', name=None, file=None, url=None, citation=None, retrieved_at=None, workflow_version=None, file_hash=None, curated_by=None, comment=None, battinfo_version=None), comment=[])]"
       ]
      },
      "execution_count": 4,
@@ -221,10 +220,10 @@
    "id": "241ee167",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T22:02:39.538673Z",
-     "iopub.status.busy": "2026-07-08T22:02:39.538673Z",
-     "iopub.status.idle": "2026-07-08T22:02:39.827821Z",
-     "shell.execute_reply": "2026-07-08T22:02:39.827312Z"
+     "iopub.execute_input": "2026-07-09T17:17:01.676121Z",
+     "iopub.status.busy": "2026-07-09T17:17:01.676121Z",
+     "iopub.status.idle": "2026-07-09T17:17:02.028366Z",
+     "shell.execute_reply": "2026-07-09T17:17:02.028366Z"
     }
    },
    "outputs": [
@@ -236,12 +235,12 @@
       "  cell spec   Molicel INR21700-P45B                [created]  .battinfo\\records\\cell-spec\\cell-spec-fpdr-z1qt-23v0-stzx.json\n",
       "  cell        S1                                   [created]  .battinfo\\records\\cell-instance\\cell-d6tp-jgqy-a3s9-4qem.json\n",
       "  test        S1 cycling                           [created]  .battinfo\\records\\test\\test-9f4c-mxny-yhym-2zh4.json\n",
-      "  dataset     S1 data                              [created]  .battinfo\\records\\dataset\\dataset-22bt-7jxb-yv3k-xgq4.json\n",
+      "  dataset     S1 data                              [created]  .battinfo\\records\\dataset\\dataset-6p2d-cy0w-25h0-2820.json\n",
       "\n",
       "  Next: ws.list(verbose=True) to inspect, or ws.publish() to publish.\n",
       "cell-instance/cell-d6tp-jgqy-a3s9-4qem.json\n",
       "cell-spec/cell-spec-fpdr-z1qt-23v0-stzx.json\n",
-      "dataset/dataset-22bt-7jxb-yv3k-xgq4.json\n",
+      "dataset/dataset-6p2d-cy0w-25h0-2820.json\n",
       "test/test-9f4c-mxny-yhym-2zh4.json\n"
      ]
     }
@@ -260,10 +259,10 @@
    "id": "03b2dfb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T22:02:39.831831Z",
-     "iopub.status.busy": "2026-07-08T22:02:39.831831Z",
-     "iopub.status.idle": "2026-07-08T22:02:39.840170Z",
-     "shell.execute_reply": "2026-07-08T22:02:39.839137Z"
+     "iopub.execute_input": "2026-07-09T17:17:02.028366Z",
+     "iopub.status.busy": "2026-07-09T17:17:02.028366Z",
+     "iopub.status.idle": "2026-07-09T17:17:02.038439Z",
+     "shell.execute_reply": "2026-07-09T17:17:02.038439Z"
     }
    },
    "outputs": [
@@ -281,7 +280,7 @@
       "...\n",
       "provenance: {\n",
       "  \"source_type\": \"measurement\",\n",
-      "  \"retrieved_at\": 1783548159,\n",
+      "  \"retrieved_at\": 1783617421,\n",
       "  \"battinfo_version\": \"0.7.0\"\n",
       "}\n"
      ]
@@ -320,10 +319,10 @@
    "id": "5e115f9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T22:02:39.843144Z",
-     "iopub.status.busy": "2026-07-08T22:02:39.843144Z",
-     "iopub.status.idle": "2026-07-08T22:02:39.848441Z",
-     "shell.execute_reply": "2026-07-08T22:02:39.847426Z"
+     "iopub.execute_input": "2026-07-09T17:17:02.038439Z",
+     "iopub.status.busy": "2026-07-09T17:17:02.038439Z",
+     "iopub.status.idle": "2026-07-09T17:17:02.048067Z",
+     "shell.execute_reply": "2026-07-09T17:17:02.048067Z"
     }
    },
    "outputs": [
@@ -392,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -38,30 +38,47 @@ files to cells (`ws.add("test", datasets="glob")`).
 
 | Namespace | Record type(s) |
 |---|---|
-| `/spec/` | Cell specs **and** test specs — the reusable *descriptions* |
+| `/spec/` | Every reusable *description* — cell, test, material, and component specs |
 | `/cell/` | Physical cells (instances) |
 | `/test/` | Test executions |
 | `/dataset/` | Datasets |
-| `/material-spec/`, `/material/` | Standalone materials, spec and instance |
-| `/electrode-spec/`, `/separator-spec/`, `/electrolyte-spec/`, ... | Component specs (and their instance namespaces) |
+| `/material/`, `/electrode/`, `/separator/`, ... | Material and component instances |
+| `/equipment/`, `/channel/` | Physical equipment units and their channels |
 
 The full map is code, not convention: `battinfo.entities.iri_namespace_map()`.
+
+Two more segment rules keep old links alive and new ones honest:
+
+- **Legacy segments are permanent aliases.** Superseded namespaces
+  (`/material-spec/`, `/electrode-spec/`, the older `/cell-type/` forms, ...)
+  keep resolving forever — anything ever minted stays dereferenceable.
+- **Reserved segments** (`id`, `ontology`, `vocab`, `doc`, `context`,
+  `resolver`, `twin`, `w3id`, `raw`, `inferred`, `turtle`, `latest`,
+  `source`) can never become record namespaces — they are claimed by the
+  resolver and ontology infrastructure
+  (`battinfo.entities.RESERVED_NAMESPACE_SEGMENTS`).
 
 ## Why w3id.org (the PURL layer)
 
 `w3id.org` is the W3C Permanent Identifier Community Group's redirect
 service: a community-maintained, permanently-hosted layer of indirection.
-The `https://w3id.org/battinfo/...` IRIs redirect to wherever the resolver
-actually lives today — so records cite an address that outlives any single
-server, domain, or hosting decision. The design: dereferencing a record IRI
-serves its resolver artifact (`index.html` for humans, `index.jsonld` /
-`index.json` for machines — content-negotiated), produced by
-`battinfo.api.publish_record`.
+The `https://w3id.org/battinfo/...` IRIs redirect to wherever the registry
+resolver actually lives today — so records cite an address that outlives any
+single server, domain, or hosting decision.
+
+Dereferencing follows linked-data convention: a record IRI names the *thing*
+(a cell, a test), not a document, so the resolver answers with a **303
+redirect** to a representation chosen by content negotiation — JSON-LD (or
+Turtle) for machines, a human-readable landing page for browsers.
+
+Records also never disappear. A withdrawn record gets a **tombstone** — the
+resource stays dereferenceable, marked `owl:deprecated` and pointing at its
+replacement where one exists — never a 404. An IRI that once resolved always
+resolves.
 
 > **Status:** during the soft launch the registry sits behind an access gate,
-> so record IRIs currently resolve to the platform's sign-in page rather than
-> the machine-readable artifact. Content negotiation with correct status
-> codes (and public reads for published records) is being implemented as the
+> so record IRIs may resolve to the platform's sign-in page rather than the
+> machine-readable artifact. Public reads for published records arrive as the
 > gate comes down — until then, treat dereferencing as not yet reliable for
 > harvesters.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ storage = [
   "boto3>=1.34"
 ]
 processing = [
-  "batterydf>=0.1",
+  "batterydf>=0.2,<0.3",
   "matplotlib>=3.8",
   "plotly>=5.20",
 ]
@@ -109,6 +109,10 @@ Changelog = "https://github.com/BIG-MAP/BattINFO/blob/main/CHANGELOG.md"
 
 [project.scripts]
 battinfo = "battinfo.cli:app"
+
+# TEMPORARY until batterydf 0.2.0 is on PyPI — remove and re-lock on release
+[tool.uv.sources]
+batterydf = { git = "https://github.com/battery-data-alliance/battery-data-format", rev = "f64c338" }
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/battinfo/entities.py
+++ b/src/battinfo/entities.py
@@ -174,7 +174,10 @@ def record_set_dirs() -> tuple[str, ...]:
 
 
 RESERVED_NAMESPACE_SEGMENTS = frozenset(
-    {"id", "ontology", "vocab", "doc", "context", "resolver", "twin", "w3id"}
+    {"id", "ontology", "vocab", "doc", "context", "resolver", "twin", "w3id",
+     # Claimed by the ontology block in the upstream w3id.org .htaccess —
+     # requests to these paths can never reach the record resolver.
+     "raw", "inferred", "turtle", "latest", "source"}
 )
 _reserved_clash = RESERVED_NAMESPACE_SEGMENTS & {k.iri_namespace for k in ENTITY_KINDS}
 if _reserved_clash:  # fail at import: a reserved segment can never become an entity namespace

--- a/src/battinfo/interop/battdat.py
+++ b/src/battinfo/interop/battdat.py
@@ -53,7 +53,8 @@ _BDF_VARIABLE_MAP: dict[str, tuple[str, str]] = {
     "temperature_t5_celsius":        ("temperature_t5",         "°C"),
 }
 
-# bdf.read() returns human-readable "Name / unit" column headers.
+# In-memory frames from bdf.read() carry human-readable "Name / unit" column
+# headers (bdf.io.save() writes the snake_case machine labels above to disk).
 # This maps the lowercased, space→underscore name part to battinfo variable names.
 _BDF_HUMAN_NAME_MAP: dict[str, str] = {
     "voltage":                  "voltage",
@@ -122,10 +123,12 @@ def _read_df(source: Any, warnings: list[str]) -> tuple[Any, Path | None]:
         return source, None
 
     path = Path(source)
-    # Try BDF-aware reader first
+    # Try BDF-aware reader first.  batterydf >= 0.2: read() returns a
+    # (polars_frame, metadata) tuple; the helper collects to pandas and applies
+    # the ratified tz="UTC" timestamp policy.
     try:
-        import bdf as _bdf  # noqa: PLC0415
-        df = _bdf.read(path, validate=False)
+        from battinfo.processing import _read_bdf_pandas  # noqa: PLC0415
+        df, _meta = _read_bdf_pandas(path, validate=False)
         return df, path
     except ImportError:
         warnings.append(

--- a/src/battinfo/processing.py
+++ b/src/battinfo/processing.py
@@ -110,6 +110,32 @@ def process_timeseries_csv(
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
+def _read_bdf_pandas(source: Path, *, validate: bool = False):
+    """Read a cycler file with ``bdf.read`` and return ``(pandas_df, metadata)``.
+
+    batterydf >= 0.2 returns a ``(polars_frame, metadata)`` tuple; this helper
+    collects to a pandas DataFrame because the downstream helpers we chain
+    (``bdf.repair.fix_time``, ``bdf.io.save``, ``bdf.validate``) operate on
+    pandas.  ``metadata`` carries at least a ``"source"`` key naming the
+    resolved reader plugin — useful provenance for callers.
+
+    ``tz="UTC"`` is passed explicitly: UTC timestamps are the ratified project
+    policy.  Upstream cannot distinguish a deliberate UTC from its default and
+    still emits a "tz defaulted to UTC" UserWarning for naive-datetime formats,
+    so that specific warning is suppressed here.
+    """
+    import warnings as _warnings  # noqa: PLC0415
+
+    import bdf  # noqa: PLC0415
+
+    with _warnings.catch_warnings():
+        _warnings.filterwarnings(
+            "ignore", message="tz defaulted to UTC", category=UserWarning
+        )
+        frame, metadata = bdf.read(source, validate=validate, lazy=False, tz="UTC")
+    return frame.to_pandas(), metadata
+
+
 def _read_bdf_csv(path: Path):
     """Read a BDF CSV or Parquet file into a DataFrame, returning None on failure."""
     try:
@@ -158,7 +184,6 @@ def generate_dataset_plots(
 def _convert_to_bdf(csv_path: Path, work_dir: Path, stem: str) -> Path | None:
     """Convert *csv_path* to BDF CSV; return output path or None."""
     try:
-        import bdf
         from bdf.io import save as bdf_save
     except ImportError:
         return None
@@ -168,11 +193,10 @@ def _convert_to_bdf(csv_path: Path, work_dir: Path, stem: str) -> Path | None:
         return out_path
 
     try:
-        sniff = bdf.detect(csv_path)
-        if sniff.id == "abstract" or sniff.confidence <= 0:
-            df = bdf.read(csv_path, validate=False)
-        else:
-            df = bdf.read(csv_path, validate=True)
+        # Tolerant conversion: bdf.read auto-detects the format (raising if no
+        # reader matches) and validate=False keeps partially-conformant files
+        # convertible — the interop policy is "express what you can".
+        df, _meta = _read_bdf_pandas(csv_path, validate=False)
         bdf_save(df, out_path, index=False)
         return out_path
     except Exception:
@@ -225,7 +249,6 @@ def convert_raw_to_bdf(raw_path: Path) -> tuple[Path | None, str | None]:
     ``.bdf.parquet`` already exists (test type re-inferred from the parquet).
     """
     try:
-        import bdf
         from bdf.io import save as bdf_save
     except ImportError:
         return None, None
@@ -252,7 +275,7 @@ def convert_raw_to_bdf(raw_path: Path) -> tuple[Path | None, str | None]:
         if df is None:
             # Suppress any diagnostic prints from batterydf plugins
             with _cl.redirect_stdout(_io.StringIO()), _cl.redirect_stderr(_io.StringIO()):
-                df = bdf.read(raw_path, validate=False)
+                df, _meta = _read_bdf_pandas(raw_path, validate=False)
             bdf_save(df, out_path, index=False)
         return out_path, _infer_test_type_from_df(df)
     except Exception:

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -429,7 +429,7 @@ def _bdf_measurement_period(csv_path: "str | Path") -> tuple[int, int] | None:
             print(
                 f"  warning: {path.name} unix_time_second={start} is implausible "
                 "(outside 2000-2100) - not stamping test/dataset times from it. "
-                "Known cause: batterydf<0.1.1 wrote epoch/1000; upgrade batterydf "
+                "Known cause: batterydf<0.2 wrote epoch/1000; upgrade batterydf "
                 "and re-run ws.convert()."
             )
             return None
@@ -1589,9 +1589,10 @@ class AuthoringWorkspace:
             raise ValueError(f"fmt must be 'parquet' or 'csv' (got {fmt!r})")
 
         try:
-            import bdf as _bdf
             import bdf.io as _bdf_io
             import bdf.repair as _bdf_repair
+
+            from battinfo.processing import _read_bdf_pandas
         except ImportError:
             raise ImportError(
                 "convert() needs the BDF converter (module 'bdf' from the batterydf "
@@ -1637,14 +1638,19 @@ class AuthoringWorkspace:
                 self._record_conversion(src, out)
                 continue
             try:
-                df = _bdf.read(src, validate=False)
+                # batterydf >= 0.2: read() returns (polars_frame, metadata); the
+                # helper collects to pandas (fix_time/save are pandas-based) and
+                # applies the ratified tz="UTC" timestamp policy.
+                df, meta = _read_bdf_pandas(src, validate=False)
                 df = _bdf_repair.fix_time(df)
                 _bdf_io.save(df, out)
             except Exception as exc:  # one bad file must not abort the batch
                 failed.append((src.name, str(exc)))
                 print(f"  FAILED: {src.name} -- {exc}")
                 continue
-            print(f"  {src.name}  ->  {out.name}  ({out.stat().st_size / 1e6:.1f} MB)")
+            reader = meta.get("source") if isinstance(meta, dict) else None
+            via = f", via {reader}" if reader else ""
+            print(f"  {src.name}  ->  {out.name}  ({out.stat().st_size / 1e6:.1f} MB{via})")
             written.append(out)
             # Remember the original so it can travel with the dataset as raw-source
             # provenance when the test is published (see ws.add('test', ...)).
@@ -1760,7 +1766,13 @@ class AuthoringWorkspace:
             try:
                 import bdf as _bdf
                 report = _bdf.validate(df)
-                if getattr(report, "ok", True) is False:
+                # batterydf >= 0.2 returns a dict report; older versions returned
+                # an object with an ``ok`` attribute.
+                if isinstance(report, dict):
+                    ok = report.get("ok", True)
+                else:
+                    ok = getattr(report, "ok", True)
+                if ok is False:
                     print(f"  BDF validation issues: {report}")
                 else:
                     print("  BDF validation passed.")

--- a/tests/test_reserved_namespace_segments.py
+++ b/tests/test_reserved_namespace_segments.py
@@ -1,0 +1,39 @@
+"""Reserved namespace segments can never become entity IRI namespaces.
+
+The reserved set mirrors IDENTIFIER_POLICY.md section 6.1: core resolver
+infrastructure paths plus the segments claimed by the ontology block in the
+upstream w3id.org .htaccess (raw/inferred/turtle/latest/source), which can
+never reach the record resolver.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.entities import ENTITY_KINDS, RESERVED_NAMESPACE_SEGMENTS
+
+
+def test_reserved_segments_include_policy_set() -> None:
+    expected = {
+        # resolver / vocabulary infrastructure
+        "id", "ontology", "vocab", "doc", "context", "resolver", "twin", "w3id",
+        # claimed by the ontology block in the upstream w3id .htaccess
+        "raw", "inferred", "turtle", "latest", "source",
+    }
+    assert expected <= RESERVED_NAMESPACE_SEGMENTS
+
+
+def test_no_entity_kind_uses_a_reserved_segment() -> None:
+    used = {kind.iri_namespace for kind in ENTITY_KINDS}
+    assert not (used & RESERVED_NAMESPACE_SEGMENTS)
+
+
+def test_reserved_segments_documented_in_identifier_policy() -> None:
+    """IDENTIFIER_POLICY.md must list every reserved segment (keep code and
+    policy from drifting)."""
+    policy = (ROOT / "IDENTIFIER_POLICY.md").read_text(encoding="utf-8")
+    for segment in RESERVED_NAMESPACE_SEGMENTS:
+        assert f"`{segment}`" in policy, f"IDENTIFIER_POLICY.md missing reserved segment {segment!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -264,7 +264,7 @@ wheels = [
 [[package]]
 name = "batterydf"
 version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/battery-data-alliance/battery-data-format?rev=f64c338#f64c3381d45147b4d017e6969e578cb9174fed6a" }
 dependencies = [
     { name = "matplotlib" },
     { name = "nbformat" },
@@ -273,17 +273,15 @@ dependencies = [
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "pint" },
+    { name = "platformdirs" },
     { name = "plotly" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "rdflib" },
     { name = "requests" },
     { name = "rich" },
     { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/e4/a2996d1310689a5ea9c3318a5e316e841985d8e113ac200ecc638f665133/batterydf-0.1.0.tar.gz", hash = "sha256:7ae8003e5e0380c5f71f6d83f65f47922bed27ad3d84002c47697ff308c75e0e", size = 94029, upload-time = "2026-02-10T19:29:14.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/52/8b1ef70d732d3c4c7b4f4acddf22e0e1ea46b26f0568b99a47999c78f39a/batterydf-0.1.0-py3-none-any.whl", hash = "sha256:95501235a643a7db07dd77a67a04ba2a38b136bf180da4f36c2eeb3dff5c1e64", size = 112628, upload-time = "2026-02-10T19:29:12.747Z" },
 ]
 
 [[package]]
@@ -351,7 +349,7 @@ tabular = [
 [package.metadata]
 requires-dist = [
     { name = "autodoc-pydantic", marker = "extra == 'docs'", specifier = ">=2.2" },
-    { name = "batterydf", marker = "extra == 'processing'", specifier = ">=0.1" },
+    { name = "batterydf", marker = "extra == 'processing'", git = "https://github.com/battery-data-alliance/battery-data-format?rev=f64c338" },
     { name = "battinfo", extras = ["publish"], marker = "extra == 'dev'" },
     { name = "battinfo", extras = ["tabular"], marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'storage'", specifier = ">=1.34" },
@@ -2800,6 +2798,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/99/fe77f10a13a778705ef05b499fc708c9a0b0a3680d9eb6bc6e1b6a6b9914/polars-1.42.1.tar.gz", hash = "sha256:2fe94f3059334650bd850ae19a9c165dcd5d9cb12cd95ea04de2201662e70e8a", size = 741532, upload-time = "2026-06-30T04:57:51.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl", hash = "sha256:3c0c65cdfa21a621650c4bdcbbccf93964d052fd766c3e70e84a55d961c259fd", size = 837622, upload-time = "2026-06-30T04:56:34.686Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/59/15bcc4dac380c6d63efa5446d8317f22671cbd6c9dadd576bd17a334c45a/polars_runtime_32-1.42.1.tar.gz", hash = "sha256:4d4809e1c1b9a6611f6944f27b24abea902b5159e6b6fa262fd716e947af5afd", size = 3045460, upload-time = "2026-06-30T04:57:52.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/29/16ff6e4e91d71e530d3581f45e342a9cc35072ac6b31dcbc2fa33de2569e/polars_runtime_32-1.42.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bbdc26d68ee5b23b0ce227fa0599220aa35b77c826b6b0a6b2d8e7f6c1c36974", size = 53117325, upload-time = "2026-06-30T04:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8e/4f8296fcfd1347f1351342fecf13bf2430d7efbae2f1f45964ec7930a99e/polars_runtime_32-1.42.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f6c0288be940b607dc4a7476c01e67fb6bbee93f5f1dd42c64970274c71008ba", size = 47446251, upload-time = "2026-06-30T04:56:41.459Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2e/0d66a7deadc453b890c3391034ca8ab4b05d0beaebbb92a7d65199fba61b/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635d9dbcae2302ae223afb395d5cd220bffa61a53d0ab6871d17c8bc830101cf", size = 51359402, upload-time = "2026-06-30T04:56:44.595Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d059e8e53cc114ff82f9bd791fd341dc53534a2c745e6f6aa37594c3a93f01fe", size = 57302723, upload-time = "2026-06-30T04:56:47.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/63/ca50adc62e44224ca5c622a842ba6f35ee87d1d40ef0df7ea2ed6c6edb08/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f91f0b13588324905682809d270e1de5f1990c908721c8527657d77a044c9919", size = 51515673, upload-time = "2026-06-30T04:56:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c3/08fbbf38deaa17bf34a601d327cb7451074098673c78b7c1a8538dde9794/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b8bf972d99d48aaaa2582e2bce966a6f43bc815bd8725d15f5cab9e2fb15d17", size = 55217259, upload-time = "2026-06-30T04:56:53.834Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/51db89361668fe077a835fc579277f824ba526e7daf7b94d23d25439e0d0/polars_runtime_32-1.42.1-cp310-abi3-win_amd64.whl", hash = "sha256:e9364c26da389a8b7339e4d29e20a3d12af730247e6ed3b7804bddce2477f428", size = 52715432, upload-time = "2026-06-30T04:56:57.109Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/2fb8592d691bd114de25d9c84300b23541dca7060eac11d7b4bed0327786/polars_runtime_32-1.42.1-cp310-abi3-win_arm64.whl", hash = "sha256:7051226e6b42ffc395a7a9190377cd28649fbfb991b8f85c6271f4e1cfb736fb", size = 46718300, upload-time = "2026-06-30T04:56:59.855Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adapts BattINFO to batterydf main ahead of the 0.2.0 release. Pin: batterydf>=0.2,<0.3 with a temporary [tool.uv.sources] git pin at f64c338; remove and re-lock when 0.2.0 is on PyPI.

- bdf.read() now returns (polars frame, metadata). A shared _read_bdf_pandas() helper (lazy=False, to_pandas, explicit tz="UTC") is used by processing.py, ws.convert() and interop/battdat.py.
- ws.convert() prints the resolved reader plugin.
- convert_csv() handles the new dict validation report; dead 0.1 detect() usage removed.
- Tutorial 6 re-executed: the 1970-era outputs from the upstream timestamp bug are gone.
- RESERVED_NAMESPACE_SEGMENTS extended with raw/inferred/turtle/latest/source (paths claimed by the ontology rules at w3id), with tests.
- docs/identifiers.md aligned with the deployed resolver (303 content negotiation, tombstones, aliases).

1375 passed / 3 skipped; ruff clean; all six guide notebooks execute; sphinx -W clean.
