### PR TITLE
Fix six data-loss and authoring bugs (convert, saves, queries, instance IRIs, templates)

### DIFF
--- a/assets/schemas/test-protocol.schema.json
+++ b/assets/schemas/test-protocol.schema.json
@@ -268,12 +268,36 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "value",
         "unit"
+      ],
+      "anyOf": [
+        {
+          "required": [
+            "value"
+          ]
+        },
+        {
+          "required": [
+            "min_value"
+          ]
+        },
+        {
+          "required": [
+            "max_value"
+          ]
+        }
       ],
       "properties": {
         "value": {
           "type": "number"
+        },
+        "min_value": {
+          "type": "number",
+          "description": "Lower bound of a window quantity (e.g. a 2.5-4.2 V voltage window); field names align with modules/common/quantity.schema.json."
+        },
+        "max_value": {
+          "type": "number",
+          "description": "Upper bound of a window quantity; field names align with modules/common/quantity.schema.json."
         },
         "unit": {
           "type": "string",

--- a/docs/pages/cli-reference.md
+++ b/docs/pages/cli-reference.md
@@ -185,6 +185,8 @@ $ battinfo query cell-spec [OPTIONS]
 * `--nominal-capacity-max FLOAT`: Filter maximum nominal capacity.
 * `--nominal-voltage-min FLOAT`: Filter minimum nominal voltage.
 * `--nominal-voltage-max FLOAT`: Filter maximum nominal voltage.
+* `--source-root PATH`: Records root to search (default: ./examples).
+* `--include-packaged-examples`: Also search BattINFO&#x27;s bundled example records.
 * `--limit INTEGER RANGE`: Maximum rows.  [default: 50; x&gt;=1]
 * `--offset INTEGER RANGE`: Start offset.  [default: 0; x&gt;=0]
 * `--format TEXT`: Output format: table|json.  [default: table]
@@ -209,6 +211,8 @@ $ battinfo query cell-instance [OPTIONS]
 * `--has-dataset TEXT`: Filter by dataset presence: true|false.
 * `--dataset-id TEXT`: Filter by linked dataset IRI.
 * `--source-type TEXT`: Filter by source type.
+* `--source-root PATH`: Records root to search (default: ./examples).
+* `--include-packaged-examples`: Also search BattINFO&#x27;s bundled example records.
 * `--limit INTEGER RANGE`: Maximum rows.  [default: 50; x&gt;=1]
 * `--offset INTEGER RANGE`: Start offset.  [default: 0; x&gt;=0]
 * `--format TEXT`: Output format: table|json.  [default: table]
@@ -233,6 +237,8 @@ $ battinfo query dataset [OPTIONS]
 * `--source-type TEXT`: Filter by source type.
 * `--data-format TEXT`: Filter by dataset format.
 * `--license TEXT`: Filter by license.
+* `--source-root PATH`: Records root to search (default: ./examples).
+* `--include-packaged-examples`: Also search BattINFO&#x27;s bundled example records.
 * `--limit INTEGER RANGE`: Maximum rows.  [default: 50; x&gt;=1]
 * `--offset INTEGER RANGE`: Start offset.  [default: 0; x&gt;=0]
 * `--format TEXT`: Output format: table|json.  [default: table]
@@ -254,6 +260,8 @@ $ battinfo query test-protocol [OPTIONS]
 * `--kind TEXT`: Filter by protocol kind.
 * `--name-contains TEXT`: Case-insensitive substring filter on protocol name.
 * `--source-type TEXT`: Filter by source type.
+* `--source-root PATH`: Records root to search (default: ./examples).
+* `--include-packaged-examples`: Also search BattINFO&#x27;s bundled example records.
 * `--limit INTEGER RANGE`: Maximum rows.  [default: 50; x&gt;=1]
 * `--offset INTEGER RANGE`: Start offset.  [default: 0; x&gt;=0]
 * `--format TEXT`: Output format: table|json.  [default: table]
@@ -275,6 +283,8 @@ $ battinfo query test-spec [OPTIONS]
 * `--kind TEXT`: Filter by protocol kind.
 * `--name-contains TEXT`: Case-insensitive substring filter on protocol name.
 * `--source-type TEXT`: Filter by source type.
+* `--source-root PATH`: Records root to search (default: ./examples).
+* `--include-packaged-examples`: Also search BattINFO&#x27;s bundled example records.
 * `--limit INTEGER RANGE`: Maximum rows.  [default: 50; x&gt;=1]
 * `--offset INTEGER RANGE`: Start offset.  [default: 0; x&gt;=0]
 * `--format TEXT`: Output format: table|json.  [default: table]
@@ -297,6 +307,8 @@ $ battinfo query tests [OPTIONS]
 * `--dataset-id TEXT`: Filter by linked dataset IRI.
 * `--kind TEXT`: Filter by test kind.
 * `--source-type TEXT`: Filter by source type.
+* `--source-root PATH`: Records root to search (default: ./examples).
+* `--include-packaged-examples`: Also search BattINFO&#x27;s bundled example records.
 * `--limit INTEGER RANGE`: Maximum rows.  [default: 50; x&gt;=1]
 * `--offset INTEGER RANGE`: Start offset.  [default: 0; x&gt;=0]
 * `--format TEXT`: Output format: table|json.  [default: table]
@@ -342,6 +354,8 @@ $ battinfo create cell-instance [OPTIONS]
 * `--dataset-id TEXT`: Optional linked dataset IRI.
 * `--source-type TEXT`: Source type: measurement|lab|bms|other.  [default: measurement]
 * `--uid TEXT`: Optional 16-char UID (dashed or undashed).
+* `--source-root PATH`: Records root for metadata type resolution (default: ./examples).
+* `--include-packaged-examples`: Also match BattINFO&#x27;s bundled example records during type resolution.
 * `--out PATH`: Optional output JSON path.
 * `--validate / --no-validate`: Validate against schema.  [default: validate]
 * `--format TEXT`: Output format: table|json.  [default: json]

--- a/src/battinfo/_workspace.py
+++ b/src/battinfo/_workspace.py
@@ -46,7 +46,7 @@ from battinfo.bundle import (
     TestConformance,
     TestSpec,
 )
-from battinfo.entities import iri_namespace_map, stable_uid
+from battinfo.entities import cell_instance_identity_seed, iri_namespace_map, stable_uid
 from battinfo.publication import DEFAULT_PUBLISH_FILENAME
 from battinfo.publication import publish as publish_bundle
 from battinfo.validate.record import validate_record_report
@@ -1713,47 +1713,42 @@ class Workspace:
             )
         return results
 
+    def _query_location(self, filters: dict[str, Any], *, dir_param: str = "directory") -> dict[str, Any]:
+        """Default a query to this workspace's records root unless the caller
+        already targeted a location (source_root= or a deprecated dir alias)."""
+        if dir_param not in filters and "source_root" not in filters:
+            filters["source_root"] = self.source_root
+        return filters
+
     def query_cell_specs(self, **filters: Any) -> list[dict[str, Any]]:
-        filters.setdefault("cell_specs_dir", self.source_root / "cell-spec")
-        return query_cell_specs(**filters)
+        return query_cell_specs(**self._query_location(filters, dir_param="cell_specs_dir"))
 
     def query(self, type: str, /, **filters: Any) -> list[dict[str, Any]]:
         normalized = type.strip().lower().replace("-", "_")
-        if normalized in {"cell_spec", "cell_specs", "cell_spec", "cell_specs"}:
-            filters.setdefault("cell_specs_dir", self.source_root / "cell-spec")
-            return query_api(type, **filters)
-        if normalized in {"cell", "cells", "cell_instance", "cell_instances"}:
-            filters.setdefault("directory", self.source_root / "cell-instance")
-            return query_api(type, **filters)
-        if normalized in {"test_spec", "test_specs", "test_protocol", "test_protocols"}:
-            filters.setdefault("directory", self.source_root / "test-protocol")
-            return query_api(type, **filters)
-        if normalized in {"test", "tests"}:
-            filters.setdefault("directory", self.source_root / "test")
-            return query_api(type, **filters)
-        if normalized in {"dataset", "datasets"}:
-            filters.setdefault("directory", self.source_root / "dataset")
-            return query_api(type, **filters)
+        if normalized in {"cell_spec", "cell_specs"}:
+            return query_api(type, **self._query_location(filters, dir_param="cell_specs_dir"))
+        if normalized in {
+            "cell", "cells", "cell_instance", "cell_instances",
+            "test_spec", "test_specs", "test_protocol", "test_protocols",
+            "test", "tests", "dataset", "datasets",
+        }:
+            return query_api(type, **self._query_location(filters))
         if normalized in {"description", "descriptions", "library_cell_spec", "library_cell_specs"}:
             filters.setdefault("directory", self.library_root)
             return query_api(type, **filters)
         return query_api(type, **filters)
 
     def query_cells(self, **filters: Any) -> list[dict[str, Any]]:
-        filters.setdefault("directory", self.source_root / "cell-instance")
-        return query_cell_instances(**filters)
+        return query_cell_instances(**self._query_location(filters))
 
     def query_tests(self, **filters: Any) -> list[dict[str, Any]]:
-        filters.setdefault("directory", self.source_root / "test")
-        return query_tests(**filters)
+        return query_tests(**self._query_location(filters))
 
     def query_test_specs(self, **filters: Any) -> list[dict[str, Any]]:
-        filters.setdefault("directory", self.source_root / "test-protocol")
-        return query_test_specs(**filters)
+        return query_test_specs(**self._query_location(filters))
 
     def query_datasets(self, **filters: Any) -> list[dict[str, Any]]:
-        filters.setdefault("directory", self.source_root / "dataset")
-        return query_datasets(**filters)
+        return query_datasets(**self._query_location(filters))
 
     def query_descriptions(self, **filters: Any) -> list[dict[str, Any]]:
         filters.setdefault("directory", self.library_root)
@@ -1977,17 +1972,23 @@ class Workspace:
         if finalized.name is None:
             finalized.name = finalized.serial_number or finalized.batch_id or "cell"
         if finalized.id is None:
-            finalized.id = _entity_iri(
-                "cell",
-                "::".join(
-                    [
-                        _with_default(finalized.cell_spec_id, "unknown-cell-spec"),
-                        finalized.serial_number or "",
-                        finalized.batch_id or "",
-                        _with_default(finalized.name, "cell"),
-                    ]
-                ),
+            # Shared cell-instance identity policy (entities.py): the same
+            # (spec IRI, serial/name) mints the same IRI here and on the
+            # low-level save_cell_instance/create_cell_instance surfaces.
+            seed = cell_instance_identity_seed(
+                cell_spec_id=finalized.cell_spec_id,
+                serial_number=finalized.serial_number,
+                batch_id=finalized.batch_id,
+                name=finalized.name,
             )
+            # name is defaulted above, so the seed is essentially always
+            # available; the fallback keeps the pre-refactor anonymous seed
+            # (colliding siblings are re-minted by _disambiguate_entity_ids).
+            if seed is None:
+                seed = "::".join(
+                    [_with_default(finalized.cell_spec_id, "unknown-cell-spec"), "", "", "cell"]
+                )
+            finalized.id = _entity_iri("cell", seed)
         if finalized.source.type is None:
             finalized.source.type = "measurement"
         if finalized.source.retrieved_at is None:

--- a/src/battinfo/api/_components.py
+++ b/src/battinfo/api/_components.py
@@ -16,11 +16,8 @@ from battinfo._util import _as_path, _citation_url_value
 from battinfo.api._records import _assert_id_matches_uid, save_record
 from battinfo.api._shared import (
     DATASET_IRI_RE,
-    DEFAULT_MATERIAL_SPECS_DIR,
-    DEFAULT_MATERIALS_DIR,
     DEFAULT_REGISTRATION_SOURCE_ROOT,
     DUPLICATE_POLICY_ERROR,
-    EXAMPLES_ROOT,
     MATERIAL_IRI_RE,
     MATERIAL_SPEC_IRI_RE,
     REGISTER_MODE_CREATE_ONLY,
@@ -28,9 +25,9 @@ from battinfo.api._shared import (
     PathLike,
     _component_iri_re,
     _iri_tail,
-    _iter_json_files,
     _normalized_dashed_uid,
     _paginate,
+    _query_record_files,
     _resolved_retrieved_at,
     _spec_iri_re,
     _str_eq,
@@ -364,13 +361,27 @@ def query_material_specs(
     formula: str | None = None,
     manufacturer: str | None = None,
     source_type: str | None = None,
-    directory: PathLike = DEFAULT_MATERIAL_SPECS_DIR,
+    source_root: PathLike | None = None,
+    directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query reusable material specifications."""
+    """Query reusable material specifications.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``, the
+    same root ``save_material_spec`` writes to). BattINFO's bundled example
+    materials are only searched with ``include_packaged_examples=True``; those
+    hits carry ``origin="packaged-example"`` so they can never masquerade as
+    your lab's inventory. ``directory=`` is a deprecated alias.
+    """
     records: list[dict[str, Any]] = []
-    for path in _iter_json_files(_as_path(directory)):
+    for path, origin in _query_record_files(
+        "material-spec",
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    ):
         doc = _load_json(path)
         spec = doc.get("material_spec", {})
         prov = doc.get("provenance", {})
@@ -385,6 +396,7 @@ def query_material_specs(
                 "formula": spec.get("formula"),
                 "manufacturer": spec.get("manufacturer"),
                 "source_type": prov.get("source_type") if isinstance(prov, Mapping) else None,
+                "origin": origin,
                 "path": str(path),
                 "record": doc,
             }
@@ -418,13 +430,25 @@ def query_materials(
     short_id_prefix: str | None = None,
     lot_id: str | None = None,
     source_type: str | None = None,
-    directory: PathLike = DEFAULT_MATERIALS_DIR,
+    source_root: PathLike | None = None,
+    directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query physical material lots/batches."""
+    """Query physical material lots/batches.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``);
+    bundled example records only with ``include_packaged_examples=True`` (hits
+    labeled ``origin="packaged-example"``). ``directory=`` is a deprecated alias.
+    """
     records: list[dict[str, Any]] = []
-    for path in _iter_json_files(_as_path(directory)):
+    for path, origin in _query_record_files(
+        "material",
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    ):
         doc = _load_json(path)
         material = doc.get("material", {})
         prov = doc.get("provenance", {})
@@ -437,6 +461,7 @@ def query_materials(
                 "short_id": material.get("short_id"),
                 "lot_id": material.get("lot_id"),
                 "source_type": prov.get("source_type") if isinstance(prov, Mapping) else None,
+                "origin": origin,
                 "path": str(path),
                 "record": doc,
             }
@@ -635,7 +660,7 @@ def save_component_instance(family: str, record: dict[str, Any] | PathLike, **kw
 
 def _query_component(
     record_key: str,
-    directory: Path,
+    files: list[tuple[Path, str]],
     *,
     id: str | None,
     name: str | None,
@@ -646,7 +671,7 @@ def _query_component(
     offset: int,
 ) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
-    for path in _iter_json_files(directory):
+    for path, origin in files:
         doc = _load_json(path)
         body = doc.get(record_key)
         if not isinstance(body, Mapping):
@@ -655,6 +680,7 @@ def _query_component(
             "id": body.get("id"),
             "name": body.get("name"),
             "short_id": body.get("short_id"),
+            "origin": origin,
             "path": str(path),
             "record": doc,
         }
@@ -679,17 +705,29 @@ def _query_component(
 def query_component_specs(
     family: str,
     *,
+    source_root: PathLike | None = None,
     directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     id: str | None = None,
     name: str | None = None,
     short_id_prefix: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query reusable component specifications for a family."""
-    d = _as_path(directory) if directory is not None else EXAMPLES_ROOT / f"{family.replace('_', '-')}-spec"
+    """Query reusable component specifications for a family.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``);
+    bundled example records only with ``include_packaged_examples=True`` (hits
+    labeled ``origin="packaged-example"``). ``directory=`` is a deprecated alias.
+    """
+    files = _query_record_files(
+        f"{family.replace('_', '-')}-spec",
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    )
     return _query_component(
-        f"{family}_spec", d, id=id, name=name, short_id_prefix=short_id_prefix,
+        f"{family}_spec", files, id=id, name=name, short_id_prefix=short_id_prefix,
         spec_ref_field=None, spec_id=None, limit=limit, offset=offset,
     )
 
@@ -697,7 +735,9 @@ def query_component_specs(
 def query_component_instances(
     family: str,
     *,
+    source_root: PathLike | None = None,
     directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     id: str | None = None,
     name: str | None = None,
     short_id_prefix: str | None = None,
@@ -705,10 +745,20 @@ def query_component_instances(
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query physical component instances for a family."""
-    d = _as_path(directory) if directory is not None else EXAMPLES_ROOT / family.replace("_", "-")
+    """Query physical component instances for a family.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``);
+    bundled example records only with ``include_packaged_examples=True`` (hits
+    labeled ``origin="packaged-example"``). ``directory=`` is a deprecated alias.
+    """
+    files = _query_record_files(
+        family.replace("_", "-"),
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    )
     return _query_component(
-        family, d, id=id, name=name, short_id_prefix=short_id_prefix,
+        family, files, id=id, name=name, short_id_prefix=short_id_prefix,
         spec_ref_field=f"{family}_spec_id", spec_id=spec_id, limit=limit, offset=offset,
     )
 

--- a/src/battinfo/api/_records.py
+++ b/src/battinfo/api/_records.py
@@ -19,9 +19,6 @@ from battinfo.api._shared import (
     CELL_IRI_RE,
     CELL_SPEC_IRI_RE,
     DATASET_IRI_RE,
-    DEFAULT_CELL_INSTANCES_DIR,
-    DEFAULT_CELL_TYPES_DIR,
-    DEFAULT_DATASETS_DIR,
     DEFAULT_LIBRARY_AGGREGATE_JSONLD,
     DEFAULT_LIBRARY_CELL_TYPES_DIR,
     DEFAULT_LIBRARY_MANIFEST_JSON,
@@ -29,8 +26,6 @@ from battinfo.api._shared import (
     DEFAULT_PACKAGED_LIBRARY_CELL_TYPES_DIR,
     DEFAULT_PUBLISH_SOURCES,
     DEFAULT_REGISTRATION_SOURCE_ROOT,
-    DEFAULT_TEST_PROTOCOLS_DIR,
-    DEFAULT_TESTS_DIR,
     DUPLICATE_POLICIES,
     DUPLICATE_POLICY_ERROR,
     DUPLICATE_POLICY_RETURN_EXISTING,
@@ -48,6 +43,7 @@ from battinfo.api._shared import (
     _normalized_dashed_uid,
     _paginate,
     _quantity_numeric_value,
+    _query_record_files,
     _resolved_retrieved_at,
     _resolved_time,
     _short_id_from_iri,
@@ -340,15 +336,30 @@ def query_cell_specs(
     nominal_voltage_min: float | None = None,
     nominal_voltage_max: float | None = None,
     spec_filters: Mapping[str, tuple[float | None, float | None]] | None = None,
-    cell_specs_dir: PathLike = DEFAULT_CELL_TYPES_DIR,
+    source_root: PathLike | None = None,
+    cell_specs_dir: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query cell types using practical metadata/property filters."""
+    """Query cell types using practical metadata/property filters.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``, the
+    same root ``save_cell_spec`` writes to). BattINFO's bundled demo fleet is
+    only searched with ``include_packaged_examples=True``; those hits carry
+    ``origin="packaged-example"``. ``cell_specs_dir=`` is a deprecated alias
+    pointing directly at one record directory.
+    """
     records: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
 
-    for path in _iter_json_files(_as_path(cell_specs_dir)):
+    for path, origin in _query_record_files(
+        "cell-spec",
+        source_root=source_root,
+        directory=cell_specs_dir,
+        include_packaged_examples=include_packaged_examples,
+        directory_param="cell_specs_dir",
+    ):
         doc = _load_json(path)
         product = doc.get("cell_spec", {})
         specs = doc.get("properties", {})
@@ -401,6 +412,7 @@ def query_cell_specs(
                 "nominal_voltage": _spec_numeric_value(specs, "nominal_voltage"),
                 "properties": specs,
                 "source": "cell-spec",
+                "origin": origin,
                 "path": str(path),
             }
         )
@@ -449,13 +461,25 @@ def query_cell_instances(
     has_dataset: bool | None = None,
     dataset_id: str | None = None,
     source_type: str | None = None,
-    directory: PathLike = DEFAULT_CELL_INSTANCES_DIR,
+    source_root: PathLike | None = None,
+    directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query physical cell instances."""
+    """Query physical cell instances.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``);
+    bundled demo records only with ``include_packaged_examples=True`` (hits
+    labeled ``origin="packaged-example"``). ``directory=`` is a deprecated alias.
+    """
     records: list[dict[str, Any]] = []
-    for path in _iter_json_files(_as_path(directory)):
+    for path, origin in _query_record_files(
+        "cell",
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    ):
         doc = _load_json(path)
         inst = doc.get("cell_instance", {})
         prov = doc.get("provenance", {})
@@ -483,6 +507,7 @@ def query_cell_instances(
             "dataset_id": linked_dataset_ids[0] if linked_dataset_ids else None,
             "dataset_ids": linked_dataset_ids,
             "source_type": prov.get("source_type") if isinstance(prov, Mapping) else None,
+            "origin": origin,
             "path": str(path),
             "record": doc,
         }
@@ -520,13 +545,25 @@ def query_datasets(
     source_type: str | None = None,
     format: str | None = None,
     license: str | None = None,
-    directory: PathLike = DEFAULT_DATASETS_DIR,
+    source_root: PathLike | None = None,
+    directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query dataset metadata records."""
+    """Query dataset metadata records.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``);
+    bundled demo records only with ``include_packaged_examples=True`` (hits
+    labeled ``origin="packaged-example"``). ``directory=`` is a deprecated alias.
+    """
     records: list[dict[str, Any]] = []
-    for path in _iter_json_files(_as_path(directory)):
+    for path, origin in _query_record_files(
+        "dataset",
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    ):
         doc = _load_json(path)
         dataset = doc.get("dataset", {})
         prov = doc.get("provenance", {})
@@ -569,6 +606,7 @@ def query_datasets(
                 item for item in about if isinstance(item, str) and TEST_IRI_RE.fullmatch(item)
             ] if isinstance(about, list) else [],
             "source_type": prov.get("source_type") if isinstance(prov, Mapping) else None,
+            "origin": origin,
             "path": str(path),
             "record": doc,
         }
@@ -602,13 +640,25 @@ def query_tests(
     dataset_id: str | None = None,
     kind: str | None = None,
     source_type: str | None = None,
-    directory: PathLike = DEFAULT_TESTS_DIR,
+    source_root: PathLike | None = None,
+    directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Query canonical test metadata records."""
+    """Query canonical test metadata records.
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``);
+    bundled demo records only with ``include_packaged_examples=True`` (hits
+    labeled ``origin="packaged-example"``). ``directory=`` is a deprecated alias.
+    """
     records: list[dict[str, Any]] = []
-    for path in _iter_json_files(_as_path(directory)):
+    for path, origin in _query_record_files(
+        "test",
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    ):
         doc = _load_json(path)
         test = doc.get("test", {})
         prov = doc.get("provenance", {})
@@ -629,6 +679,7 @@ def query_tests(
                 "conformance": test.get("conformance"),
                 "dataset_ids": [item for item in dataset_ids if isinstance(item, str)],
                 "source_type": prov.get("source_type") if isinstance(prov, Mapping) else None,
+                "origin": origin,
                 "path": str(path),
                 "record": doc,
             }
@@ -664,7 +715,9 @@ def query_test_specs(
     has_cv_hold: bool | None = None,
     has_rest: bool | None = None,
     has_eis: bool | None = None,
-    directory: PathLike = DEFAULT_TEST_PROTOCOLS_DIR,
+    source_root: PathLike | None = None,
+    directory: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
@@ -673,9 +726,19 @@ def query_test_specs(
     Beyond identity filters, the ``mode`` / ``direction`` / ``tag`` / ``c_rate`` /
     ``has_cv_hold`` / ``has_rest`` / ``has_eis`` filters match against the derived
     ``facets`` rollup, so an agent can find protocols by what their method *does*
-    (e.g. all specs with a CV hold, or any using C/2)."""
+    (e.g. all specs with a CV hold, or any using C/2).
+
+    Searches YOUR records under ``source_root`` (default: ``./examples``);
+    bundled demo records only with ``include_packaged_examples=True`` (hits
+    labeled ``origin="packaged-example"``). ``directory=`` is a deprecated alias.
+    """
     records: list[dict[str, Any]] = []
-    for path in _iter_json_files(_as_path(directory)):
+    for path, origin in _query_record_files(
+        "test-protocol",
+        source_root=source_root,
+        directory=directory,
+        include_packaged_examples=include_packaged_examples,
+    ):
         doc = _load_json(path)
         protocol = doc.get("test_spec", {})
         prov = doc.get("provenance", {})
@@ -691,6 +754,7 @@ def query_test_specs(
                 "protocol_url": protocol.get("protocol_url"),
                 "source_type": prov.get("source_type") if isinstance(prov, Mapping) else None,
                 "facets": doc.get("facets") if isinstance(doc.get("facets"), Mapping) else {},
+                "origin": origin,
                 "path": str(path),
                 "record": doc,
             }
@@ -765,9 +829,16 @@ def resolve_cell_spec_id(
     chemistry: str | None = None,
     format: str | None = None,
     exact_model: bool = True,
+    source_root: PathLike | None = None,
+    include_packaged_examples: bool = False,
     limit: int = 50,
 ) -> str:
-    """Resolve a unique `cell-spec` IRI from metadata filters."""
+    """Resolve a unique `cell-spec` IRI from metadata filters.
+
+    Metadata filters resolve against YOUR records (see ``query_cell_specs``);
+    pass ``include_packaged_examples=True`` to also match BattINFO's bundled
+    demo fleet.
+    """
     if cell_spec_id is not None:
         if not CELL_SPEC_IRI_RE.fullmatch(cell_spec_id):
             raise ValueError("cell_spec_id must match https://w3id.org/battinfo/spec/{uid}.")
@@ -778,6 +849,8 @@ def resolve_cell_spec_id(
         chemistry=chemistry,
         format=format,
         model_name_contains=model_name,
+        source_root=source_root,
+        include_packaged_examples=include_packaged_examples,
         limit=limit,
         offset=0,
     )
@@ -811,13 +884,17 @@ def create_cell_instance(
     dataset_id: str | None = None,
     source_type: str = "measurement",
     uid: str | None = None,
+    source_root: PathLike | None = None,
+    include_packaged_examples: bool = False,
     out_path: PathLike | None = None,
     validate: bool = True,
 ) -> dict[str, Any]:
     """Create a physical cell-instance document.
 
     You can pass a canonical `cell_spec_id`, a `cell_spec` document/path, or metadata filters
-    (`model_name`, `manufacturer`, ...) to resolve the type.
+    (`model_name`, `manufacturer`, ...) to resolve the type. Metadata filters resolve against
+    YOUR records under ``source_root`` (default ``./examples``); pass
+    ``include_packaged_examples=True`` to also match the bundled demo fleet.
     """
     resolved_cell_spec_id = cell_spec_id
 
@@ -843,6 +920,8 @@ def create_cell_instance(
         manufacturer=manufacturer,
         chemistry=chemistry,
         format=format,
+        source_root=source_root,
+        include_packaged_examples=include_packaged_examples,
     )
 
     if source_type not in {"measurement", "lab", "bms", "other"}:
@@ -851,7 +930,18 @@ def create_cell_instance(
     if dataset_id is not None and not DATASET_IRI_RE.fullmatch(dataset_id):
         raise ValueError("dataset_id must match https://w3id.org/battinfo/dataset/{uid}.")
 
-    dashed_uid = _normalized_dashed_uid(uid)
+    if uid is None:
+        # Mint through the shared cell-instance identity policy so the same
+        # (spec IRI, serial) yields the same IRI here, in save_cell_instance,
+        # and in the workspace — not a fresh random identity per surface.
+        from battinfo.entities import cell_instance_identity_seed, stable_uid  # noqa: PLC0415
+
+        identity_seed = cell_instance_identity_seed(
+            cell_spec_id=resolved_cell_spec_id, serial_number=serial_number
+        )
+        dashed_uid = stable_uid(identity_seed) if identity_seed is not None else _normalized_dashed_uid(None)
+    else:
+        dashed_uid = _normalized_dashed_uid(uid)
     instance_id = f"https://w3id.org/battinfo/cell/{dashed_uid}"
 
     out: dict[str, Any] = {
@@ -998,17 +1088,19 @@ def _identity_minted_uid(entity_kind: str, entity: Any) -> str:
             ]
         )
     elif entity_kind == "cell":
-        name = entity.name or entity.serial_number or entity.batch_id
-        if not _seed_part(name):
-            return _normalized_dashed_uid(None)
-        seed = "::".join(
-            [
-                _seed_part(entity.cell_spec_id, "unknown-cell-spec"),
-                entity.serial_number or "",
-                entity.batch_id or "",
-                _seed_part(name, "cell"),
-            ]
+        from battinfo.entities import cell_instance_identity_seed  # noqa: PLC0415
+
+        # Single shared identity policy for cell instances (see entities.py):
+        # the workspace finalizer and both low-level save surfaces mint from it.
+        shared_seed = cell_instance_identity_seed(
+            cell_spec_id=entity.cell_spec_id,
+            serial_number=entity.serial_number,
+            batch_id=entity.batch_id,
+            name=entity.name,
         )
+        if shared_seed is None:
+            return _normalized_dashed_uid(None)
+        seed = shared_seed
     elif entity_kind == "test-protocol":
         if not (_seed_part(entity.name) or _seed_part(entity.version)):
             return _normalized_dashed_uid(None)
@@ -1196,7 +1288,15 @@ def _record_from_test_protocol(spec: TestSpec) -> dict[str, Any]:
 
 
 def _resolve_references_for_save(doc: dict[str, Any], source_root: Path) -> None:
-    report = validate_references_report(doc, source_root, allow_missing=True)
+    """Reference gate for the save path (default ON via ``resolve_references=True``).
+
+    Cross-record references (``cell_spec_id``, component/material ``*_spec_id``,
+    ``protocol_id``, dataset links, ...) must resolve to records that exist under
+    *source_root* — a dangling reference is an error, not a silent success.
+    Staged workflows that intentionally save the referencing record first can
+    opt out with ``resolve_references=False``.
+    """
+    report = validate_references_report(doc, source_root, allow_missing=False)
     if report.ok:
         return
     raise ValueError(format_report_errors(report, prefix="Reference validation failed"))
@@ -1954,7 +2054,13 @@ def save_batch(
                         source_root=source_root,
                         mode=mode_normalized,
                         duplicate_policy=duplicate_policy_normalized,
-                        resolve_references=resolve_references,
+                        # Per-record reference checks are deferred inside the
+                        # batch (records in a set may legitimately reference
+                        # each other in any order, even circularly); when
+                        # resolve_references=True the COMPLETED set is
+                        # link-validated below, so a dangling reference still
+                        # fails the batch — just not half-way through it.
+                        resolve_references=False,
                         publish=publish,
                         publish_root=publish_root,
                         build_jsonld=build_jsonld,

--- a/src/battinfo/api/_shared.py
+++ b/src/battinfo/api/_shared.py
@@ -10,17 +10,19 @@ import json
 import math
 import re
 import secrets
+import warnings
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
-from battinfo._util import _now_unix
+from battinfo._util import _as_path, _now_unix
 from battinfo.bundle import (
     BatteryTestType,
 )
 from battinfo.entities import (
     ENTITY_KINDS,
     entity_id_from_doc,
+    iter_entity_files,
     kind_for_doc,
 )
 from battinfo.validate.core import DEFAULT_POLICY, ValidationPolicy
@@ -263,6 +265,51 @@ def _iter_json_files(directory: Path) -> Iterable[Path]:
     if not directory.exists():
         return []
     return sorted(directory.glob("*.json"))
+
+
+# Origin labels attached to query hits so results always say where they came from.
+QUERY_ORIGIN_LOCAL = "local"
+QUERY_ORIGIN_PACKAGED = "packaged-example"
+
+
+def _query_record_files(
+    entity_type: str,
+    *,
+    source_root: PathLike | None,
+    directory: PathLike | None,
+    include_packaged_examples: bool,
+    directory_param: str = "directory",
+) -> list[tuple[Path, str]]:
+    """Resolve which record files a ``query_*`` function searches, with origins.
+
+    The default location is the user's own records under
+    ``<cwd>/examples/<type-dir>`` — the same root the ``save_*`` functions write
+    to by default — never the examples bundled inside the installed wheel.
+    BattINFO's packaged demo records are only searched when the caller asks for
+    them explicitly (``include_packaged_examples=True``), and those hits are
+    labeled ``origin="packaged-example"`` so they can never masquerade as lab
+    records. ``directory``/per-function dir kwargs remain as deprecated aliases
+    pointing directly at a single record directory.
+    """
+    files: list[tuple[Path, str]] = []
+    if directory is not None:
+        if source_root is not None:
+            raise ValueError(f"Pass either source_root= or {directory_param}=, not both.")
+        warnings.warn(
+            f"{directory_param}= is deprecated; pass source_root= pointing at the records "
+            "root (the parent of the per-type directories) instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        files.extend((path, QUERY_ORIGIN_LOCAL) for path in _iter_json_files(_as_path(directory)))
+    else:
+        root = _as_path(source_root) if source_root is not None else Path(DEFAULT_REGISTRATION_SOURCE_ROOT)
+        files.extend((path, QUERY_ORIGIN_LOCAL) for path in iter_entity_files(entity_type, root))
+    if include_packaged_examples:
+        files.extend(
+            (path, QUERY_ORIGIN_PACKAGED) for path in iter_entity_files(entity_type, EXAMPLES_ROOT)
+        )
+    return files
 
 
 def _editorial_record_id(*values: object) -> str:

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -2210,7 +2210,8 @@ class TestSpec(BundleJsonModel):
             record["safety"] = copy.deepcopy(self.safety)
         if self.conditions:
             record["conditions"] = {
-                name: qty.model_dump(mode="json") for name, qty in self.conditions.items()
+                name: qty.model_dump(mode="json", exclude_none=True)
+                for name, qty in self.conditions.items()
             }
         if self.artifacts:
             record["artifacts"] = [a.to_record() for a in self.artifacts]

--- a/src/battinfo/cli.py
+++ b/src/battinfo/cli.py
@@ -1498,6 +1498,10 @@ def query_cell_specs(
     nominal_capacity_max: float | None = typer.Option(None, help="Filter maximum nominal capacity."),
     nominal_voltage_min: float | None = typer.Option(None, help="Filter minimum nominal voltage."),
     nominal_voltage_max: float | None = typer.Option(None, help="Filter maximum nominal voltage."),
+    source_root: Path | None = typer.Option(None, help="Records root to search (default: ./examples)."),
+    include_packaged_examples: bool = typer.Option(
+        False, "--include-packaged-examples", help="Also search BattINFO's bundled example records."
+    ),
     limit: int = typer.Option(50, min=1, help="Maximum rows."),
     offset: int = typer.Option(0, min=0, help="Start offset."),
     output_format: str = typer.Option("table", "--format", help="Output format: table|json."),
@@ -1514,6 +1518,8 @@ def query_cell_specs(
         nominal_capacity_max=nominal_capacity_max,
         nominal_voltage_min=nominal_voltage_min,
         nominal_voltage_max=nominal_voltage_max,
+        source_root=source_root,
+        include_packaged_examples=include_packaged_examples,
         limit=limit,
         offset=offset,
     )
@@ -1542,6 +1548,10 @@ def query_cell_instances(
     has_dataset: str | None = typer.Option(None, help="Filter by dataset presence: true|false."),
     dataset_id: str | None = typer.Option(None, help="Filter by linked dataset IRI."),
     source_type: str | None = typer.Option(None, help="Filter by source type."),
+    source_root: Path | None = typer.Option(None, help="Records root to search (default: ./examples)."),
+    include_packaged_examples: bool = typer.Option(
+        False, "--include-packaged-examples", help="Also search BattINFO's bundled example records."
+    ),
     limit: int = typer.Option(50, min=1, help="Maximum rows."),
     offset: int = typer.Option(0, min=0, help="Start offset."),
     output_format: str = typer.Option("table", "--format", help="Output format: table|json."),
@@ -1557,6 +1567,8 @@ def query_cell_instances(
         has_dataset=dataset_bool,
         dataset_id=dataset_id,
         source_type=source_type,
+        source_root=source_root,
+        include_packaged_examples=include_packaged_examples,
         limit=limit,
         offset=offset,
     )
@@ -1582,6 +1594,10 @@ def query_datasets(
     source_type: str | None = typer.Option(None, help="Filter by source type."),
     data_format: str | None = typer.Option(None, "--data-format", help="Filter by dataset format."),
     license: str | None = typer.Option(None, help="Filter by license."),
+    source_root: Path | None = typer.Option(None, help="Records root to search (default: ./examples)."),
+    include_packaged_examples: bool = typer.Option(
+        False, "--include-packaged-examples", help="Also search BattINFO's bundled example records."
+    ),
     limit: int = typer.Option(50, min=1, help="Maximum rows."),
     offset: int = typer.Option(0, min=0, help="Start offset."),
     output_format: str = typer.Option("table", "--format", help="Output format: table|json."),
@@ -1596,6 +1612,8 @@ def query_datasets(
         source_type=source_type,
         format=data_format,
         license=license,
+        source_root=source_root,
+        include_packaged_examples=include_packaged_examples,
         limit=limit,
         offset=offset,
     )
@@ -1619,6 +1637,10 @@ def query_test_specs(
     kind: str | None = typer.Option(None, help="Filter by protocol kind."),
     name_contains: str | None = typer.Option(None, help="Case-insensitive substring filter on protocol name."),
     source_type: str | None = typer.Option(None, help="Filter by source type."),
+    source_root: Path | None = typer.Option(None, help="Records root to search (default: ./examples)."),
+    include_packaged_examples: bool = typer.Option(
+        False, "--include-packaged-examples", help="Also search BattINFO's bundled example records."
+    ),
     limit: int = typer.Option(50, min=1, help="Maximum rows."),
     offset: int = typer.Option(0, min=0, help="Start offset."),
     output_format: str = typer.Option("table", "--format", help="Output format: table|json."),
@@ -1630,6 +1652,8 @@ def query_test_specs(
         kind=kind,
         name_contains=name_contains,
         source_type=source_type,
+        source_root=source_root,
+        include_packaged_examples=include_packaged_examples,
         limit=limit,
         offset=offset,
     )
@@ -1653,6 +1677,10 @@ def query_tests(
     dataset_id: str | None = typer.Option(None, help="Filter by linked dataset IRI."),
     kind: str | None = typer.Option(None, help="Filter by test kind."),
     source_type: str | None = typer.Option(None, help="Filter by source type."),
+    source_root: Path | None = typer.Option(None, help="Records root to search (default: ./examples)."),
+    include_packaged_examples: bool = typer.Option(
+        False, "--include-packaged-examples", help="Also search BattINFO's bundled example records."
+    ),
     limit: int = typer.Option(50, min=1, help="Maximum rows."),
     offset: int = typer.Option(0, min=0, help="Start offset."),
     output_format: str = typer.Option("table", "--format", help="Output format: table|json."),
@@ -1665,6 +1693,8 @@ def query_tests(
         dataset_id=dataset_id,
         kind=kind,
         source_type=source_type,
+        source_root=source_root,
+        include_packaged_examples=include_packaged_examples,
         limit=limit,
         offset=offset,
     )
@@ -1695,6 +1725,13 @@ def create_cell_instance(
     dataset_id: str | None = typer.Option(None, help="Optional linked dataset IRI."),
     source_type: str = typer.Option("measurement", help="Source type: measurement|lab|bms|other."),
     uid: str | None = typer.Option(None, help="Optional 16-char UID (dashed or undashed)."),
+    source_root: Path | None = typer.Option(
+        None, help="Records root for metadata type resolution (default: ./examples)."
+    ),
+    include_packaged_examples: bool = typer.Option(
+        False, "--include-packaged-examples",
+        help="Also match BattINFO's bundled example records during type resolution.",
+    ),
     out: Path | None = typer.Option(None, help="Optional output JSON path."),
     validate: bool = typer.Option(True, "--validate/--no-validate", help="Validate against schema."),
     output_format: str = typer.Option("json", "--format", help="Output format: table|json."),
@@ -1713,6 +1750,8 @@ def create_cell_instance(
             dataset_id=dataset_id,
             source_type=source_type,
             uid=uid,
+            source_root=source_root,
+            include_packaged_examples=include_packaged_examples,
             out_path=out,
             validate=validate,
         )

--- a/src/battinfo/data/schemas/test-protocol.schema.json
+++ b/src/battinfo/data/schemas/test-protocol.schema.json
@@ -268,12 +268,36 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "value",
         "unit"
+      ],
+      "anyOf": [
+        {
+          "required": [
+            "value"
+          ]
+        },
+        {
+          "required": [
+            "min_value"
+          ]
+        },
+        {
+          "required": [
+            "max_value"
+          ]
+        }
       ],
       "properties": {
         "value": {
           "type": "number"
+        },
+        "min_value": {
+          "type": "number",
+          "description": "Lower bound of a window quantity (e.g. a 2.5-4.2 V voltage window); field names align with modules/common/quantity.schema.json."
+        },
+        "max_value": {
+          "type": "number",
+          "description": "Upper bound of a window quantity; field names align with modules/common/quantity.schema.json."
         },
         "unit": {
           "type": "string",

--- a/src/battinfo/entities.py
+++ b/src/battinfo/entities.py
@@ -41,6 +41,38 @@ def stable_uid(seed: str) -> str:
     return "-".join((token[:4], token[4:8], token[8:12], token[12:16]))
 
 
+def cell_instance_identity_seed(
+    *,
+    cell_spec_id: str | None,
+    serial_number: str | None = None,
+    batch_id: str | None = None,
+    name: str | None = None,
+) -> Optional[str]:
+    """Identity seed for a physical cell instance — shared by every minting surface.
+
+    The instance IRI is deterministic from (spec IRI, serial/batch/name), so the
+    same physical cell authored through the workspace (``ws.add('cell', ...)``),
+    ``save_cell_instance`` or ``create_cell_instance`` lands on the same IRI
+    instead of minting parallel identities per surface.
+
+    Returns ``None`` when the instance carries no distinguishing identity at all
+    (no name, serial, or batch) — callers must then fall back to their own
+    anonymous policy (e.g. a random uid), because two anonymous but physically
+    distinct cells must never silently dedup into one.
+    """
+    label = (name or serial_number or batch_id or "").strip()
+    if not label:
+        return None
+    return "::".join(
+        [
+            (cell_spec_id or "").strip() or "unknown-cell-spec",
+            serial_number or "",
+            batch_id or "",
+            label,
+        ]
+    )
+
+
 @dataclass(frozen=True)
 class EntityKind:
     """Metadata describing one BattINFO record type.

--- a/src/battinfo/testmethod.py
+++ b/src/battinfo/testmethod.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import re
 from typing import Any, Optional, Sequence
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = [
     "Quantity",
@@ -56,10 +56,37 @@ class ExperimentSyntaxError(ValueError):
 # ── Model ─────────────────────────────────────────────────────────────────────
 
 class Quantity(BaseModel):
-    """A scalar value with its unit (e.g. ``{value: 4.2, unit: "V"}``)."""
+    """A value (or min/max window) with its unit.
+
+    Scalar form: ``{value: 4.2, unit: "V"}``. Window form (aligned with the
+    canonical quantity schema's ``min_value``/``max_value`` fields):
+    ``{min_value: 2.5, max_value: 4.2, unit: "V"}`` — e.g. a test-spec voltage
+    window. At least one of ``value``/``min_value``/``max_value`` is required.
+    """
     model_config = ConfigDict(extra="forbid")
-    value: float
+    value: Optional[float] = None
+    min_value: Optional[float] = None
+    max_value: Optional[float] = None
     unit: str
+
+    @model_validator(mode="after")
+    def _require_some_value(self) -> "Quantity":
+        if self.value is None and self.min_value is None and self.max_value is None:
+            raise ValueError(
+                "Quantity needs at least one of value, min_value, max_value "
+                "(e.g. {'value': 25, 'unit': 'degC'} or "
+                "{'min_value': 2.5, 'max_value': 4.2, 'unit': 'V'})."
+            )
+        if (
+            self.min_value is not None
+            and self.max_value is not None
+            and self.min_value > self.max_value
+        ):
+            raise ValueError(
+                f"Quantity min_value ({self.min_value}) must not exceed "
+                f"max_value ({self.max_value})."
+            )
+        return self
 
 
 class Termination(BaseModel):
@@ -294,6 +321,11 @@ def _fmt_crate(value: float) -> str:
 
 
 def _fmt_setpoint(kind: str, qty: Quantity) -> str:
+    if qty.value is None:
+        # Window form ({min_value, max_value}) — render as a range label.
+        lo = _fmt_number(qty.min_value) if qty.min_value is not None else "?"
+        hi = _fmt_number(qty.max_value) if qty.max_value is not None else "?"
+        return f"{lo}..{hi} {qty.unit}"
     if kind == "c_rate":
         return _fmt_crate(qty.value)
     if kind == "current":
@@ -333,7 +365,7 @@ def render_step(step: Step) -> str:
         head = "Rest"
     elif step.mode == "cv":
         volt = step.setpoints.get("voltage")
-        head = f"Hold at {_fmt_number(volt.value)} V" if volt else "Hold"
+        head = f"Hold at {_fmt_number(volt.value)} V" if volt and volt.value is not None else "Hold"
     elif step.mode in ("cc", "cp", "cr"):
         word = "Charge" if step.direction == "charge" else "Discharge"
         kind = next(iter(step.setpoints), None)
@@ -343,7 +375,7 @@ def render_step(step: Step) -> str:
         rate = next((k for k in step.setpoints if k != "voltage"), None)
         volt = step.setpoints.get("voltage")
         rate_str = f" at {_fmt_setpoint(rate, step.setpoints[rate])}" if rate else ""
-        volt_str = f" to {_fmt_number(volt.value)} V then hold" if volt else ""
+        volt_str = f" to {_fmt_number(volt.value)} V then hold" if volt and volt.value is not None else ""
         head = f"{word}{rate_str}{volt_str}"
     else:
         # eis / scan / group / unknown — not PyBaMM-expressible; use a label.
@@ -401,22 +433,25 @@ def compute_facets(steps: Sequence[Step],
         if step.mode in _CONTROL_MODE:
             control_modes.add(_CONTROL_MODE[step.mode])
         for key, qty in step.setpoints.items():
+            values = [v for v in (qty.value, qty.min_value, qty.max_value) if v is not None]
             if key == "c_rate":
-                c_rates.append(qty.value)
+                c_rates.extend(values)
             elif key == "voltage":
-                voltages.append(qty.value)
+                voltages.extend(values)
         for term in step.termination:
             if term.quantity == "voltage":
                 voltages.append(term.value)
             elif term.quantity == "c_rate":
                 c_rates.append(term.value)
-        if step.temperature is not None:
+        if step.temperature is not None and step.temperature.value is not None:
             temperatures.append(step.temperature.value)
         tags.update(step.tags)
 
     for key, qty in (conditions or {}).items():
         if key in ("temperature", "ambient_temperature", "room_temperature"):
-            temperatures.append(qty.value)
+            temperatures.extend(
+                v for v in (qty.value, qty.min_value, qty.max_value) if v is not None
+            )
 
     leaf_modes = {s.mode for s in _iter_leaf_steps(steps)}
     facets: dict[str, Any] = {

--- a/src/battinfo/testmethod.py
+++ b/src/battinfo/testmethod.py
@@ -193,15 +193,25 @@ def _parse_duration(text: str) -> Quantity:
     return Quantity(value=_to_float(m.group(1), text) * _TIME_TABLE[m.group(2).lower()], unit="s")
 
 
+def _require_value(qty: Quantity, context: str) -> float:
+    """Step-syntax quantities are always single-valued; min/max windows have no
+    meaning inside a parsed step, so reject them with a parse-level error."""
+    if qty.value is None:
+        raise ExperimentSyntaxError(f"{context} requires a single value, not a min/max window.")
+    return qty.value
+
+
 def _termination_from_value(kind: str, qty: Quantity, direction: str | None) -> Termination:
     """Map a parsed ``until`` value to a termination, inferring approach direction
     from the step's charge/discharge sense when not otherwise determined."""
     if kind == "voltage":
-        return Termination(quantity="voltage", value=qty.value, unit=qty.unit,
+        return Termination(quantity="voltage", value=_require_value(qty, "A voltage termination"),
+                           unit=qty.unit,
                            direction="above" if direction == "charge" else "below")
     if kind in ("current", "c_rate"):
         # Cutoff currents are crossed from above as the cell relaxes/charges taper.
-        return Termination(quantity=kind, value=qty.value, unit=qty.unit, direction="below")
+        return Termination(quantity=kind, value=_require_value(qty, "A current termination"),
+                           unit=qty.unit, direction="below")
     raise ExperimentSyntaxError(f"Unsupported termination quantity '{kind}'.")
 
 
@@ -340,7 +350,7 @@ def _fmt_setpoint(kind: str, qty: Quantity) -> str:
 
 
 def _fmt_duration(qty: Quantity) -> str:
-    seconds = qty.value
+    seconds = _require_value(qty, "A step duration")
     if seconds % 3600 == 0:
         return f"for {_fmt_number(seconds / 3600)} hours"
     if seconds % 60 == 0:

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -965,6 +965,134 @@ _BDF_CANONICAL_COLUMNS: list[tuple[str, str]] = [
 ]
 
 
+def _unmapped_source_columns(
+    src: Path, plugin_id: str | None, out_columns: list[str]
+) -> list[str]:
+    """Source columns that did not survive a BDF conversion (best-effort).
+
+    Reads the raw column header of *src* through the resolved reader plugin and
+    returns every source column that neither resolves to a BDF canonical name
+    nor passes through to the converted output. Binary formats whose parsers
+    cannot cheaply expose a header return ``[]`` (nothing to compare against),
+    and any inspection failure degrades to ``[]`` — the report must never break
+    a conversion that already succeeded.
+    """
+    try:
+        import bdf.io as _bdf_io  # noqa: PLC0415
+
+        plugin = _bdf_io.PLUGINS[plugin_id] if plugin_id in _bdf_io.PLUGINS else None
+        parser = getattr(plugin, "table_parser", None)
+        read_headings = getattr(parser, "read_column_headings", None)
+        if read_headings is None:
+            return []
+        raw_headers = [h for h in read_headings(src) if isinstance(h, str) and h.strip()]
+        normalizer = getattr(parser, "normalizer", None)
+        survived = set(out_columns)
+        unmapped: list[str] = []
+        for header in raw_headers:
+            if header in survived:
+                continue
+            try:
+                if normalizer is not None and normalizer.resolve([header]):
+                    continue  # renamed into a canonical BDF column
+            except Exception:  # noqa: BLE001 — treat resolver hiccups as unmapped
+                pass
+            unmapped.append(header)
+        return unmapped
+    except Exception:  # noqa: BLE001 — reporting is best-effort by design
+        return []
+
+
+# Legacy/authored test-spec condition keys -> (canonical condition name, default unit).
+# ws.template() used to emit unit-suffixed keys with bare scalars or {min,max}
+# dicts; these keep loading (coerced to proper quantities) so old drafts survive.
+_TEMPLATE_CONDITION_KEYS: dict[str, tuple[str, str]] = {
+    "temperature": ("temperature", "degC"),
+    "temperature_degC": ("temperature", "degC"),
+    "applied_pressure": ("applied_pressure", "kPa"),
+    "applied_pressure_kilopascal": ("applied_pressure", "kPa"),
+    "voltage_window": ("voltage_window", "V"),
+    "voltage_window_volt": ("voltage_window", "V"),
+    "soc_window": ("soc_window", "%"),
+    "c_rate": ("c_rate", "A/Ah"),
+    "d_rate": ("d_rate", "A/Ah"),
+}
+
+
+def _clean_template_conditions(raw: Any) -> tuple[dict[str, dict] | None, list[str]]:
+    """Lift authored/template ``conditions`` to quantity shapes the model accepts.
+
+    - Drops null placeholders (unfilled template entries) instead of failing.
+    - Coerces legacy shapes: bare scalars under unit-suffixed keys
+      (``temperature_degC: 25``) and ``{min, max}`` windows become
+      ``{value|min_value|max_value, unit}`` quantities.
+    - Non-numeric entries (e.g. ``atmosphere: "argon"``) cannot be quantities;
+      they are returned as notes so the information is kept, not dropped.
+    """
+    if not isinstance(raw, dict):
+        return None, []
+    out: dict[str, dict] = {}
+    notes: list[str] = []
+    for key, value in raw.items():
+        if value is None or str(key).startswith("_"):
+            continue
+        name, default_unit = _TEMPLATE_CONDITION_KEYS.get(key, (str(key), ""))
+        if isinstance(value, bool):
+            notes.append(f"condition {key}: {value}")
+            continue
+        if isinstance(value, (int, float)):
+            qty: dict[str, Any] = {"value": float(value)}
+        elif isinstance(value, dict):
+            qty = {k: v for k, v in value.items() if v is not None and not str(k).startswith("_")}
+            # legacy window keys
+            if "min" in qty:
+                qty["min_value"] = qty.pop("min")
+            if "max" in qty:
+                qty["max_value"] = qty.pop("max")
+            if not any(k in qty for k in ("value", "min_value", "max_value")):
+                continue  # placeholder left unfilled
+        elif isinstance(value, str):
+            if value.strip():
+                notes.append(f"condition {key}: {value.strip()}")
+            continue
+        else:
+            notes.append(f"condition {key}: {value!r}")
+            continue
+        if not qty.get("unit"):
+            if not default_unit:
+                raise ValueError(
+                    f"condition {key!r} needs a unit, e.g. "
+                    '{"value": 25, "unit": "degC"}.'
+                )
+            qty["unit"] = default_unit
+        out[name] = qty
+    return (out or None), notes
+
+
+def _clean_template_steps(raw: Any) -> builtins.list[str] | None:
+    """Normalize authored/template ``steps`` to the PyBaMM-string list the model parses.
+
+    Strings pass through; the old template's ``{"description": ...}`` dict
+    placeholder is dropped, and a dict whose description was actually edited is
+    lifted to its string so the authored step is not silently ignored.
+    """
+    if not isinstance(raw, list):
+        return None
+    steps: list[str] = []
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            steps.append(item.strip())
+        elif isinstance(item, dict):
+            description = item.get("description")
+            if (
+                isinstance(description, str)
+                and description.strip()
+                and description.strip().lower() != "fill in test steps here"
+            ):
+                steps.append(description.strip())
+    return steps or None
+
+
 class AuthoringWorkspace:
     """The blessed authoring surface: a simplified workspace for BattINFO records.
 
@@ -1004,7 +1132,7 @@ class AuthoringWorkspace:
         # in-memory search cache; populated lazily from registry API or local index
         self._search_cache: list[dict] | None = None
         # converted-file → original-source mapping (lazy-loaded from manifest)
-        self._conversion_sources: dict[str, str] | None = None
+        self._conversion_sources: dict[str, Any] | None = None
         # paths written by the most recent ws.save() — submit() uses this to
         # avoid re-submitting records from previous sessions in the same directory
         self._session_paths: set[Path] = set()
@@ -1626,6 +1754,7 @@ class AuthoringWorkspace:
         suffix = f".bdf.{fmt}"
         written: list[Path] = []
         failed: list[tuple[str, str]] = []
+        lossy: list[tuple[str, list[str]]] = []
         for src in input_files:
             # NEWARE filenames carry an embedded short-ID batch key used later for
             # cell↔file matching; keep that.  Other formats use the plain stem.
@@ -1652,12 +1781,29 @@ class AuthoringWorkspace:
             via = f", via {reader}" if reader else ""
             print(f"  {src.name}  ->  {out.name}  ({out.stat().st_size / 1e6:.1f} MB{via})")
             written.append(out)
+            # A conversion that silently discards source columns is data loss
+            # behind a success message — compare the source header against what
+            # actually survived and report every column left behind.
+            unmapped = _unmapped_source_columns(src, reader, list(df.columns))
+            if unmapped:
+                lossy.append((src.name, unmapped))
+                print(f"  WARNING: {len(unmapped)} source column(s) were NOT mapped to BDF "
+                      f"and are missing from {out.name}:")
+                for col in unmapped:
+                    print(f"    - {col}")
+                print(f"    (reader plugin: {reader or 'unknown'} -- if that looks wrong, the "
+                      "file was likely detected as the wrong instrument format)")
+                print("    Fix: ws.bdf_columns() lists the canonical names, then "
+                      f"ws.convert_csv({src.name!r}, hints={{'<source column>': '<bdf name>'}}).")
             # Remember the original so it can travel with the dataset as raw-source
             # provenance when the test is published (see ws.add('test', ...)).
-            self._record_conversion(src, out)
+            self._record_conversion(src, out, unmapped_columns=unmapped)
 
         print(f"\nConverted {len(written)} file(s) -> {bdf_dir}"
               + (f"  ({len(failed)} failed)" if failed else ""))
+        if lossy:
+            print(f"  DATA-LOSS WARNING: {len(lossy)} file(s) had unmapped source columns "
+                  "(details above) -- the converted files do NOT contain those columns.")
         if failed:
             print("  Failed files may be an unsupported variant -- try exporting a CSV "
                   "and ws.convert('*.csv'), or ws.convert_csv(path, hints={...}).")
@@ -1783,6 +1929,24 @@ class AuthoringWorkspace:
 
         mapped = ", ".join(sorted(set(hints.values()))) if hints else "(no remap)"
         print(f"  {src.name}  ->  {out.name}   mapped: {mapped}")
+        # Columns that are still not BDF canonical names were kept as-is, but
+        # downstream BDF tooling will not recognize them — say so out loud
+        # instead of green-lighting a partially mapped file silently.
+        def _is_canonical(column: str) -> bool:
+            try:
+                from bdf.spec import COLUMN_ONTOLOGY  # noqa: PLC0415
+                return COLUMN_ONTOLOGY.get(column) is not None
+            except Exception:  # noqa: BLE001 — fall back to the curated subset
+                return column in {name for name, _ in _BDF_CANONICAL_COLUMNS}
+
+        unmapped = [c for c in df.columns if not _is_canonical(c)]
+        if unmapped:
+            print(f"  WARNING: {len(unmapped)} column(s) are not BDF canonical names "
+                  "(kept unchanged, but BDF tooling will ignore them):")
+            for col in unmapped:
+                print(f"    - {col}")
+            print("    Fix: ws.bdf_columns() lists the canonical names; re-run "
+                  "ws.convert_csv(path, hints={'<source column>': '<bdf name>'}).")
         return out
 
     def commands(self) -> None:
@@ -1932,7 +2096,7 @@ class AuthoringWorkspace:
             print(f"No {label} records found" + (f" matching {query!r}." if query else "."))
         return out
 
-    def template(self, record_type: str, **kwargs) -> Path:
+    def template(self, record_type: str | None = None, **kwargs) -> Path:
         """Write a fillable JSON template for a cell spec, test spec, or equipment spec.
 
         Fill in the generated file, then load it with ``ws.load(path)``.
@@ -1951,6 +2115,11 @@ class AuthoringWorkspace:
                         name="SkyRC MC3000", manufacturer="SkyRC", model="MC3000",
                         equipment_class="cycler", channel_count=4)
         """
+        if record_type is None:
+            raise ValueError(
+                "template() needs a record type: 'cell-spec', 'test-spec', or "
+                "'equipment-spec'. Example: ws.template('cell-spec', manufacturer='...', model='...')"
+            )
         rt = record_type.replace("_", "-")
         if rt in ("test-spec", "test-protocol"):   # accept old name during transition
             return self._template_test_spec(**kwargs)
@@ -1985,7 +2154,8 @@ class AuthoringWorkspace:
 
         safe_mfr = re.sub(r"[^a-zA-Z0-9]", "-", manufacturer)
         safe_model = re.sub(r"[^a-zA-Z0-9]", "-", model)
-        out_path = self._root / f"{safe_mfr}-{safe_model}.cell-spec.json"
+        slug = f"{safe_mfr}-{safe_model}".strip("-") or "cell-spec"
+        out_path = self._root / f"{slug}.cell-spec.json"
         if out_path.exists():
             print(f"  exists: {out_path.name}  (delete to regenerate)")
             return out_path
@@ -1994,29 +2164,56 @@ class AuthoringWorkspace:
         return out_path
 
     def _template_test_spec(self, **kwargs) -> Path:
+        from battinfo.bundle import BatteryTestType  # noqa: PLC0415
+
         name = kwargs.get("name", "")
-        test_type = kwargs.get("type", kwargs.get("kind", ""))
+        test_type = kwargs.get("type", kwargs.get("kind", "")) or ""
+        allowed_types = [t.value for t in BatteryTestType]
+        if test_type and test_type not in allowed_types:
+            raise ValueError(
+                f"type must be one of: {', '.join(allowed_types)} (got {test_type!r})."
+            )
+
+        def _scalar(value: Any, unit: str) -> dict:
+            return {"value": value, "unit": unit}
+
+        def _window(value: Any, unit: str) -> dict:
+            lo = hi = None
+            if isinstance(value, dict):
+                lo = value.get("min_value", value.get("min"))
+                hi = value.get("max_value", value.get("max"))
+            elif isinstance(value, (list, tuple)) and len(value) == 2:
+                lo, hi = value
+            return {"min_value": lo, "max_value": hi, "unit": unit}
+
+        steps = kwargs.get("steps", kwargs.get("experiment"))
         template = {
             "name":        name,
             "type":        test_type,
+            "_allowed_types": allowed_types,
             "description": kwargs.get("description", None),
             "instrument":  kwargs.get("instrument",  None),
-            "steps": kwargs.get("steps", [
-                {"description": "Fill in test steps here"}
-            ]),
+            "atmosphere":  kwargs.get("atmosphere",  None),
+            # PyBaMM-style step strings; ws.load() parses them into the
+            # structured method. Leave empty if the method comes later.
+            "steps": list(steps) if steps else [],
+            "_steps_help": "PyBaMM-style strings, e.g. 'Discharge at C/5 for 10 hours "
+                           "or until 2.5 V', 'Hold at 4.2 V until C/50', 'Rest for 30 minutes'.",
+            # Every condition is a quantity: {value, unit} or {min_value, max_value, unit}.
+            # Fill in what applies and delete the rest; null placeholders are
+            # ignored by ws.load(). Keys starting with '_' are comments.
             "conditions": {
-                "temperature_degC": kwargs.get("temperature_degC", None),
-                "applied_pressure_kilopascal": kwargs.get("applied_pressure_kilopascal", None),
-                "atmosphere":       kwargs.get("atmosphere",       None),
-                "voltage_window_volt": kwargs.get("voltage_window_volt", {"min": None, "max": None}),
-                "soc_window":       kwargs.get("soc_window",       {"min": None, "max": None}),
-                "c_rate":           kwargs.get("c_rate",           None),
-                "d_rate":           kwargs.get("d_rate",           None),
+                "temperature":      _scalar(kwargs.get("temperature_degC"), "degC"),
+                "applied_pressure": _scalar(kwargs.get("applied_pressure_kilopascal"), "kPa"),
+                "voltage_window":   _window(kwargs.get("voltage_window_volt"), "V"),
+                "soc_window":       _window(kwargs.get("soc_window"), "%"),
+                "c_rate":           _scalar(kwargs.get("c_rate"), "A/Ah"),
+                "d_rate":           _scalar(kwargs.get("d_rate"), "A/Ah"),
             },
             "citation":    kwargs.get("citation",    None),
             "source_file": kwargs.get("source_file", None),
         }
-        safe_name = re.sub(r"[^a-zA-Z0-9]", "-", name or "test-spec")
+        safe_name = re.sub(r"[^a-zA-Z0-9]", "-", name).strip("-") or "test-spec"
         out_path = self._root / f"{safe_name}.test-spec.json"
         if out_path.exists():
             print(f"  exists: {out_path.name}  (delete to regenerate)")
@@ -5420,8 +5617,9 @@ class AuthoringWorkspace:
     def _conversions_path(self) -> Path:
         return self._root / ".battinfo" / "conversions.json"
 
-    def _load_conversions(self) -> dict[str, str]:
-        """Mapping of converted-file path → original source path (both absolute)."""
+    def _load_conversions(self) -> dict[str, Any]:
+        """Mapping of converted-file path → source path (str) or a dict with
+        ``source`` + ``unmapped_columns`` (both paths absolute)."""
         if self._conversion_sources is None:
             p = self._conversions_path()
             self._conversion_sources = (
@@ -5429,10 +5627,29 @@ class AuthoringWorkspace:
             )
         return self._conversion_sources
 
-    def _record_conversion(self, src: Path, out: Path) -> None:
-        """Remember that *out* was converted from *src*, for provenance at publish."""
+    def _record_conversion(
+        self, src: Path, out: Path, *, unmapped_columns: builtins.list[str] | None = None
+    ) -> None:
+        """Remember that *out* was converted from *src*, for provenance at publish.
+
+        When the conversion dropped source columns (see :meth:`convert`), their
+        names are recorded alongside the source link so the loss stays visible
+        after the session ends. Entries without loss keep the legacy plain-string
+        form (out -> src) for compatibility with existing manifests.
+        """
         conv = self._load_conversions()
-        conv[str(out.resolve())] = str(src.resolve())
+        if unmapped_columns:
+            conv[str(out.resolve())] = {
+                "source": str(src.resolve()),
+                "unmapped_columns": list(unmapped_columns),
+            }
+        else:
+            existing = conv.get(str(out.resolve()))
+            # Don't erase a previously recorded loss report with a bare re-link.
+            if isinstance(existing, dict) and existing.get("unmapped_columns"):
+                existing["source"] = str(src.resolve())
+            else:
+                conv[str(out.resolve())] = str(src.resolve())
         p = self._conversions_path()
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps(conv, indent=2, ensure_ascii=False), encoding="utf-8")
@@ -5445,7 +5662,10 @@ class AuthoringWorkspace:
         no longer exists.
         """
         conv = self._load_conversions()
-        src = conv.get(str(data_path.resolve()))
+        entry = conv.get(str(data_path.resolve()))
+        # Entries are either the legacy plain source string or a dict carrying
+        # the source plus an unmapped-column loss report (see _record_conversion).
+        src = entry.get("source") if isinstance(entry, dict) else entry
         if not src:
             return None
         sp = Path(src)
@@ -5899,19 +6119,13 @@ class AuthoringWorkspace:
             print("  No cell instances to add" + (f" (match={match!r})." if match else "."))
             return []
 
-        # Inherit spec properties as default measured values on each instance.
-        spec_defaults: dict[str, Any] = {}
-        try:
-            specs_obj = getattr(spec, "properties", None)
-            raw_specs: dict = specs_obj if isinstance(specs_obj, dict) else (
-                spec.to_record().get("properties") or {}
-            )
-            spec_defaults = {
-                k: v for k, v in raw_specs.items()
-                if isinstance(v, dict) and v.get("value") is not None
-            }
-        except Exception:
-            pass
+        # NOTE: spec nominal ratings are deliberately NOT copied into each
+        # instance's `measured` block. Rated/nominal values are not
+        # measurements — auto-copying them fabricated per-cell "measurement"
+        # provenance for values nobody measured. The spec's ratings stay on
+        # the spec record, which every instance already references via
+        # cell_spec_id; genuine measurements arrive via measured=... on
+        # ws.cell()/Cell or from test data.
 
         # Conformance (vs the cell spec): one value applied to all, or a parallel list.
         if isinstance(conformance, (list, tuple)):
@@ -5933,7 +6147,6 @@ class AuthoringWorkspace:
                 grade=grade,
                 manufactured_at=production_date,
                 expires_at=expiration_date,
-                measured=spec_defaults if spec_defaults else None,
                 conformance=conf,
             )
             if iri is not None:
@@ -5950,22 +6163,57 @@ class AuthoringWorkspace:
         return cells
 
     def _load_test_spec(self, path: Path) -> Any:
+        from battinfo.bundle import BatteryTestType  # noqa: PLC0415
+
         raw = json.loads(path.read_text(encoding="utf-8"))
+        # Keys starting with "_" are in-file comments written by ws.template()
+        # (e.g. _allowed_types, _steps_help) — never record content.
+        raw = {k: v for k, v in raw.items() if not str(k).startswith("_")}
+
+        allowed_types = [t.value for t in BatteryTestType]
+        test_type = raw.get("type") or raw.get("kind") or ""
+        if not test_type:
+            raise ValueError(
+                f"{path.name}: fill in 'type' before loading. "
+                f"Allowed values: {', '.join(allowed_types)}."
+            )
+        if test_type not in allowed_types:
+            raise ValueError(
+                f"{path.name}: unknown type {test_type!r}. "
+                f"Allowed values: {', '.join(allowed_types)}."
+            )
+
+        conditions, condition_notes = _clean_template_conditions(raw.get("conditions"))
+        steps = _clean_template_steps(raw.get("experiment") or raw.get("steps"))
+
+        # Fields with no structured home on a test spec are preserved as notes
+        # rather than silently dropped (instrument belongs on the test run;
+        # atmosphere has no numeric quantity form).
+        notes: list[str] = []
+        for label, value in (("instrument", raw.get("instrument")),
+                             ("atmosphere", raw.get("atmosphere"))):
+            if isinstance(value, str) and value.strip():
+                notes.append(f"{label}: {value.strip()}")
+        notes.extend(condition_notes)
+
         # Forward the authored method so it survives into the saved record (and
         # thence the published JSON-LD as an EMMO process graph). Humans author the
         # PyBaMM-style `experiment`/`steps` strings; a pre-built structured `method`
         # is also accepted. Protocol-level record/safety/conditions/artifacts pass through.
         tp = self._ws.test_protocol(
             name=raw.get("name", ""),
-            type=raw.get("type") or raw.get("kind", ""),
+            type=test_type,
             description=raw.get("description"),
-            experiment=raw.get("experiment") or raw.get("steps"),
+            experiment=steps,
             cycles=raw.get("cycles"),
             method=raw.get("method"),
-            conditions=raw.get("conditions"),
+            conditions=conditions,
             record=raw.get("record"),
             safety=raw.get("safety"),
             artifacts=raw.get("artifacts"),
+            citation=raw.get("citation"),
+            source_file=raw.get("source_file"),
+            comment=notes or None,
         )
         return tp
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -193,7 +193,7 @@ def test_query_cell_specs_exposes_iec_code(tmp_path: Path) -> None:
     )
     save_cell_spec(record, source_root=tmp_path)
 
-    rows = query_cell_specs(cell_specs_dir=tmp_path / "cell-spec")
+    rows = query_cell_specs(source_root=tmp_path)
 
     assert len(rows) == 1
     assert rows[0]["iec_code"] == "IFpR26650"
@@ -637,11 +637,11 @@ def test_save_test_protocol_and_test_with_protocol_reference(tmp_path: Path) -> 
     assert protocol["entity_type"] == "test-protocol"
     assert test["entity_type"] == "test"
 
-    protocol_rows = query_test_specs(directory=tmp_path / "test-protocol")
+    protocol_rows = query_test_specs(source_root=tmp_path)
     assert len(protocol_rows) == 1
     assert protocol_rows[0]["id"] == protocol["id"]
 
-    test_rows = query_tests(directory=tmp_path / "test")
+    test_rows = query_tests(source_root=tmp_path)
     assert len(test_rows) == 1
     assert test_rows[0]["protocol_id"] == protocol["id"]
 
@@ -908,20 +908,27 @@ def test_save_record_accepts_canonical_records_and_paths(tmp_path: Path) -> None
     assert dataset_payload["path"].endswith("dataset-8c1h-8pk6-8034-vav6.json")
 
 
-def test_save_cell_instance_missing_reference_is_deferred_until_set_validation(tmp_path: Path) -> None:
+def test_save_cell_instance_dangling_reference_fails_by_default(tmp_path: Path) -> None:
+    """P1 fix 2: a dangling *_spec_id reference is an error at save time (default ON),
+    with the missing IRIs named; resolve_references=False remains the staged-workflow
+    opt-out, and set-level validation still catches the gap afterwards."""
     source_root = tmp_path / "examples"
-    payload = save_cell_instance(
-        Cell(
-            uid="eysh4h5sk4bxzkgg",
-            cell_spec_id="https://w3id.org/battinfo/spec/pvn1-43h7-rm3e-mjqq",
-            dataset_id="https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x",
-            source_type="measurement",
-        ),
-        source_root=source_root,
-        resolve_references=True,
+    draft = Cell(
+        uid="eysh4h5sk4bxzkgg",
+        cell_spec_id="https://w3id.org/battinfo/spec/pvn1-43h7-rm3e-mjqq",
+        dataset_id="https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x",
+        source_type="measurement",
     )
-    assert payload["status"] == "created"
+    with pytest.raises(ValueError) as excinfo:
+        save_cell_instance(draft, source_root=source_root, resolve_references=True)
+    message = str(excinfo.value)
+    assert "Reference validation failed" in message
+    assert "https://w3id.org/battinfo/spec/pvn1-43h7-rm3e-mjqq" in message
+    assert "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x" in message
 
+    # Staged workflows can opt out explicitly; the set validator still reports the gap.
+    payload = save_cell_instance(draft, source_root=source_root, resolve_references=False)
+    assert payload["status"] == "created"
     index = build_index(source_root=source_root, validate=True)
     assert index["failed"] == 1
     assert "cell_instance.cell_spec_id" in index["failures"][0]["error"]

--- a/tests/test_cli_query_create_publish.py
+++ b/tests/test_cli_query_create_publish.py
@@ -234,7 +234,10 @@ def test_publish_cell_spec_cli_accepts_input_file(tmp_path: Path, monkeypatch) -
     assert payload["page_url"] == "https://battery-genome.org/registry/cell-spec/cell-spec-002"
 
 
-def test_save_record_with_resolve_references_defers_missing_targets(tmp_path: Path) -> None:
+def test_save_record_with_resolve_references_rejects_missing_targets(tmp_path: Path) -> None:
+    """P1 fix 2: --resolve-references (the default) fails a save whose references
+    don't exist under source_root; --no-resolve-references stays the staged-workflow
+    opt-out."""
     runner = CliRunner()
     source_root = tmp_path / "examples"
     cell_instance_path = tmp_path / "cell-instance.json"
@@ -277,8 +280,26 @@ def test_save_record_with_resolve_references_defers_missing_targets(tmp_path: Pa
             "json",
         ],
     )
-    assert result.exit_code == 0, result.stdout
-    payload = json.loads(result.stdout)
+    assert result.exit_code == 1
+    assert "Reference validation failed" in result.stdout
+    assert "https://w3id.org/battinfo/spec/eysh-4h5s-k4bx-zkgg" in result.stdout
+
+    deferred = runner.invoke(
+        app,
+        [
+            "save",
+            "record",
+            "--input",
+            str(cell_instance_path),
+            "--source-root",
+            str(source_root),
+            "--no-resolve-references",
+            "--format",
+            "json",
+        ],
+    )
+    assert deferred.exit_code == 0, deferred.stdout
+    payload = json.loads(deferred.stdout)
     assert payload["status"] == "created"
 
 

--- a/tests/test_lab_p1_traps.py
+++ b/tests/test_lab_p1_traps.py
@@ -1,0 +1,445 @@
+"""Regression tests for the P1 lab-engineer campaign: six silent-data-loss/authoring traps.
+
+Source: docs/internal/LAB-ENGINEER-CAMPAIGN-2026-07-17.md, clusters C2 + the C3
+template item. Each test pins the FIXED behavior so the trap cannot silently
+return:
+
+1. ws.convert / convert_csv never green-light a lossy conversion silently.
+2. Dangling ``*_spec_id`` references fail save by default (opt-out kwarg).
+3. query_* never silently searches the wheel's bundled examples.
+4. Cell-instance IRIs are deterministic across every minting surface.
+5. ws.add("cell") does not fabricate measurements from spec ratings.
+6. ws.template("test-spec") round-trips through ws.load(), and a voltage
+   window is expressible in the Quantity model + schema.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+import battinfo
+from battinfo import api
+from battinfo.bundle import BatteryTestType, Cell, CellSpec
+from battinfo.testmethod import Quantity
+from battinfo.validate.record import validate_record_report
+from battinfo.ws import AuthoringWorkspace
+
+# ── Fix 1: convert must report unmapped/dropped source columns ────────────────
+
+def test_convert_reports_unmapped_source_columns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A conversion that discards source columns (the Digatron-via-wrong-plugin
+    red-team case: AhStep[Ah]/Step/Mode gone behind a success message) must
+    print a loud per-file report naming every dropped column and pointing at
+    ws.bdf_columns() / convert_csv(hints=...)."""
+    pytest.importorskip("bdf")
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    src = tmp_path / "digatron_export.csv"
+    src.write_text(
+        "test_time_second,voltage_volt,current_ampere,AhStep[Ah],Step,Mode\n"
+        "0,3.7,1.0,0.0,1,CC\n"
+        "1,3.71,1.0,0.001,1,CC\n",
+        encoding="utf-8",
+    )
+
+    written = ws.convert("*.csv")
+
+    assert len(written) == 1
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "AhStep[Ah]" in out and "Step" in out and "Mode" in out
+    assert "bdf_columns()" in out
+    assert "convert_csv" in out
+    assert "DATA-LOSS WARNING" in out
+    # And the loss is recorded durably in the conversion manifest, without
+    # breaking raw-source provenance lookup.
+    manifest = json.loads((tmp_path / ".battinfo" / "conversions.json").read_text(encoding="utf-8"))
+    entry = manifest[str(written[0].resolve())]
+    assert entry["source"] == str(src.resolve())
+    assert set(entry["unmapped_columns"]) == {"AhStep[Ah]", "Step", "Mode"}
+    assert ws._resolve_raw_source(written[0]) == src.resolve()
+
+
+def test_convert_clean_file_has_no_loss_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pytest.importorskip("bdf")
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    (tmp_path / "clean.csv").write_text(
+        "test_time_second,voltage_volt,current_ampere\n0,3.7,1.0\n1,3.71,1.0\n",
+        encoding="utf-8",
+    )
+    written = ws.convert("*.csv")
+    assert len(written) == 1
+    out = capsys.readouterr().out
+    assert "DATA-LOSS WARNING" not in out
+    # Legacy plain-string manifest form is kept for lossless conversions.
+    manifest = json.loads((tmp_path / ".battinfo" / "conversions.json").read_text(encoding="utf-8"))
+    assert isinstance(manifest[str(written[0].resolve())], str)
+
+
+def test_convert_csv_warns_on_non_canonical_columns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pd = pytest.importorskip("pandas")
+    src = tmp_path / "maccor.csv"
+    pd.DataFrame({"Cycle": [1, 2], "Voltage(V)": [3.7, 3.6], "Weird Col": [0, 1]}).to_csv(
+        src, index=False
+    )
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    ws.convert_csv(src, hints={"Cycle": "cycle_count", "Voltage(V)": "voltage_volt"}, validate=False)
+    out = capsys.readouterr().out
+    assert "WARNING" in out and "Weird Col" in out
+    assert "bdf_columns()" in out
+    # Mapped columns are not flagged.
+    assert "- cycle_count" not in out and "- voltage_volt" not in out
+
+
+def test_resolve_raw_source_accepts_legacy_manifest_entries(tmp_path: Path) -> None:
+    """Manifests written before the loss report (plain out->src strings) keep working."""
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    src = tmp_path / "raw.csv"
+    src.write_text("a\n1\n", encoding="utf-8")
+    out = tmp_path / "bdf" / "raw.bdf.csv"
+    out.parent.mkdir()
+    out.write_text("a\n1\n", encoding="utf-8")
+    manifest_path = tmp_path / ".battinfo" / "conversions.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps({str(out.resolve()): str(src.resolve())}), encoding="utf-8"
+    )
+    assert ws._resolve_raw_source(out) == src.resolve()
+
+
+# ── Fix 2: dangling *_spec_id references fail save by default ─────────────────
+
+def test_save_cell_spec_rejects_dangling_component_reference(tmp_path: Path) -> None:
+    spec = CellSpec(
+        manufacturer="Acme",
+        model="X3",
+        format="pouch",
+        chemistry="Li-ion",
+        electrolyte_spec_id="https://w3id.org/battinfo/spec/zzzz-zzzz-zzzz-zzzz",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        api.save_cell_spec(spec, source_root=tmp_path)
+    message = str(excinfo.value)
+    assert "Reference validation failed" in message
+    assert "https://w3id.org/battinfo/spec/zzzz-zzzz-zzzz-zzzz" in message
+    # Staged workflows opt out explicitly.
+    payload = api.save_cell_spec(spec, source_root=tmp_path, resolve_references=False)
+    assert payload["status"] == "created"
+
+
+def test_save_cell_spec_accepts_existing_component_reference(tmp_path: Path) -> None:
+    saved = api.save_electrolyte_spec(
+        api.create_electrolyte_spec(
+            name="1M LiPF6 EC:DMC", uid="2222222222222222", body={"family": "organic"}
+        ),
+        source_root=tmp_path,
+    )
+    electrolyte_id = saved["id"]
+    payload = api.save_cell_spec(
+        CellSpec(
+            manufacturer="Acme",
+            model="X4",
+            format="pouch",
+            chemistry="Li-ion",
+            electrolyte_spec_id=electrolyte_id,
+        ),
+        source_root=tmp_path,
+    )
+    assert payload["status"] == "created"
+
+
+def test_save_material_rejects_dangling_material_spec_reference(tmp_path: Path) -> None:
+    material = api.create_material(
+        uid="1234abcd5678ef90",
+        material_spec_id="https://w3id.org/battinfo/spec/zzzz-zzzz-zzzz-zzzz",
+        lot_id="LOT-9",
+    )
+    with pytest.raises(ValueError, match="Reference validation failed"):
+        api.save_material(material, source_root=tmp_path)
+    payload = api.save_material(material, source_root=tmp_path, resolve_references=False)
+    assert payload["status"] == "created"
+
+
+# ── Fix 3: query_* never silently searches the wheel's bundled examples ───────
+
+def test_query_defaults_do_not_return_packaged_examples(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """query_material_specs() (and siblings) in an empty directory must return
+    nothing — not present BattINFO's shipped example fleet as the user's lab."""
+    monkeypatch.chdir(tmp_path)
+    assert api.query_material_specs() == []
+    assert api.query_materials() == []
+    assert api.query_cell_specs() == []
+    assert api.query_cell_instances() == []
+    assert api.query_datasets() == []
+    assert api.query_tests() == []
+    assert api.query_test_specs() == []
+    assert api.query_electrode_specs() == []
+
+
+def test_query_packaged_examples_require_explicit_opt_in_and_are_labeled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    rows = api.query_material_specs(include_packaged_examples=True)
+    assert rows
+    assert all(row["origin"] == "packaged-example" for row in rows)
+    specs = api.query_cell_specs(manufacturer="A123", include_packaged_examples=True)
+    assert specs
+    assert all(row["origin"] == "packaged-example" for row in specs)
+
+
+def test_query_source_root_matches_save_location(tmp_path: Path) -> None:
+    api.save_material_spec(
+        api.create_material_spec(name="LFP powder", uid="1111111111111111"),
+        source_root=tmp_path,
+    )
+    rows = api.query_material_specs(source_root=tmp_path)
+    assert [row["name"] for row in rows] == ["LFP powder"]
+    assert rows[0]["origin"] == "local"
+
+
+def test_query_directory_alias_is_deprecated_but_works(tmp_path: Path) -> None:
+    api.save_material_spec(
+        api.create_material_spec(name="NMC811 powder", uid="3333333333333333"),
+        source_root=tmp_path,
+    )
+    with pytest.warns(DeprecationWarning, match="directory= is deprecated"):
+        rows = api.query_material_specs(directory=tmp_path / "material-spec")
+    assert [row["name"] for row in rows] == ["NMC811 powder"]
+
+    with pytest.raises(ValueError, match="not both"):
+        api.query_material_specs(source_root=tmp_path, directory=tmp_path / "material-spec")
+
+
+# ── Fix 4: deterministic instance IRIs across every minting surface ───────────
+
+def test_cell_instance_iri_is_deterministic_across_surfaces(tmp_path: Path) -> None:
+    """The same (spec IRI, serial) must mint the SAME cell IRI via the
+    workspace, save_cell_instance, and create_cell_instance — one identity, not
+    one per surface/record store."""
+    # Surface 1: workspace authoring.
+    ws_root = tmp_path / "ws"
+    ws_root.mkdir()
+    ws = battinfo.workspace(str(ws_root))
+    ws.add(
+        "cell",
+        spec=CellSpec(manufacturer="Acme", model="X1", format="cylindrical", chemistry="Li-ion"),
+        serial_numbers=["SN-42"],
+    )
+    ws.save()
+    ws_iri = None
+    spec_iri = None
+    for path in sorted(ws_root.rglob("*.json")):
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            continue
+        if isinstance(doc.get("cell_instance"), dict):
+            ws_iri = doc["cell_instance"]["id"]
+            spec_iri = doc["cell_instance"]["cell_spec_id"]
+    assert ws_iri is not None and spec_iri is not None
+
+    # Surface 2: low-level save_cell_instance (separate record store).
+    api_root = tmp_path / "api"
+    saved_spec = api.save_cell_spec(
+        CellSpec(manufacturer="Acme", model="X1", format="cylindrical", chemistry="Li-ion"),
+        source_root=api_root,
+    )
+    assert saved_spec["id"] == spec_iri  # spec identity converges too
+    saved = api.save_cell_instance(
+        Cell(cell_spec_id=saved_spec["id"], serial_number="SN-42"), source_root=api_root
+    )
+    assert saved["id"] == ws_iri
+
+    # Surface 3: create_cell_instance (previously minted a fresh random uid).
+    created = api.create_cell_instance(cell_spec_id=saved_spec["id"], serial_number="SN-42")
+    assert created["cell_instance"]["id"] == ws_iri
+
+
+def test_anonymous_cell_instances_never_dedup(tmp_path: Path) -> None:
+    """A cell with no serial/batch/name has no identity: two of them must mint
+    DIFFERENT IRIs (random), never silently collapse into one record."""
+    spec = api.save_cell_spec(
+        CellSpec(manufacturer="Acme", model="X9", format="pouch", chemistry="Li-ion"),
+        source_root=tmp_path,
+    )
+    first = api.create_cell_instance(cell_spec_id=spec["id"])
+    second = api.create_cell_instance(cell_spec_id=spec["id"])
+    assert first["cell_instance"]["id"] != second["cell_instance"]["id"]
+
+
+# ── Fix 5: no fabricated measurements on ws.add("cell") ───────────────────────
+
+def test_ws_add_cell_does_not_copy_spec_ratings_into_measured(tmp_path: Path) -> None:
+    """Rated/nominal spec values are not measurements. The instance record must
+    not carry a measured={...} block auto-copied from the spec under
+    provenance type='measurement'."""
+    ws = battinfo.workspace(str(tmp_path))
+    spec = CellSpec(
+        manufacturer="Acme",
+        model="X2",
+        format="cylindrical",
+        chemistry="Li-ion",
+        properties={"nominal_capacity": {"value": 5.0, "unit": "Ah"}},
+    )
+    cells = ws.add("cell", spec=spec, serial_numbers=["A1"])
+    assert cells[0].measured in (None, {})
+    ws.save()
+    instance_docs = [
+        json.loads(p.read_text(encoding="utf-8"))
+        for p in tmp_path.rglob("*.json")
+        if p.name.startswith("cell-") and "cell-spec" not in p.name
+    ]
+    instance_docs = [d for d in instance_docs if isinstance(d.get("cell_instance"), dict)]
+    assert instance_docs
+    for doc in instance_docs:
+        assert not doc.get("measured")
+        assert not doc["cell_instance"].get("measured")
+
+
+def test_ws_cell_still_accepts_genuine_measured_values(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    spec = CellSpec(manufacturer="Acme", model="X2", format="cylindrical", chemistry="Li-ion")
+    cell = ws._ws.cell(spec, serial_number="B1", measured={"capacity": {"value": 4.87, "unit": "Ah"}})
+    assert cell.measured["capacity"]["value"] == 4.87
+
+
+# ── Fix 6: template <-> load round-trip + Quantity windows ────────────────────
+
+def test_test_spec_template_round_trips_through_load(tmp_path: Path) -> None:
+    """ws.load(ws.template('test-spec', ...)) must work with only the user
+    filling values — no scalar/min-max shape rejections, no null-placeholder
+    errors (the 14-pydantic-error red-team case)."""
+    ws = battinfo.workspace(str(tmp_path))
+    path = ws.template(
+        "test-spec",
+        name="CC discharge C/5",
+        type="capacity_check",
+        description="Constant-current discharge at C/5 to 2.5 V cutoff.",
+        temperature_degC=25,
+        voltage_window_volt={"min": 2.5, "max": 4.2},
+    )
+    tp = ws.load(path)
+    assert tp.name == "CC discharge C/5"
+    assert tp.test_type == BatteryTestType.CAPACITY_CHECK
+    assert tp.conditions["temperature"].value == 25.0
+    window = tp.conditions["voltage_window"]
+    assert (window.min_value, window.max_value, window.unit) == (2.5, 4.2, "V")
+    # Unfilled placeholders are dropped, not errors.
+    assert "c_rate" not in tp.conditions and "applied_pressure" not in tp.conditions
+
+
+def test_test_spec_template_placeholders_only_still_loads(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    path = ws.template("test-spec", name="Bare", type="cycling")
+    tp = ws.load(path)
+    assert tp.conditions == {}
+    assert tp.method == []
+
+
+def test_voltage_window_survives_save_and_validates(tmp_path: Path) -> None:
+    """Acceptance: a 2.5-4.2 V voltage window is expressible and the saved
+    record passes schema validation (model and schema agree on min/max names)."""
+    ws = battinfo.workspace(str(tmp_path))
+    path = ws.template(
+        "test-spec", name="Window", type="cycling", voltage_window_volt=(2.5, 4.2)
+    )
+    ws.load(path)
+    ws.save()
+    docs = [
+        json.loads(p.read_text(encoding="utf-8"))
+        for p in tmp_path.rglob("*.json")
+        if "test-protocol" in p.name
+    ]
+    docs = [d for d in docs if isinstance(d.get("test_spec"), dict)]
+    assert docs
+    record = docs[0]
+    assert record["conditions"]["voltage_window"] == {
+        "min_value": 2.5,
+        "max_value": 4.2,
+        "unit": "V",
+    }
+    report = validate_record_report(record)
+    assert report.ok, [issue.message for issue in report.errors]
+
+
+def test_legacy_template_shapes_still_load(tmp_path: Path) -> None:
+    """Old drafts written by the pre-fix template (scalar temperature_degC,
+    {min,max} windows, null placeholders, dict step placeholder) must load."""
+    ws = battinfo.workspace(str(tmp_path))
+    draft = {
+        "name": "Legacy",
+        "type": "capacity_check",
+        "description": None,
+        "instrument": None,
+        "steps": [{"description": "Fill in test steps here"}],
+        "conditions": {
+            "temperature_degC": 25,
+            "applied_pressure_kilopascal": None,
+            "atmosphere": "argon",
+            "voltage_window_volt": {"min": 2.5, "max": 4.2},
+            "soc_window": {"min": None, "max": None},
+            "c_rate": None,
+            "d_rate": None,
+        },
+        "citation": None,
+        "source_file": None,
+    }
+    path = tmp_path / "legacy.test-spec.json"
+    path.write_text(json.dumps(draft, indent=2), encoding="utf-8")
+    tp = ws.load(path)
+    assert tp.conditions["temperature"].value == 25.0
+    window = tp.conditions["voltage_window"]
+    assert (window.min_value, window.max_value, window.unit) == (2.5, 4.2, "V")
+    # Non-quantity information is preserved as a note, not silently dropped.
+    assert any("atmosphere: argon" in note for note in tp.comment)
+
+
+def test_template_missing_type_error_lists_allowed_values(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    path = ws.template("test-spec", name="No type yet")
+    with pytest.raises(ValueError) as excinfo:
+        ws.load(path)
+    message = str(excinfo.value)
+    assert "type" in message
+    assert "cycling" in message and "capacity_check" in message and "other" in message
+
+
+def test_quantity_model_supports_min_max_windows() -> None:
+    window = Quantity(min_value=2.5, max_value=4.2, unit="V")
+    assert window.value is None
+    with pytest.raises(ValueError, match="at least one of"):
+        Quantity(unit="V")
+    with pytest.raises(ValueError, match="must not exceed"):
+        Quantity(min_value=4.2, max_value=2.5, unit="V")
+    # Scalar form unchanged.
+    assert Quantity(value=25, unit="degC").value == 25.0
+
+
+def test_template_no_arg_error_lists_supported_kinds(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    with pytest.raises(ValueError) as excinfo:
+        ws.template()
+    message = str(excinfo.value)
+    assert "cell-spec" in message and "test-spec" in message and "equipment-spec" in message
+
+
+def test_template_empty_name_writes_sane_filenames(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    cell_path = ws.template("cell-spec")
+    assert cell_path.name == "cell-spec.cell-spec.json"
+    test_path = ws.template("test-spec", type="cycling")
+    assert test_path.name == "test-spec.test-spec.json"

--- a/tests/test_material_contract.py
+++ b/tests/test_material_contract.py
@@ -96,8 +96,8 @@ def test_material_spec_and_instance_roundtrip(tmp_path: Path) -> None:
     saved_material = api.save_material(material, source_root=tmp_path)  # resolves spec reference
     assert saved_material["entity_type"] == "material"
 
-    assert [s["name"] for s in api.query_material_specs(directory=tmp_path / "material-spec")] == ["LFP"]
-    assert [m["lot_id"] for m in api.query_materials(directory=tmp_path / "material")] == ["LOT-1"]
+    assert [s["name"] for s in api.query_material_specs(source_root=tmp_path)] == ["LFP"]
+    assert [m["lot_id"] for m in api.query_materials(source_root=tmp_path)] == ["LOT-1"]
 
     index = api.build_index(source_root=tmp_path)
     assert index["material_spec_count"] == 1

--- a/tests/test_scope_acceptance.py
+++ b/tests/test_scope_acceptance.py
@@ -89,14 +89,14 @@ def test_scope_examples_cover_simple_cell_tests_and_dataset_links(tmp_path: Path
     cell_rows = query_cell_specs(
         manufacturer="A123",
         format="cylindrical",
-        cell_specs_dir=source_root / "cell-spec",
+        source_root=source_root,
     )
     assert len(cell_rows) == 1
     assert cell_rows[0]["model_name"] == "ANR26650M1-B"
     assert cell_rows[0]["nominal_capacity"] == 2.5
 
     instance_rows = query_cell_instances(
-        directory=source_root / "cell-instance",
+        source_root=source_root,
         cell_spec_id=cell_spec_doc["cell_spec"]["id"],
         has_dataset=True,
         dataset_id=dataset_doc["dataset"]["id"],
@@ -104,14 +104,14 @@ def test_scope_examples_cover_simple_cell_tests_and_dataset_links(tmp_path: Path
     assert len(instance_rows) == 1
     assert instance_rows[0]["id"] == cell_instance_doc["cell_instance"]["id"]
 
-    observed_kinds = {row["kind"] for row in query_tests(directory=source_root / "test", cell_id=cell_instance_doc["cell_instance"]["id"])}
+    observed_kinds = {row["kind"] for row in query_tests(source_root=source_root, cell_id=cell_instance_doc["cell_instance"]["id"])}
     assert expected_kinds.issubset(observed_kinds)
 
-    hppc_rows = query_tests(directory=source_root / "test", kind="hppc", dataset_id=dataset_doc["dataset"]["id"])
+    hppc_rows = query_tests(source_root=source_root, kind="hppc", dataset_id=dataset_doc["dataset"]["id"])
     assert len(hppc_rows) == 1
 
     dataset_rows = query_datasets(
-        directory=source_root / "dataset",
+        source_root=source_root,
         related_cell_id=cell_instance_doc["cell_instance"]["id"],
         related_test_id="https://w3id.org/battinfo/test/5p7v-2n8k-4m3t-6q9r",
         format="application/x-hdf5",

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -7474,12 +7474,36 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
           "type": "object",
           "additionalProperties": false,
           "required": [
-            "value",
             "unit"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "value"
+              ]
+            },
+            {
+              "required": [
+                "min_value"
+              ]
+            },
+            {
+              "required": [
+                "max_value"
+              ]
+            }
           ],
           "properties": {
             "value": {
               "type": "number"
+            },
+            "min_value": {
+              "type": "number",
+              "description": "Lower bound of a window quantity (e.g. a 2.5-4.2 V voltage window); field names align with modules/common/quantity.schema.json."
+            },
+            "max_value": {
+              "type": "number",
+              "description": "Upper bound of a window quantity; field names align with modules/common/quantity.schema.json."
             },
             "unit": {
               "type": "string",


### PR DESCRIPTION
Six fixes for silent data loss and broken authoring paths. Each has regression tests in tests/test_lab_p1_traps.py. Part of the lab-engineer campaign (P1).

- ws.convert / convert_csv report every dropped source column per file, name the detected reader plugin, and point at ws.bdf_columns() and convert_csv(hints=...). Losses are recorded in .battinfo/conversions.json.
- Saves fail on dangling `*_spec_id` references, naming the missing IRIs. Opt out with resolve_references=False. save_batch still allows references within the batch but validates the completed set.
- query_* functions no longer fall back to the wheel's bundled examples. Default is ./examples under the cwd; packaged examples only with include_packaged_examples=True, and every hit carries an origin field. source_root= replaces directory= (kept as a deprecated alias).
- Cell instance IRIs come from one shared identity function; the same (spec, serial) mints the same IRI on the workspace and low-level surfaces. create_cell_instance previously minted a random uid per call.
- ws.add("cell") no longer copies spec ratings into measured= with measurement provenance. Ratings stay on the spec.
- ws.template("test-spec") output now loads. The Quantity model gained min_value/max_value (matching the schema), the template writes valid shapes and lists allowed types in-file, and the loader strips placeholders and coerces legacy shapes. A 2.5-4.2 V voltage window is now expressible.

Full suite 1400 passed (23 new tests), ruff clean.

The test-protocol schema changed (Quantity min/max), so the registry's vendored schemas need a re-vendor after this merges.

Caller-visible changes: saves with dangling references now raise; query_* with no path searches ./examples, not the installed package.
