### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,7 @@
-<!-- Thanks for contributing to BattINFO! Please fill in the sections below. -->
+## What
 
-## What does this PR do?
+## Why
 
-Briefly describe the change and the motivation. Link any related issue
-(e.g. `Closes #123`).
+## How
 
-## Type of change
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation / examples
-- [ ] Ontology mapping or schema change
-- [ ] Refactor / maintenance
-
-## Checklist
-
-- [ ] The quality gate passes locally (`ruff`, `mypy`, `pytest` + coverage) — see [CONTRIBUTING.md](../CONTRIBUTING.md).
-- [ ] New behaviour is covered by tests.
-- [ ] User-facing changes are noted in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`.
-- [ ] Docs/examples updated if the change affects them.
-- [ ] No ontology IRIs are hardcoded as bare strings in business logic.
+## Testing


### PR DESCRIPTION
## What

A pull request template: What / Why / How / Testing.

## Why

Keeps PR descriptions uniform and readable. GitHub pre-fills it for every new PR.

## How

One file, .github/PULL_REQUEST_TEMPLATE.md.

## Testing

None needed; GitHub picks the file up by convention.
