### PR TITLE
docs: lab-work cookbook, how-tos, glossary; correct inaccurate claims

### DIFF
--- a/.tools/quality/run_doc_snippets.py
+++ b/.tools/quality/run_doc_snippets.py
@@ -35,9 +35,15 @@ SNIPPET_FILES = (
     "QUICKSTART.md",
     "docs/python-api.md",
     "docs/pages/getting-started.rst",
+    "docs/pages/troubleshooting.md",
     "docs/howto/bulk-ingest.md",
+    "docs/howto/build-a-cell-from-components.md",
+    "docs/howto/find-existing-records.md",
     "docs/howto/fix-validation-errors.md",
+    "docs/howto/label-your-cells.md",
     "docs/howto/register-equipment.md",
+    "docs/howto/register-materials.md",
+    "docs/test-specs.md",
 )
 
 SKIP_MARKERS = ("<!-- doc-snippet: skip -->", ".. doc-snippet: skip")

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -8,10 +8,13 @@ BattINFO turns battery metadata into machine-readable Linked Data. In five minut
 |---|---|---|
 | Describe cells/tests/datasets interactively and publish them (the common case) | **Authoring workspace** | `ws = battinfo.workspace(".")` then `ws.quickstart()` |
 | Create a single record in code and save/publish it | **Models + functions** | `CellSpec(...)` + `battinfo.publish(...)` (this page) |
-| Build or script the full object graph programmatically (ingest pipelines, batch tooling) | **Object-graph engine** | `battinfo.Workspace` — the lower-level engine the authoring workspace wraps |
+| Register materials, electrodes, and other components | **`battinfo.api` functions** | `create_material_spec(...)` + `save_material_spec(...)` — see the [cookbook](docs/pages/cookbook.md) |
 
-If in doubt, start with `battinfo.workspace(".")` — it wraps everything else. See
-[Workspace authoring](docs/workspace-authoring.md) for the guided tour.
+If in doubt, start with `battinfo.workspace(".")` for cells, tests, datasets,
+and equipment. The workspace does **not** cover materials or component specs —
+those are authored through `battinfo.api`. The full per-record-type coverage
+map is in [Workspace authoring](docs/workspace-authoring.md#what-each-surface-can-author-today);
+the guided tour is on the same page.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ and resolvable through persistent `https://w3id.org/battinfo/` identifiers.
 
 [**Quickstart**](QUICKSTART.md) ·
 [**Documentation**](docs/index.md) ·
+[**Cookbook**](docs/pages/cookbook.md) ·
 [**Tutorials**](#tutorials) ·
 [**Contributing**](#contributing) ·
 [**Cite**](#citation)
+
+New words? The [plain-language glossary](docs/pages/glossary.md) decodes
+*Linked Data*, *EMMO*, *IRI*, and friends in two sentences each.
 
 </div>
 
@@ -122,8 +126,8 @@ Or from the command line:
 battinfo --help
 ```
 
-For interactive, multi-record work, the authoring workspace is the blessed surface —
-it wraps everything else:
+For interactive, multi-record work — cells, tests, datasets, equipment — the
+authoring workspace is the blessed surface:
 
 ```python
 import battinfo
@@ -131,8 +135,11 @@ ws = battinfo.workspace(".")
 ws.quickstart()   # prints a copy-pasteable end-to-end example
 ```
 
-The [quickstart's "Which surface do I use?" table](QUICKSTART.md#which-surface-do-i-use)
-maps the three entry points (workspace, models + `publish`, `battinfo.Workspace` engine).
+**Lab work?** Start at the [cookbook](docs/pages/cookbook.md) — twelve bench
+tasks (register materials, build a cell from components, label cells, convert
+cycler exports, publish) each mapped to a runnable recipe. The
+[capability table](docs/workspace-authoring.md#what-each-surface-can-author-today)
+shows which surface (workspace, `battinfo.api`, CLI) authors which record types today.
 
 **→ Read the [full quickstart](QUICKSTART.md) and the [documentation index](docs/index.md).**
 
@@ -239,8 +246,9 @@ CI runs the same checks across Python 3.11/3.12 on Linux and Windows via the
 
 ## Citation
 
-If you use BattINFO in your research, please cite it. Once the first release is
-archived on Zenodo, the concept DOI badge above will resolve to a citable record:
+If you use BattINFO in your research, please cite it. The concept DOI arrives
+with the 0.8 release (the first Zenodo-archived release); the badge above will
+then resolve to a citable record:
 
 ```bibtex
 @software{battinfo,

--- a/docs/cell-fleet.md
+++ b/docs/cell-fleet.md
@@ -19,9 +19,15 @@ A cell-spec gains five optional top-level reference fields (siblings of the inli
 | `housing_spec_id` | `housing-spec` |
 
 A cell may **reference**, **inline**, or both — inline holders stay optional, so existing
-records are unaffected. References are existence-checked against the source root, and the
-JSON-LD emits reference nodes (`hasPositiveElectrode: {"@id": <electrode-spec IRI>}`, etc.);
+records are unaffected. The JSON-LD emits reference nodes
+(`hasPositiveElectrode: {"@id": <electrode-spec IRI>}`, etc.);
 when a basis/inline node is also present, the `@id` is merged onto it.
+
+> **Check your references.** Saving does *not* currently reject a
+> `*_spec_id` that points at nothing — a typo lands on disk silently. Run
+> `validate_record_report` over the record set after building (it reports
+> `reference.missing` per dangling IRI); the recipe is in
+> {ref}`How-to: build a cell from components <validate-the-set>`.
 
 ```python
 import battinfo as bi

--- a/docs/component-specs.md
+++ b/docs/component-specs.md
@@ -20,10 +20,10 @@ A generic factory in `api.py` is parameterized by family; thin per-family wrappe
 generated from the entity registry, so the surface matches the cell/material API:
 
 ```python
-import battinfo as bi
+from battinfo.api import create_electrode_spec, save_electrode_spec, create_component_spec
 
 # electrode-spec whose coating references standalone material-specs by IRI
-electrode = bi.create_electrode_spec(
+electrode = create_electrode_spec(
     name="NMC811 cathode", polarity="positive", manufacturer="Canrud",
     body={
         "coating": {"component": {
@@ -34,11 +34,14 @@ electrode = bi.create_electrode_spec(
             "property": {"loading": {"value": 21, "unit": "mg/cm2"}}},
         "current_collector": {"name": "Aluminium foil", "property": {"thickness": {"value": 15, "unit": "um"}}},
     })
-bi.save_electrode_spec(electrode, source_root="examples")
+save_electrode_spec(electrode, source_root="examples", mode="upsert")
 
 # generic form is also available
-bi.create_component_spec("electrolyte", name="…", body={...})
+create_component_spec("electrolyte", name="…", body={...})
 ```
+
+The step-by-step bench version of this — materials first, IRIs harvested from
+each save — is [How-to: build a cell from components](howto/build-a-cell-from-components.md).
 
 Per family you get `create_<family>_spec`, `save_<family>_spec`, `query_<family>_specs`,
 `template_<family>_spec` and the bare-name instance equivalents (`create_<family>`,
@@ -64,4 +67,6 @@ and emit `OrganicElectrolyte` / `AqueousElectrolyte` JSON-LD with `hasSolute`/`h
 wheel). Coverage: NMC811 cathode + graphite anode electrodes; Celgard PP + ceramic-coated PE
 separators; Al/Cu current collectors; organic + aqueous electrolytes; CR2032 coin + LFP 100 Ah
 prismatic housings — grounded in the DIGIBAT Discovery-Benchmark and the Cell_Design_Tool.
-Cell-specs will reference these component-specs by IRI in Phase 3.
+Cell-specs reference these component-specs by IRI today via the five `*_spec_id`
+fields — see [Cells](cell-fleet.md) for the reference seam and the example fleet
+that uses it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,10 @@ myst_enable_extensions = [
     "fieldlist",
 ]
 
+# GitHub-style #anchors for markdown headings (h1-h3), so pages can deep-link
+# each other the same way on GitHub and in the built site.
+myst_heading_anchors = 3
+
 autosectionlabel_prefix_document = True
 
 templates_path = ["_templates"]

--- a/docs/guides/01-concepts.ipynb
+++ b/docs/guides/01-concepts.ipynb
@@ -14,7 +14,9 @@
     "\n",
     "*Already have cycler data on disk? Jump straight to [Guide 6 — Publish your first dataset](06-publish-your-data.ipynb) and come back here for the concepts.*\n",
     "\n",
-    "**Estimated time:** 10 minutes"
+    "**Estimated time:** 10 minutes\n",
+    "\n",
+    "*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
    ]
   },
   {

--- a/docs/guides/02-first-cell-type.ipynb
+++ b/docs/guides/02-first-cell-type.ipynb
@@ -14,7 +14,9 @@
     "**Estimated time:** 15 minutes\n",
     "**Prerequisites:** [Guide 1 — Concepts](01-concepts.ipynb)\n",
     "\n",
-    "Everything this guide writes lands in `_scratch/guide-02/`."
+    "Everything this guide writes lands in `_scratch/guide-02/`.\n",
+    "\n",
+    "*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
    ]
   },
   {

--- a/docs/guides/03-linked-records.ipynb
+++ b/docs/guides/03-linked-records.ipynb
@@ -22,7 +22,9 @@
     "\n",
     "Everything writes to `_scratch/guide-03/`. This is the depth version of\n",
     "[Guide 6 — Publish your first dataset](06-publish-your-data.ipynb), which runs\n",
-    "the same chain from a raw cycler file in five minutes."
+    "the same chain from a raw cycler file in five minutes.\n",
+    "\n",
+    "*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
    ]
   },
   {
@@ -241,7 +243,9 @@
     "\n",
     "A `Test` is one execution of the test spec on one cell. Passing `data=`\n",
     "attaches the measured file, and the workspace creates the linked `Dataset`\n",
-    "record for it in the same call:"
+    "record for it in the same call:\n",
+    "\n",
+    "Testing on a multi-channel cycler? Register the unit once and name the channel on each test (`channel=\"Cycler 1/CH2\"`) so the record keeps which slot produced the data — see [How-to: register equipment](../howto/register-equipment.md)."
    ]
   },
   {
@@ -482,7 +486,7 @@
     "`ws.publish()` submits the records to the registry review queue (staged — a\n",
     "curator promotes them to the public index); `zenodo=True` archives the data\n",
     "with a citable DOI first. Both need credentials, so this cell is a guarded\n",
-    "no-op without them:"
+    "no-op without them. (Publishing goes to the Battery Genome registry at battery-genome.org; during the soft launch, API keys are granted by the registry operators — there is no self-service key page yet.)"
    ]
   },
   {

--- a/docs/guides/04-semantic-layer.ipynb
+++ b/docs/guides/04-semantic-layer.ipynb
@@ -10,7 +10,9 @@
     "This guide examines the JSON-LD that BattINFO produces, explains how it connects to EMMO, and shows how to work with it using RDF tools.\n",
     "\n",
     "**Estimated time:** 20 minutes\n",
-    "**Prerequisites:** [Guide 2](02-first-cell-type.ipynb) or [Guide 3](03-linked-records.ipynb)"
+    "**Prerequisites:** [Guide 2](02-first-cell-type.ipynb) or [Guide 3](03-linked-records.ipynb)\n",
+    "\n",
+    "*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
    ]
   },
   {

--- a/docs/guides/05-descriptors.ipynb
+++ b/docs/guides/05-descriptors.ipynb
@@ -12,7 +12,9 @@
     "**Estimated time:** 40 minutes\n",
     "**Prerequisites:** [Guide 2 — Describing a cell](02-first-cell-type.ipynb)\n",
     "\n",
-    "Everything writes under `_scratch/guide-05/`."
+    "Everything writes under `_scratch/guide-05/`.\n",
+    "\n",
+    "*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
    ]
   },
   {

--- a/docs/guides/06-publish-your-data.ipynb
+++ b/docs/guides/06-publish-your-data.ipynb
@@ -21,7 +21,9 @@
     "5. **Publish** — a DOI on Zenodo + the registry review queue\n",
     "\n",
     "*Prerequisites: `pip install \"battinfo[processing]\"` — the `processing` extra brings the BDF converter (`batterydf`) that Stage 1 uses. Stage 5 needs\n",
-    "credentials and is guarded so the notebook runs fully offline without them.*"
+    "credentials and is guarded so the notebook runs fully offline without them.*\n",
+    "\n",
+    "*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
    ]
   },
   {
@@ -66,7 +68,9 @@
     "\n",
     "Every instrument speaks its own format; BDF (Battery Data Format) is the one tidy,\n",
     "documented table they all become. NEWARE `.ndax`, Biologic `.mpt`, Excel and MATLAB\n",
-    "exports are auto-detected by `ws.convert()`; CSV exports use an explicit pattern."
+    "exports are auto-detected by `ws.convert()`; CSV exports use an explicit pattern.\n",
+    "\n",
+    "No reader for your instrument (Arbin, Maccor, an in-house export)? Save a CSV from the instrument software and map its headers yourself: `ws.bdf_columns()` prints the canonical column names, and `ws.convert_csv(path, hints={\"Voltage(V)\": \"voltage_volt\", ...})` does the rename. Check the validation report it prints — a measured column listed under `extras` is unmapped and will be invisible downstream."
    ]
   },
   {
@@ -164,7 +168,9 @@
     "\n",
     "Data without its test conditions is trivia. The chain **cell → test → dataset** is\n",
     "what lets someone who was never in your lab reuse the numbers. `ws.add(\"test\", ...)`\n",
-    "creates the test record and a dataset record pointing at the converted file."
+    "creates the test record and a dataset record pointing at the converted file.\n",
+    "\n",
+    "(To also record *which cycler channel* ran the test, register your equipment once — [How-to: register equipment](../howto/register-equipment.md) — and pass `channel=...` here.)"
    ]
   },
   {
@@ -308,7 +314,7 @@
     "the dataset with a citable DOI. Both need credentials, so this cell is a guarded\n",
     "no-op until you provide them:\n",
     "\n",
-    "- `ws.login(api_key=\"bk_...\")` — registry key, from the registry settings page\n",
+    "- `ws.login(api_key=\"bk_...\")` — key for the Battery Genome registry (battery-genome.org). During the soft launch keys are granted by the registry operators; there is no self-service key page yet\n",
     "- `ZENODO_SANDBOX_TOKEN` — a [Zenodo sandbox](https://sandbox.zenodo.org) token for a\n",
     "  dry-run DOI (use `sandbox=True`); drop it for the real thing"
    ]

--- a/docs/howto/build-a-cell-from-components.md
+++ b/docs/howto/build-a-cell-from-components.md
@@ -1,0 +1,199 @@
+# Build a cell from components
+
+Describe a coin cell the way you built it: materials → electrodes →
+electrolyte/separator/housing → cell spec → physical cells — every layer a
+saved record, every link an IRI. This whole page is one continuous script;
+run it top to bottom.
+
+**Ingredients:** a library folder (here `my-library`) and the material specs
+from [Register materials](register-materials.md). All the `create_*`/`save_*`
+functions live in `battinfo.api`.
+
+## 1. Register the parts and harvest their IRIs
+
+Every `save_*` call returns a dict whose `"id"` is the record's permanent IRI —
+capture it, it is how the next layer refers to this one:
+
+```python
+from battinfo.api import create_material_spec, save_material_spec
+
+LAB = "my-library"
+
+def material(name, **kw):
+    return save_material_spec(create_material_spec(name=name, **kw),
+                              source_root=LAB, mode="upsert")["id"]
+
+NMC811_IRI   = material("NMC811", material_class="active_material",
+                        electrode_polarity="positive", formula="LiNi0.8Mn0.1Co0.1O2")
+GRAPHITE_IRI = material("Graphite", material_class="active_material",
+                        electrode_polarity="negative", formula="C")
+PVDF_IRI     = material("PVDF", material_class="binder", formula="(C2H2F2)n")
+CB_IRI       = material("Carbon black", material_class="conductive_additive", formula="C")
+LIPF6_IRI    = material("LiPF6", material_class="electrolyte_salt", formula="LiPF6")
+EC_IRI       = material("EC", material_class="electrolyte_solvent", formula="C3H4O3")
+EMC_IRI      = material("EMC", material_class="electrolyte_solvent", formula="C4H8O3")
+```
+
+(electrode-recipe)=
+## 2. The electrodes — a 96/2/2 coating, by IRI
+
+```python
+from battinfo.api import create_component_spec, save_component_spec
+
+cathode = create_component_spec(
+    "electrode", name="NMC811 cathode 96/2/2", polarity="positive",
+    body={
+        "coating": {
+            "component": {
+                "active_material": [{"name": "NMC811", "material_spec_id": NMC811_IRI,
+                                     "property": {"mass_fraction": {"value": 0.96, "unit": "1"}}}],
+                "binder":   [{"name": "PVDF", "material_spec_id": PVDF_IRI,
+                              "property": {"mass_fraction": {"value": 0.02, "unit": "1"}}}],
+                "additive": [{"name": "Carbon black", "material_spec_id": CB_IRI,
+                              "property": {"mass_fraction": {"value": 0.02, "unit": "1"}}}],
+            },
+            "property": {"loading":   {"value": 21, "unit": "mg/cm2"},
+                         "thickness": {"value": 75, "unit": "um"}},
+        },
+        "current_collector": {"name": "Aluminium foil",
+                              "property": {"thickness": {"value": 15, "unit": "um"}}},
+    })
+CATHODE_IRI = save_component_spec("electrode", cathode, source_root=LAB, mode="upsert")["id"]
+
+anode = create_component_spec(
+    "electrode", name="Graphite anode", polarity="negative",
+    body={
+        "coating": {
+            "component": {
+                "active_material": [{"name": "Graphite", "material_spec_id": GRAPHITE_IRI,
+                                     "property": {"mass_fraction": {"value": 0.96, "unit": "1"}}}],
+                "binder": [{"name": "PVDF", "material_spec_id": PVDF_IRI}],
+            },
+            "property": {"loading": {"value": 12, "unit": "mg/cm2"}},
+        },
+        "current_collector": {"name": "Copper foil",
+                              "property": {"thickness": {"value": 10, "unit": "um"}}},
+    })
+ANODE_IRI = save_component_spec("electrode", anode, source_root=LAB, mode="upsert")["id"]
+```
+
+The `body=` shapes mirror the canonical examples in
+[`examples/electrode-spec/`](https://github.com/BIG-MAP/BattINFO/tree/main/examples/electrode-spec)
+— when in doubt, open one and copy its structure.
+
+## 3. Electrolyte, separator, housing
+
+```python
+electrolyte = create_component_spec(
+    "electrolyte", name="1M LiPF6 EC:EMC 3:7",
+    body={
+        "family": "organic",
+        "salt": {"name": "LiPF6", "material_spec_id": LIPF6_IRI,
+                 "property": {"concentration": {"value": 1.0, "unit": "mol/L"}}},
+        "solvent_mixture": {"component": [
+            {"name": "EC", "material_spec_id": EC_IRI,
+             "property": {"volume_fraction": {"value": 0.3, "unit": "1"}}},
+            {"name": "EMC", "material_spec_id": EMC_IRI,
+             "property": {"volume_fraction": {"value": 0.7, "unit": "1"}}},
+        ]},
+    })
+ELECTROLYTE_IRI = save_component_spec("electrolyte", electrolyte,
+                                      source_root=LAB, mode="upsert")["id"]
+
+separator = create_component_spec(
+    "separator", name="Celgard 2325",
+    body={"material": "polypropylene", "structure": "trilayer",
+          "property": {"thickness": {"value": 25, "unit": "um"},
+                       "porosity":  {"value": 0.39, "unit": "1"}}})
+SEPARATOR_IRI = save_component_spec("separator", separator,
+                                    source_root=LAB, mode="upsert")["id"]
+
+housing = create_component_spec(
+    "housing", name="CR2032 coin housing",
+    body={"cell_format": "coin",
+          "case": {"size_code": "2032", "material": "Stainless steel",
+                   "property": {"diameter": {"value": 20, "unit": "mm"},
+                                "height":   {"value": 3.2, "unit": "mm"}}}})
+HOUSING_IRI = save_component_spec("housing", housing,
+                                  source_root=LAB, mode="upsert")["id"]
+```
+
+> The first argument names the component family — note it goes before `name=`:
+> the electrolyte's `"organic"`/`"aqueous"` classification is the `family` key
+> *inside* `body=`, not a keyword argument.
+
+## 4. The cell spec — all five references
+
+```python
+import battinfo
+from battinfo.api import save_cell_spec
+
+cell = battinfo.CellSpec(
+    manufacturer="My Lab", model="COIN-NMC811-A", format="coin", chemistry="Li-ion",
+    positive_electrode_spec_id=CATHODE_IRI,
+    negative_electrode_spec_id=ANODE_IRI,
+    electrolyte_spec_id=ELECTROLYTE_IRI,
+    separator_spec_id=SEPARATOR_IRI,
+    housing_spec_id=HOUSING_IRI,
+    nominal_capacity={"value": 0.004, "unit": "Ah"},
+    nominal_voltage={"value": 3.7, "unit": "V"},
+)
+CELL_IRI = save_cell_spec(cell, source_root=LAB, mode="upsert")["id"]
+```
+
+This is shipped, working behavior — the five `*_spec_id` reference fields are
+part of the `CellSpec` model today, and the packaged
+[example fleet](../cell-fleet.md) uses exactly this pattern. A cell may
+reference components, inline them, or both (inline holders remain optional —
+see [Components](../component-specs.md)).
+
+## 5. The physical cells
+
+```python
+from battinfo.api import save_cell_instance
+
+for name in ("B7-01", "B7-02", "B7-03"):
+    save_cell_instance({"cell_spec_id": CELL_IRI, "name": name},
+                       source_root=LAB, mode="upsert")
+```
+
+(For interactive batches — including printing labels — the workspace's
+`ws.add("cell", spec=..., names=[...])` does the same thing; see
+[Label your cells](label-your-cells.md).)
+
+(validate-the-set)=
+## 6. Validate the whole set
+
+Save does **not** currently reject a reference to a spec that does not exist —
+a typo in an IRI lands on disk silently. `validate_record_report` catches it,
+so finish every build session by sweeping the library:
+
+```python
+import json
+from pathlib import Path
+from battinfo import validate_record_report
+
+bad = 0
+for path in sorted(Path(LAB).rglob("*.json")):
+    report = validate_record_report(json.loads(path.read_text(encoding="utf-8")),
+                                    source_root=LAB)
+    if not report.ok:
+        bad += 1
+        print(f"INVALID {path.name}")
+        for issue in report.issues:
+            print("  -", issue.message)
+print(f"{bad} invalid record(s)")   # 0 invalid record(s)
+assert bad == 0
+```
+
+A dangling reference reports as `reference.missing` with the offending IRI —
+fix the reference (or register the missing part) and re-run.
+
+## What you have now
+
+A three-level graph on disk — cell → components → materials — where every node
+is a schema-valid record with a permanent IRI, and shared parts (that binder,
+that electrolyte) are registered once and referenced everywhere. The
+[cell fleet page](../cell-fleet.md) shows the same pattern across the packaged
+example fleet, and [Find existing records](find-existing-records.md) shows how
+to query what you have built.

--- a/docs/howto/find-existing-records.md
+++ b/docs/howto/find-existing-records.md
@@ -1,0 +1,87 @@
+# Find what already exists
+
+Three surfaces, three scopes. Know which one you are asking before you trust
+an answer:
+
+| You are asking about… | Use | Scope |
+|---|---|---|
+| Records in **this workspace session** | `ws.list(verbose=True)` | What you have added/saved locally with the workspace |
+| Records in a **library folder on disk** | `battinfo.api.query_*` / `battinfo query` (CLI) | Exactly the directory you point it at |
+| Records **published to the registry** | `ws.search(...)` | The live Battery Genome registry (battery-genome.org) |
+
+## Your workspace session: `ws.list`
+
+```python
+import battinfo
+
+ws = battinfo.workspace(".")
+spec = battinfo.CellSpec(manufacturer="My Lab", model="COIN-NMC811-A",
+                         format="coin", chemistry="Li-ion")
+ws.add("cell", spec=spec, names=["B7-01", "B7-02"])
+ws.save()
+
+listing = ws.list(verbose=True)   # prints every record, grouped by type, with IRIs
+```
+
+Records tagged `[this session]` are the ones `ws.submit()` would send.
+Equipment and channel records are registered separately
+(`ws.add("equipment", ...)`) and do not currently appear in `ws.list` output.
+
+## A library folder: `query_*`
+
+Every `query_*` function takes the directory to search. **Pass it explicitly**
+— with no argument they read the example records packaged inside the BattINFO
+wheel, which look plausible but are not yours:
+
+```python
+from battinfo.api import query_cell_specs, query_material_specs
+
+# the records ws.save() wrote for this workspace:
+mine = query_cell_specs(cell_specs_dir=".battinfo/records/cell-spec")
+print([r["model_name"] for r in mine])       # ['COIN-NMC811-A']
+
+# a library you built with save_* functions (source_root="my-library"):
+mats = query_material_specs(directory="my-library/material-spec")
+```
+
+One asymmetry to know about: `query_cell_specs` calls its directory argument
+`cell_specs_dir`; the other `query_*` functions call it `directory`.
+
+The CLI equivalent (`battinfo query cell-spec`, `battinfo query test-spec`, …)
+currently reads only the packaged example records — it has no directory
+option, so use the Python `query_*` functions for your own library.
+
+<!-- doc-snippet: skip -->
+```python
+# Filters match the record fields:
+query_cell_specs(chemistry="Li-ion", cell_format="coin",
+                 cell_specs_dir="my-library/cell-spec")
+query_material_specs(material_class="binder", directory="my-library/material-spec")
+```
+
+## The registry: `ws.search`
+
+`ws.search` asks the live registry — the shared index of *published* records:
+
+<!-- doc-snippet: skip -->
+```python
+spec = ws.search("samsung inr21700 50e")[0]        # fuzzy: tolerates typos
+cells = ws.search(type="cell", serial="tpejqj")     # instances by serial / short ID
+tests = ws.search(type="test-spec", query="capacity")
+```
+
+Reading the registry needs no account or API key. What the results mean:
+
+- **A hit** is a published record; `ws.load(hit)` references it in your session
+  (reusing its IRI) instead of authoring a duplicate.
+- **No hits** means nothing published matches — your own unpublished records
+  will *not* appear here; they are only visible to `ws.list` and `query_*`.
+- **Offline** (or registry unreachable): search falls back to a local clone of
+  the records repository if you have one configured, otherwise it returns an
+  empty list after printing a "Registry unreachable" notice. An empty result
+  while offline is not evidence that a record does not exist.
+
+`ws.status()` (what have I published?) talks to the registry too, and needs
+`ws.login(api_key=...)` first — see the
+[troubleshooting page](../pages/troubleshooting.md) if it asks for a
+workspace id.

--- a/docs/howto/label-your-cells.md
+++ b/docs/howto/label-your-cells.md
@@ -1,0 +1,73 @@
+# Label your cells — names, serials, and QR codes
+
+## Names vs. serial numbers
+
+- **`names=[...]`** — *your* identity for a cell: the marker-pen label, the
+  batch ID, "B7-01". This is the primary identifier for lab-built cells,
+  which have no serial number.
+- **`serial_numbers=[...]`** — the *manufacturer's* identity, printed on the
+  wrapper of a commercial cell. Only use it for that; do not invent serials
+  for cells you built.
+
+Use either, or both in parallel (same length, matched by position):
+
+```python
+import battinfo
+
+ws = battinfo.workspace(".")
+spec = battinfo.CellSpec(manufacturer="My Lab", model="COIN-NMC811-A",
+                         format="coin", chemistry="Li-ion")
+
+# lab-built coin cells: names only
+cells = ws.add("cell", spec=spec, names=["B7-01", "B7-02", "B7-03"])
+
+# commercial cells: manufacturer serials, plus your own shelf label
+bought = ws.add("cell", spec=spec, names=["shelf-A-04"],
+                serial_numbers=["INR-9F3K72"])
+
+ws.save()   # mints one permanent IRI per cell
+```
+
+## What goes on the label
+
+After `ws.save()` each cell object carries its permanent IRI; the last path
+segment is the cell's UID and its first six characters (dashes dropped) are
+the `short_id` — the thing to write on the cell when a full IRI will not fit:
+
+```python
+for cell in cells:
+    uid = cell.id.rsplit("/", 1)[-1]          # e.g. gm6p-mrc6-p6cc-0m18
+    short_id = uid.replace("-", "")[:6]       # e.g. gm6pmr
+    print(f"{cell.name}: {short_id}   {cell.id}")
+```
+
+The UID alphabet deliberately omits `i`, `l`, `o`, and `u`, so a handwritten
+short ID survives being read back from a photo
+([Identifiers](../identifiers.md)). The short ID also does real work later:
+name your data files after it and `ws.add("test", datasets="glob")` matches
+files to cells automatically.
+
+## QR codes
+
+A QR code holding the cell IRI turns any phone camera into a record lookup.
+[segno](https://pypi.org/project/segno/) is a one-file QR library — it is not
+a BattINFO dependency, so install it separately (`pip install segno`):
+
+<!-- doc-snippet: skip -->
+```python
+import segno
+
+for cell in cells:
+    qr = segno.make(cell.id, error="m")            # the IRI is the payload
+    qr.save(f"{cell.name}-qr.png", scale=6)        # or .svg for vector labels
+```
+
+Print the PNG/SVG next to the name and short ID. Scanning resolves the IRI
+through `w3id.org`: machine clients get the record as JSON-LD; a browser
+lands on the cell's registry page (behind the sign-in gate while the platform
+is in soft launch — see [Identifiers](../identifiers.md)).
+
+> **Printable label sheets:** the Battery Genome platform
+> ([battery-genome.org](https://www.battery-genome.org)) generates printable
+> QR sheets for registered cells, so you do not have to lay out labels
+> yourself.

--- a/docs/howto/register-materials.md
+++ b/docs/howto/register-materials.md
@@ -1,0 +1,85 @@
+# Register the materials in your lab
+
+Five lines per material — create it, save it into your library, keep the IRI:
+
+```python
+from battinfo.api import create_material_spec, save_material_spec
+
+nmc = create_material_spec(name="NMC811", material_class="active_material",
+                           electrode_polarity="positive", formula="LiNi0.8Mn0.1Co0.1O2")
+saved = save_material_spec(nmc, source_root="my-library", mode="upsert")
+NMC811_IRI = saved["id"]   # e.g. https://w3id.org/battinfo/spec/3ypr-gngx-x28c-rarf
+```
+
+`source_root` is the folder that holds your record library (records land in
+`my-library/material-spec/`). `mode="upsert"` makes the call safe to re-run:
+the same material converges on the same record instead of erroring as a
+duplicate.
+
+## Variants
+
+A binder, a conductive additive, a salt, a solvent — same five lines, different
+`material_class`:
+
+```python
+pvdf = save_material_spec(create_material_spec(
+    name="PVDF", material_class="binder", formula="(C2H2F2)n"),
+    source_root="my-library", mode="upsert")
+
+salt = save_material_spec(create_material_spec(
+    name="LiPF6", material_class="electrolyte_salt", formula="LiPF6"),
+    source_root="my-library", mode="upsert")
+```
+
+Valid `material_class` values: `active_material`, `binder`,
+`conductive_additive`, `current_collector`, `separator_material`,
+`electrolyte_salt`, `electrolyte_solvent`, `electrolyte_additive`,
+`metal_electrode`, `coating`, `other`.
+
+With a manufacturer and a datasheet number:
+
+```python
+graphite = save_material_spec(create_material_spec(
+    name="Graphite", material_class="active_material", electrode_polarity="negative",
+    formula="C", manufacturer="Targray",
+    property={"specific_capacity": {"value": 355, "unit": "mAh/g"}}),
+    source_root="my-library", mode="upsert")
+```
+
+Quantities are always `{"value": ..., "unit": ...}` maps; a measured value can
+also carry the conditions it was measured under — see
+[Materials](../material-spec.md) for the property and composition reference.
+
+## Find them again
+
+Query your own library by passing its directory explicitly — with no argument,
+`query_material_specs()` reads the example records packaged with BattINFO, not
+yours:
+
+```python
+from battinfo.api import query_material_specs
+
+mine = query_material_specs(material_class="active_material",
+                            directory="my-library/material-spec")
+print(sorted(m["name"] for m in mine))   # ['Graphite', 'NMC811']
+```
+
+## Log a physical lot
+
+The spec is the datasheet; a `material` record is the jar on the shelf:
+
+```python
+from battinfo.api import create_material, save_material
+
+lot = create_material(material_spec_id=NMC811_IRI, lot_id="CANRUD-NMC-2026-07")
+save_material(lot, source_root="my-library", mode="upsert")
+```
+
+## What just happened
+
+Each save wrote one plain-JSON record into your library and minted it a
+permanent `https://w3id.org/battinfo/spec/` IRI. That IRI is how everything
+else refers to the material: electrode recipes reference it
+(see [Build a cell from components](build-a-cell-from-components.md)), and the
+saved record validates against the material-spec schema before it lands.
+Re-saving with `mode="upsert"` updates in place — same IRI, never a duplicate.

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -76,11 +76,13 @@ resource stays dereferenceable, marked `owl:deprecated` and pointing at its
 replacement where one exists — never a 404. An IRI that once resolved always
 resolves.
 
-> **Status:** during the soft launch the registry sits behind an access gate,
-> so record IRIs may resolve to the platform's sign-in page rather than the
-> machine-readable artifact. Public reads for published records arrive as the
-> gate comes down — until then, treat dereferencing as not yet reliable for
-> harvesters.
+> **Status:** the resolver and content negotiation are live for published
+> records — a request with `Accept: application/ld+json` (or `text/turtle`)
+> returns the machine-readable record with no login. In a *browser*, the
+> human landing page sits behind the platform's sign-in gate during the soft
+> launch, so a scanned label may show a sign-in prompt while a harvester gets
+> data from the same IRI. Records that were never published to the registry
+> return `404 Record not found`.
 
 ## Enforcement
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,15 @@ BattINFO is the implementation layer for the EMMO domain-battery ontology — pr
 
 ## Getting started
 
+Lab work? **Start at the [cookbook](pages/cookbook.md)** — "I want to…" ×
+twelve bench tasks, each linked to a runnable recipe. The
+[glossary](pages/glossary.md) and [troubleshooting](pages/troubleshooting.md)
+pages live next to it.
+
 | | |
 |---|---|
 | **[Quickstart](../QUICKSTART.md)** | Create and publish your first cell-spec record in 5 minutes |
+| **[Cookbook](pages/cookbook.md)** | Task-first index of the bench recipes: materials, cells, labels, tests, publishing |
 | **[1 — Concepts](guides/01-concepts.ipynb)** | The record model, IRIs, and the semantic layer |
 | **[2 — Describing a cell](guides/02-first-cell-type.ipynb)** | Author and publish a cell spec, with a taste of material-level depth |
 | **[3 — Linked records](guides/03-linked-records.ipynb)** | Cells, test specs, tests, and datasets with the workspace |
@@ -49,7 +55,7 @@ Each notebook runs from its own folder and writes only to a throwaway `_scratch/
 
 | | |
 |---|---|
-| **[How-to guides](howto/bulk-ingest.md)** | Task recipes: bulk ingest, fixing validation errors, resuming submissions, funding/ORCID |
+| **[How-to guides](pages/cookbook.md)** | Task recipes: register materials, build a cell from components, label cells, register equipment and channels, find existing records, bulk ingest, fix validation errors, resume submissions, funding/ORCID |
 | **[Instance / test / dataset workflow](instance-test-dataset-workflow.md)** | Detailed workflow reference for linked records |
 | **[Editorial cell-spec workflow](internal/editorial-cell-type-workflow.md)** | Submission and curation workflow for the cell-spec library |
 | **[Ingest manifest contract](ingest-manifest-contract.md)** | Batch intake from a folder of raw data files |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,7 @@
    :hidden:
 
    pages/getting-started
+   pages/cookbook
    pages/guides
    pages/howto
    pages/reference

--- a/docs/material-spec.md
+++ b/docs/material-spec.md
@@ -2,18 +2,14 @@
 
 BattINFO models every entity as a **spec + instance** pair: a *spec* is the reusable,
 datasheet-like type description; an *instance* is a physical realization of that spec.
-This page documents the first standalone material family — `material-spec` (the type)
-and `material` (a physical lot/batch) — and the entity registry that makes adding such
-families uniform.
+This page is the field reference for the material family — `material-spec` (the grade)
+and `material` (a physical lot/batch).
 
-## The entity registry
-
-All record types are declared once in [`src/battinfo/entities.py`](../src/battinfo/entities.py)
-as `EntityKind` entries (top-level JSON key, schema file, on-disk subdirectory, IRI
-namespace, and the instance→spec link field). Dispatch, validation, IRI minting, the
-record-set directory list, and `build_index` all derive from this registry, so a new
-spec/instance family is a single registry entry plus its schema and examples — not a
-copy-paste across `api.py`, `ws.py`, and the validators.
+> **Just want to register your materials?** The recipe is
+> [How-to: register materials](howto/register-materials.md). (How new
+> spec/instance families are added uniformly — the entity registry in
+> [`src/battinfo/entities.py`](../src/battinfo/entities.py) — is an
+> implementation topic; see [How BattINFO is built](how-battinfo-is-built.md).)
 
 ## Records
 
@@ -89,9 +85,12 @@ Cell-specs still embed materials inline (`positive_electrode.coating.component`,
 to a standalone spec and reference it by IRI:
 
 ```python
-specs = bi.extract_material_specs(cell_spec_record)   # one material-spec per unique material
-spec  = bi.material_spec_from_component(holder, material_class="active_material")
-holder = bi.link_component_to_spec(holder, spec["material_spec"]["id"])  # holder now carries material_spec_id
+from battinfo.materials import (
+    extract_material_specs, link_component_to_spec, material_spec_from_component)
+
+specs = extract_material_specs(cell_spec_record)   # one material-spec per unique material
+spec  = material_spec_from_component(holder, material_class="active_material")
+holder = link_component_to_spec(holder, spec["material_spec"]["id"])  # holder now carries material_spec_id
 ```
 
 The embedded `material-component` holder gained an optional `material_spec_id` field for
@@ -100,9 +99,11 @@ this reference. Rewiring the full cell-spec fleet onto references is Phase 3.
 ## Worked example (Python API)
 
 ```python
-import battinfo as bi
+from battinfo.api import (
+    create_material, create_material_spec, query_material_specs,
+    save_material, save_material_spec)
 
-spec = bi.create_material_spec(
+spec = create_material_spec(
     name="LFP",
     material_class="active_material",
     electrode_polarity="positive",
@@ -111,17 +112,18 @@ spec = bi.create_material_spec(
     manufacturer="Canrud",
     property={"specific_capacity": {"value": 160, "unit": "mAh/g"}},
 )
-bi.save_material_spec(spec, source_root="examples")
+save_material_spec(spec, source_root="examples", mode="upsert")
 
-lot = bi.create_material(
+lot = create_material(
     material_spec_id=spec["material_spec"]["id"],
     lot_id="CANRUD-LFP-2026-03",
     supplier="Canrud",
     property={"mass": {"value": 19.5, "unit": "mg"}},
 )
-bi.save_material(lot, source_root="examples")  # resolves the material_spec_id reference
+save_material(lot, source_root="examples", mode="upsert")  # resolves the material_spec_id reference
 
-bi.query_material_specs(material_class="active_material")
+# pass directory= explicitly — the default reads the packaged examples
+query_material_specs(material_class="active_material", directory="examples/material-spec")
 ```
 
 ## Examples

--- a/docs/pages/cookbook.md
+++ b/docs/pages/cookbook.md
@@ -1,0 +1,44 @@
+# Cookbook — I want to…
+
+The bench tasks, task-first. Each link is a short recipe you can run today;
+none of them require reading the architecture pages first. New to BattINFO
+entirely? The {doc}`tutorials <guides>` teach the model these recipes assume,
+and the [glossary](glossary.md) decodes the vocabulary.
+
+| I want to… | Recipe |
+|---|---|
+| **Register the materials** in my lab (actives, binders, salts, solvents) | [Register materials](../howto/register-materials.md) |
+| **Describe an electrode recipe** (96/2/2 coating, loading, thickness) | {ref}`Build a cell from components — electrodes <electrode-recipe>` |
+| **Describe a cell I built** from its parts (electrodes, electrolyte, separator, housing) | [Build a cell from components](../howto/build-a-cell-from-components.md) |
+| **Log the cells on my bench** (lab names, no serial numbers) | [Label your cells — names vs. serials](../howto/label-your-cells.md) |
+| **Register my cycler and its channels** | [Register equipment](../howto/register-equipment.md) |
+| **Define a test protocol** (CC-CV cycling, capacity check, EIS, …) | [Test specs](../test-specs.md) |
+| **Log a test run** linked to a cell, a protocol, and a channel | [Workspace authoring](../workspace-authoring.md) · [Guide 3 — Linked records](../guides/03-linked-records.ipynb) |
+| **Convert a cycler export** to a tidy table (NEWARE, Biologic, Maccor CSV, …) | [Guide 6 — Stage 1: Convert](../guides/06-publish-your-data.ipynb) · unmapped columns? see [troubleshooting](troubleshooting.md#converted-file-is-missing-columns) |
+| **Validate my records and fix what's wrong** | [Fix validation errors](../howto/fix-validation-errors.md) |
+| **Publish, and get a DOI** | [Guide 6 — Publish your first dataset](../guides/06-publish-your-data.ipynb) |
+| **Put labels / QR codes on my cells** | [Label your cells](../howto/label-your-cells.md) |
+| **Find out what already exists** (my session, my library, the registry) | [Find existing records](../howto/find-existing-records.md) |
+
+## When something doesn't work
+
+The [troubleshooting page](troubleshooting.md) covers the classic surprises:
+empty search results, template files that will not load, columns that vanish
+in conversion, IRIs that open a sign-in page, and validation errors about
+dates.
+
+## The 30-second orientation
+
+Everything in BattINFO is a **spec** (a reusable description: a material
+grade, a cell product, a test protocol) or an **instance** (a physical thing
+or event: this cell, this test run). You register specs once, point instances
+at them, and every saved record gets a permanent IRI you can print on a label
+or cite in a paper. The {doc}`tutorials <guides>` build this up properly.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+troubleshooting
+glossary
+```

--- a/docs/pages/getting-started.rst
+++ b/docs/pages/getting-started.rst
@@ -8,6 +8,11 @@ BattINFO is the semantic data layer for battery technology. It gives you:
 - Automatic JSON → JSON-LD conversion aligned with the EMMO Battery Domain Ontology
 - A reusable cell-spec library backed by canonical records in ``battinfo-records``
 
+Working at the bench? The :doc:`cookbook <cookbook>` maps twelve lab tasks —
+register materials, build a cell from components, label cells, publish — to
+short runnable recipes, and the :doc:`glossary <glossary>` decodes the
+vocabulary in plain language.
+
 
 Installation
 ------------
@@ -106,7 +111,8 @@ BattINFO ships a command-line interface for validation and querying:
    # Validate a cell-spec record
    battinfo validate examples/cell-spec/A123__ANR26650M1-B.json --profile cell-spec
 
-   # Query all registered cell specs
+   # Query the example cell specs packaged with BattINFO (for your own
+   # library, use the Python query_* functions with an explicit directory)
    battinfo query cell-spec
 
    # Save a cell record from a draft file

--- a/docs/pages/glossary.md
+++ b/docs/pages/glossary.md
@@ -1,0 +1,82 @@
+# Glossary — the vocabulary, in plain language
+
+Two sentences per term, no prerequisites. For the full story behind any of
+them, follow the link at the end of the entry.
+
+**Linked Data**
+: Data published so that every thing (a cell, a material, a test) has a web
+  address, and records point at each other by those addresses instead of by
+  ambiguous names. It is what lets someone else's software follow your
+  cell → test → dataset chain without guessing.
+
+**IRI**
+: The web address that names one record, e.g.
+  `https://w3id.org/battinfo/cell/gm6p-mrc6-p6cc-0m18` — an
+  internationalized URL used as a permanent identifier. BattINFO IRIs never
+  change and never get reused, so they are safe to print on a cell wrapper or
+  cite in a paper ([Identifiers](../identifiers.md)).
+
+**EMMO**
+: The Elementary Multiperspective Material Ontology — a big, curated
+  dictionary of science and engineering concepts, each with a formal
+  definition and an IRI. BattINFO uses its battery and electrochemistry
+  branches so that "capacity" in your record means exactly the same thing as
+  in everyone else's.
+
+**Ontology**
+: A machine-readable dictionary plus the rules relating its terms ("a coin
+  cell *is a* battery cell"). Software uses it to reason about your records;
+  you mostly never touch it directly.
+
+**JSON-LD**
+: Ordinary JSON with a small `@context` block that maps its keys to ontology
+  IRIs — human-readable and machine-interpretable at once. BattINFO generates
+  it from your records automatically; you author plain JSON or Python.
+
+**RDF**
+: The underlying data model of Linked Data: every fact is a triple
+  (*subject – property – value*), and a pile of triples forms a graph.
+  JSON-LD is one way of writing RDF down; Turtle is another.
+
+**SPARQL**
+: The query language for RDF graphs — SQL's cousin for linked records. It is
+  what makes questions like "all datasets from NMC811 cells cycled at 45 °C"
+  answerable across datasets that have never seen each other.
+
+**spec vs. instance**
+: A *spec* is a reusable description — the datasheet: a material grade, a
+  cell product, a test protocol. An *instance* is one physical realization —
+  this jar of powder, the cell labelled B7-01, the test run that finished
+  Tuesday.
+
+**descriptor**
+: The research-grade level of a cell spec: electrode composition,
+  electrolyte formulation, separator, construction — the detail below the
+  datasheet numbers ({doc}`Guide 5 <../guides/05-descriptors>`).
+
+**@type stacking**
+: One record carrying several ontology classes at once: a cylindrical LFP
+  cell is simultaneously a `BatteryCell`, a `CylindricalBattery`, and a
+  `LithiumIronPhosphateBattery`. BattINFO stacks these automatically from
+  the format and chemistry you enter.
+
+**SHACL**
+: A rule language for checking RDF graphs — the semantic layer's
+  counterpart of JSON Schema. One of the layers behind
+  `validate_record_report` ([validation contract](../validation-contract.md)).
+
+**content negotiation**
+: One IRI, several representations: the same address returns JSON-LD to a
+  script asking for `application/ld+json` and a human web page to a browser.
+  This is why an IRI can "open a sign-in page" for you but still serve data
+  to machines ([troubleshooting](troubleshooting.md)).
+
+**BDF**
+: Battery Data Format — the one tidy, documented table layout that every
+  cycler export is converted into (`ws.convert()` /
+  `ws.convert_csv()`), so downstream tools read one format instead of ten.
+
+**short ID**
+: The first six characters of a record's UID (e.g. `gm6pmr`) — the
+  handwriting-sized version of an IRI, used in filenames and on cell labels
+  ([Label your cells](../howto/label-your-cells.md)).

--- a/docs/pages/howto.rst
+++ b/docs/pages/howto.rst
@@ -6,15 +6,20 @@ does a single job, states its ingredients up front, and gets out of your way.
 The code is executed in CI wherever it can run offline.
 
 New to BattINFO? Start with the :doc:`tutorials <guides>` instead — they teach
-the model that these recipes assume.
+the model that these recipes assume. Not sure which recipe you need? The
+:doc:`cookbook <cookbook>` maps twelve bench tasks to their recipes.
 
 .. toctree::
    :maxdepth: 1
 
    ../workspace-authoring
+   ../howto/register-materials
+   ../howto/build-a-cell-from-components
+   ../howto/label-your-cells
+   ../howto/register-equipment
+   ../howto/find-existing-records
    ../howto/bulk-ingest
    ../howto/fix-validation-errors
-   ../howto/register-equipment
    ../howto/resume-a-submission
    ../howto/tag-funding-and-orcid
    ../reading-a-record

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -1,0 +1,138 @@
+# Troubleshooting
+
+The classic surprises, with what is actually happening and the fix. Everything
+here reflects the current release; several of these edges are actively being
+smoothed.
+
+## `ws.search(...)` returns nothing
+
+`ws.search` queries the **live registry** — only *published* records exist
+there. Your own unsaved/unpublished records will never show up in search;
+inspect them with `ws.list(verbose=True)` or the `query_*` functions instead
+([Find existing records](../howto/find-existing-records.md)).
+
+If you are offline (or the registry is unreachable), search prints a
+"Registry unreachable" notice and falls back to a local clone of the records
+repository if configured — otherwise you get an empty list. An empty result
+while offline proves nothing about what exists.
+
+## "I don't have an API key"
+
+Reading needs no key: `ws.search`, resolving IRIs, and all local authoring
+work without an account. A key (`ws.login(api_key="bk_...")`) is only needed
+to **publish** to the registry (battery-genome.org). During the soft launch,
+keys are granted by the registry operators — there is no self-service key
+page yet; contact the Battery Genome team for publish access. `ws.status()`
+also needs a login, because it asks the registry about *your* workspace.
+
+## `ws.template("test-spec")` output won't load
+
+Known sharp edge. The generated test-spec template currently emits shapes the
+record model rejects: bare scalars where `{"value": ..., "unit": ...}` maps
+are required, a `{"min": ..., "max": ...}` voltage window the model cannot
+yet express, and `null` placeholders that are themselves invalid — so
+`ws.load()` fails with a stack of pydantic errors even after you fill it in.
+
+Until the template round-trip is fixed, author test specs directly in Python —
+this path works today and parses plain-English steps into the structured
+method:
+
+```python
+import battinfo
+
+battinfo.save_test_spec(battinfo.TestSpec(
+    name="Capacity Check - C/10 at 25 C",
+    kind="capacity_check",
+    experiment=["Charge at C/3 until 4.2 V", "Hold at 4.2 V until C/20",
+                "Discharge at C/10 until 2.5 V"],
+    conditions={"ambient_temperature": {"value": 25.0, "unit": "degC"}},
+), source_root="my-library", mode="upsert")
+```
+
+Put voltage limits in the step strings (as above) rather than in a
+min/max window. See [Test specs](../test-specs.md) for the full recipe.
+
+## "Which install extra do I need?"
+
+Each missing optional dependency raises an error naming its extra. The map:
+
+| You want | Install |
+|---|---|
+| Convert raw cycler files (`ws.convert()`) + plotting | `pip install "battinfo[processing]"` |
+| Read CSV/Parquet/XLSX tables (`ws.convert_csv`, dataset enrichment) | `pip install "battinfo[tabular]"` |
+| RO-Crate validation when publishing | `pip install "battinfo[publish]"` |
+| QR codes for cell labels | `pip install segno` (not a BattINFO extra) |
+
+## My record's IRI opens a sign-in page
+
+Content negotiation is doing its job. A `https://w3id.org/battinfo/...` IRI
+serves **two representations**: machine clients asking for
+`application/ld+json` (or `text/turtle`) get the record data — publicly, no
+login; browsers get the human landing page on the Battery Genome platform,
+which sits behind a sign-in gate during the soft launch. Verify the machine
+path yourself:
+
+```bash
+curl -sL -H "Accept: application/ld+json" \
+  https://w3id.org/battinfo/spec/27p5-216g-0vyc-98he
+```
+
+A `404 Record not found` from the resolver means the record was never
+published to the registry (local records resolve only after publishing).
+
+## Converted file is missing columns
+
+`ws.convert_csv(path, hints=...)` renames only the columns you map; columns
+it does not recognize pass through with their original names, and the BDF
+validation report then lists them under `extras` (with anything required
+under `missing`). If a column you care about — a capacity or step column —
+shows up in `extras`, it is not mapped to the canonical vocabulary and
+downstream tools will not see it.
+
+Fix: print the canonical target names and extend `hints`:
+
+```python
+import battinfo
+
+ws = battinfo.workspace(".")
+columns = ws.bdf_columns()   # prints all canonical BDF column names
+```
+
+<!-- doc-snippet: skip -->
+```python
+ws.convert_csv("export.csv", hints={
+    "Voltage(V)":  "voltage_volt",
+    "Current(A)":  "current_ampere",
+    "AhDis[Ah]":   "discharging_capacity_ah",   # map, don't lose, capacity
+})
+```
+
+Treat any non-empty `extras` list on a column you measured as a red flag —
+never accept a "successful" conversion without checking it.
+
+## Validation error: date "is not of type 'integer'"
+
+Canonical records store timestamps (`test.started_at`, `test.ended_at`,
+`provenance.retrieved_at`, …) as **Unix seconds**. The authoring surfaces
+(`battinfo.TestSpec(...)`, `ws.add(...)`, `create_*`) accept ISO dates like
+`"2026-01-15"` and convert for you — but if you hand-edit a saved JSON record
+and type an ISO string into one of these fields, schema validation rejects it
+with `'2026-07-17' is not of type 'integer'`. Fix: edit through the authoring
+surface, or enter the Unix timestamp. (Some fields, like a cell instance's
+`manufactured_at`, are flexible and take either form — the validator error
+tells you which field objected.)
+
+## Dangling references save without complaint
+
+`save_cell_spec` does not currently verify that a referenced
+`*_spec_id` exists — a typo lands on disk silently. Run
+`validate_record_report` over your library after a build session; it reports
+`reference.missing` with the offending IRI. The recipe is in
+{ref}`Build a cell from components <validate-the-set>`.
+
+## Still stuck?
+
+Open an issue at
+[github.com/BIG-MAP/BattINFO/issues](https://github.com/BIG-MAP/BattINFO/issues)
+with the record (or a redacted version) and the full error text — the
+validators' machine-readable output is designed to be pasted.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -18,7 +18,7 @@ reference follows below; for the layered architecture, see
 | Author research-grade composition (materials, electrodes, electrolyte) | `battinfo.authoring` — see {doc}`Tutorial 5 <../guides/05-descriptors>` |
 | Load, query, save, or resolver-publish canonical records | `battinfo.api` helpers |
 | Turn a folder of photos and CSVs into a linked submission | `battinfo.ingest` — one-command folder intake |
-| Drive everything from the shell | The `battinfo` CLI — see the {doc}`CLI reference </pages/cli-reference>` |
+| Script validation, saving, and publishing from the shell | The `battinfo` CLI — see the {doc}`CLI reference </pages/cli-reference>` |
 
 If you are new here, start with the {doc}`tutorials </pages/guides>` — six
 notebooks that walk the whole story end to end.

--- a/docs/test-specs.md
+++ b/docs/test-specs.md
@@ -1,10 +1,39 @@
 # Test specs
 
-A **test-spec** (`test-protocol` record) is the reusable, IRI-addressable description of a test
+A **test-spec** is the reusable, IRI-addressable description of a test
 procedure — the *spec* half of `test-spec` + `test`. A `test` (instance) links a cell-instance to
 a test-spec via `protocol_id` and to its `dataset`s.
 
-`examples/test-protocol/` now carries **one example for every `BatteryTestType`** value (20
+> **One thing, three names.** A *test spec* is stored as a `test-protocol`
+> record on disk and authored as the `TestSpec` Python class — same object
+> throughout. The `kind=` argument (the workspace calls it `type=`) takes any
+> `BatteryTestType` value: `cycling`, `capacity_check`, `rate_capability`,
+> `hppc`, `ici`, `gitt`, `dcir`, `eis`, `impedance`, `calendar_ageing`,
+> `formation`, `rpt`, `quasi_ocv`, `field`, `duty_cycle`, `wltp`, `nedc`,
+> `sem`, `characterization`, `other`.
+
+## Authoring
+
+```python
+import battinfo
+
+battinfo.save_test_spec(battinfo.TestSpec(
+    name="Capacity Check — C/10 at 25 C",
+    kind="capacity_check",
+    description="CC-CV charge then slow C/10 discharge.",
+    experiment=["Charge at C/3 until 4.2 V", "Hold at 4.2 V until C/20", "Discharge at C/10 until 2.5 V"],
+    conditions={"ambient_temperature": {"value": 25.0, "unit": "degC"}},
+), source_root="examples", mode="upsert")
+```
+
+`experiment` PyBaMM-style strings parse into the structured `method[]` (steps with
+mode/direction/setpoints/termination); `facets` are derived automatically for filtering.
+The model is two-layer by design: a descriptive `method[]` (what the procedure is) plus
+actionable `artifacts[]` (runnable protocol files carried as linked distributions).
+
+## How each kind is modelled
+
+`examples/test-protocol/` carries **one example for every `BatteryTestType`** value (20
 kinds), enforced by `tests/test_test_contract.py::test_test_protocol_examples_cover_full_battery_test_type_enum`.
 
 | Kind | Modelled with |
@@ -15,29 +44,13 @@ kinds), enforced by `tests/test_test_contract.py::test_test_protocol_examples_co
 | wltp, nedc | drive-cycle power profile — `description` + `protocol_url`; the full time-resolved trace is carried as a linked actionable artifact |
 | sem, characterization, field, other | minimal `name` + `kind` + `description` (no electrochemical method) |
 
-## Authoring
-
-```python
-import battinfo as bi
-
-bi.save_test_spec(bi.TestSpec(
-    name="Capacity Check — C/10 at 25 C",
-    kind=bi.BatteryTestType.CAPACITY_CHECK,
-    description="CC-CV charge then slow C/10 discharge.",
-    experiment=["Charge at C/3 until 4.2 V", "Hold at 4.2 V until C/20", "Discharge at C/10 until 2.5 V"],
-    conditions={"ambient_temperature": {"value": 25.0, "unit": "degC"}},
-), source_root="examples")
-```
-
-`experiment` PyBaMM-style strings parse into the structured `method[]` (steps with
-mode/direction/setpoints/termination); `facets` are derived automatically for filtering.
-The model is two-layer by design: a descriptive `method[]` (what the procedure is) plus
-actionable `artifacts[]` (runnable protocol files carried as linked distributions).
-
 > The `kind` enum in `test-protocol.schema.json` is kept in sync with the `BatteryTestType`
-> Python enum (`bundle.py`); the coverage test guards against drift.
+> Python enum (`battinfo.bundle.BatteryTestType`); the coverage test guards against drift.
 
-## Semantic depth of a test protocol
+## Going deeper: semantic depth of a test protocol
+
+*Everything below is background for ontology-curious readers — nothing in it
+is needed to author or run a test spec.*
 
 The current representation types the protocol at the class level and carries a free-text
 `description`. EMMO domain-electrochemistry has richer terms that allow a more explicit,

--- a/docs/workspace-authoring.md
+++ b/docs/workspace-authoring.md
@@ -1,8 +1,10 @@
 # Workspace authoring
 
-`battinfo.workspace(".")` is the blessed authoring surface — the one entry point that
-covers the common case end-to-end: describe the cells you tested, attach tests and data,
-and publish, without touching the lower layers.
+`battinfo.workspace(".")` is the blessed authoring surface for the lab-log
+workflow — describe the cells you tested, attach tests and data, and publish,
+without touching the lower layers. It covers cells, tests, datasets, and
+equipment; materials and component specs are authored through `battinfo.api`
+(see the [coverage table](#what-each-surface-can-author-today) below).
 
 ```python
 import battinfo
@@ -17,7 +19,9 @@ ws.quickstart()   # prints the copy-pasteable version of everything below
 import battinfo
 ws = battinfo.workspace(".")
 
-# 1. One-time: log in (get a key at the registry settings page)
+# 1. One-time: log in. Publishing goes to the Battery Genome registry
+#    (battery-genome.org); during the soft launch API keys are granted by
+#    the registry operators — there is no self-service key page yet.
 ws.login(api_key="YOUR_KEY")        # or ws.setup() to see options
 
 # 2. Tag this work with the project that funded it (optional, once per
@@ -54,11 +58,34 @@ Every verb is a method on the returned `AuthoringWorkspace` (also importable as
 |---|---|---|
 | Describe cells/tests/datasets interactively and publish them (the common case) | **Authoring workspace** | `ws = battinfo.workspace(".")` — this page |
 | Create a single record in code and save/publish it | **Models + functions** | `CellSpec(...)` + `battinfo.publish(...)` — see the [Python API](pages/api-reference.rst) |
-| Build or script the full object graph programmatically (ingest pipelines, batch tooling) | **Object-graph engine** | `battinfo.Workspace` |
+| Register materials and component specs (electrodes, electrolytes, …) | **`battinfo.api` functions** | `create_*` / `save_*` — see the [cookbook](pages/cookbook.md) |
+| Build or script the full object graph programmatically (ingest pipelines, batch tooling) | **Object-graph engine** | `battinfo._workspace.Workspace` |
+
+## What each surface can author today
+
+Verified against the current release — where a cell says "no", that is a
+roadmap item, not an omission in your usage:
+
+| Record type | Workspace (`ws.*`) | Python (`battinfo` / `battinfo.api`) | CLI (`battinfo …`) |
+|---|---|---|---|
+| Cell spec | yes — `template` + `load`, `search` + reuse, `spec=` on `add("cell")` | yes — `CellSpec` + `save_cell_spec` / `publish` | yes — `template` / `save cell-spec` / `validate` |
+| Cell (physical instance) | yes — `add("cell", names=[...])` | yes — `save_cell_instance` | yes — `create` / `save cell-instance` |
+| Test spec (protocol) | partial — `template("test-spec")` exists but its output currently fails `ws.load()` ([troubleshooting](pages/troubleshooting.md)) | yes — `TestSpec` + `save_test_spec` (recommended) | yes — `template` / `save test-spec` |
+| Test | yes — `add("test", cell=..., data=..., channel=...)` | yes — `Test` + `save_test` | yes — `save test` |
+| Dataset | yes — created by `add("test", data=...)` | yes — `Dataset` + `save_dataset` | yes — `save dataset` |
+| Equipment + channels | **yes — best path**: `add("equipment", ...)` ([how-to](howto/register-equipment.md)) | yes — `battinfo.api` equipment/channel functions | no |
+| Material spec / lot | no | **yes — the path**: `battinfo.api` `create`/`save_material_spec` ([how-to](howto/register-materials.md)) | partial — `save record --input file.json` |
+| Component specs (electrode, electrolyte, separator, current-collector, housing) | no | **yes — the path**: `battinfo.api` per-family `create`/`save` ([how-to](howto/build-a-cell-from-components.md)) | partial — `save record --input file.json` |
+
+Two CLI caveats: `battinfo query` currently reads only the example records
+packaged with BattINFO (no directory option — use the Python `query_*`
+functions for your own library), and there are no CLI `template`/`query`
+commands for materials or components.
 
 ## The layers underneath
 
-- **`battinfo.Workspace`** (in `battinfo._workspace`) is the object-graph engine: it
+- **`battinfo._workspace.Workspace`** is the object-graph engine (the top-level
+  `battinfo.Workspace` alias is deprecated): it
   holds linked `CellSpec` / `Cell` / `Test` / `Dataset` objects,
   finalizes ids and provenance, and writes the canonical records. The authoring
   workspace delegates to it; script against it directly when you are building


### PR DESCRIPTION
Task-first documentation for lab work, plus corrections where doc claims did not match the code. Part of the lab-engineer campaign (P2). Documents current main; where a behavior is a known defect being fixed separately, recipes teach the path that is correct either way.

New pages: a cookbook (12 common tasks -> recipes), how-tos for registering materials, building a cell from components, finding existing records, and labelling cells (QR), a troubleshooting page, and a plain-language glossary. Linked from the README and the docs index.

Corrections, each verified by running the code:

- "The workspace wraps everything" / "drive everything from the shell": not true for materials and components. Replaced with a capability table.
- cell-fleet.md claimed references are existence-checked on save. They are not; claim removed, validation recipe linked instead.
- component-specs.md called cell->component references "Phase 3". They ship today; fixed.
- identifiers.md said dereferencing is "not yet reliable". The machine path is live (tested against the resolver): JSON-LD and Turtle resolve; browsers hit the soft-launch gate. Rewritten.
- "Get a key at the registry settings page": no such page exists. Reworded to operator-granted access during soft launch.
- Deprecated bi.* imports in examples replaced with current ones.

Also: test-specs.md reordered recipe-first with a naming box; guides now link the equipment how-to; guide 06 surfaces bdf_columns and conversion hints. Notebook edits are markdown-only.

Every code block on new or edited pages was executed (37 executed, 0 failed, 18 skipped with reasons) and the new pages are wired into run_doc_snippets.py so CI keeps executing them. sphinx-build -W clean.

Follow-up, not in this PR: the battinfo.org site copy needs the same accuracy pass.
