### PR TITLE
docs: reconcile two pages with PR 286 behavior

### DIFF
--- a/docs/cell-fleet.md
+++ b/docs/cell-fleet.md
@@ -23,10 +23,12 @@ records are unaffected. The JSON-LD emits reference nodes
 (`hasPositiveElectrode: {"@id": <electrode-spec IRI>}`, etc.);
 when a basis/inline node is also present, the `@id` is merged onto it.
 
-> **Check your references.** Saving does *not* currently reject a
-> `*_spec_id` that points at nothing — a typo lands on disk silently. Run
-> `validate_record_report` over the record set after building (it reports
-> `reference.missing` per dangling IRI); the recipe is in
+> **References are checked at save.** A `*_spec_id` that points at nothing
+> fails the save with the missing IRI named (opt out with
+> `resolve_references=False` for staged workflows; `save_batch` allows
+> references within the batch and validates the completed set). Running
+> `validate_record_report` over a finished set is still a good final sweep;
+> the recipe is in
 > {ref}`How-to: build a cell from components <validate-the-set>`.
 
 ```python

--- a/docs/howto/build-a-cell-from-components.md
+++ b/docs/howto/build-a-cell-from-components.md
@@ -187,7 +187,10 @@ assert bad == 0
 ```
 
 A dangling reference reports as `reference.missing` with the offending IRI —
-fix the reference (or register the missing part) and re-run.
+fix the reference (or register the missing part) and re-run. Saves also
+check references by default, so a typo normally fails at `save_*` time
+before it ever lands on disk; this sweep is the belt-and-braces check over
+a finished set.
 
 ## What you have now
 

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -27,15 +27,18 @@ also needs a login, because it asks the registry about *your* workspace.
 
 ## `ws.template("test-spec")` output won't load
 
-Known sharp edge. The generated test-spec template currently emits shapes the
-record model rejects: bare scalars where `{"value": ..., "unit": ...}` maps
-are required, a `{"min": ..., "max": ...}` voltage window the model cannot
-yet express, and `null` placeholders that are themselves invalid — so
-`ws.load()` fails with a stack of pydantic errors even after you fill it in.
+Fixed as of the current release: the template now round-trips through
+`ws.load()` once you fill in the values. Condition placeholders use
+`{"value": ..., "unit": ...}` maps, windows use
+`{"min_value": ..., "max_value": ..., "unit": ...}` (a 2.5–4.2 V voltage
+window is expressible), and the file lists the allowed `type` values in
+`_allowed_types`. If `type` is left empty, the load error names every
+allowed value.
 
-Until the template round-trip is fixed, author test specs directly in Python —
-this path works today and parses plain-English steps into the structured
-method:
+If you are on an older version and the template fails with a stack of
+pydantic errors, author the test spec directly in Python instead — this
+path works on all versions and parses plain-English steps into the
+structured method:
 
 ```python
 import battinfo
@@ -49,8 +52,7 @@ battinfo.save_test_spec(battinfo.TestSpec(
 ), source_root="my-library", mode="upsert")
 ```
 
-Put voltage limits in the step strings (as above) rather than in a
-min/max window. See [Test specs](../test-specs.md) for the full recipe.
+See [Test specs](../test-specs.md) for the full recipe.
 
 ## "Which install extra do I need?"
 


### PR DESCRIPTION
PR #287 documented main as it was before PR #286 merged. Two spots are now stale: the troubleshooting entry for the test-spec template (fixed; old-version workaround kept) and the reference-checking claims in cell-fleet and the build-a-cell how-to (saves check references by default now). sphinx -W clean; doc snippets pass.