### PR TITLE
transform: never drop electrode basis in JSON-LD

### DIFF
--- a/assets/mappings/domain-battery/entity_type_map.json
+++ b/assets/mappings/domain-battery/entity_type_map.json
@@ -221,12 +221,29 @@
         "node_type": "SiliconGraphiteElectrode",
         "battery_types": []
       },
+      "silicon": {
+        "relation": "hasNegativeElectrode",
+        "node_type": "SiliconBasedElectrode",
+        "battery_types": []
+      },
+      "si": {
+        "relation": "hasNegativeElectrode",
+        "node_type": "SiliconBasedElectrode",
+        "battery_types": []
+      },
       "hard-carbon": {
         "relation": "hasNegativeElectrode",
         "node_type": "HardCarbonElectrode",
         "battery_types": []
       },
       "lithium": {
+        "relation": "hasNegativeElectrode",
+        "node_type": "LithiumElectrode",
+        "battery_types": [
+          "LithiumMetalBattery"
+        ]
+      },
+      "lithium-metal": {
         "relation": "hasNegativeElectrode",
         "node_type": "LithiumElectrode",
         "battery_types": [

--- a/assets/vocab/emmo-labels.ttl
+++ b/assets/vocab/emmo-labels.ttl
@@ -182,6 +182,7 @@
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_74459386_875c_4303_b774_60125b599d06> skos:prefLabel "PouchCase"@en .
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_79a9e1be_35b0_4c3c_8087_b5f967ca0e87> skos:prefLabel "ChargingVoltage"@en .
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_79d1b273_58cd_4be6_a250_434817f7c261> skos:prefLabel "ActiveMaterial"@en .
+<https://w3id.org/emmo/domain/electrochemistry#electrochemistry_79e12290_d1e5_4c41_916c_18f1e4d7fb51> skos:prefLabel "SiliconBasedElectrode"@en .
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_7b3eb826_b968_493a_8396_cc3a5f09ecb3> skos:prefLabel "DCInternalResistance"@en .
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_7df82c48_b599_4b02_bef0_9facc9c39410> skos:prefLabel "hasAdditive"@en .
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_808e94df_e002_4e64_a6db_182ed75078c6> skos:prefLabel "hasSolvent"@en .

--- a/src/battinfo/data/mappings/domain-battery/entity_type_map.json
+++ b/src/battinfo/data/mappings/domain-battery/entity_type_map.json
@@ -221,12 +221,29 @@
         "node_type": "SiliconGraphiteElectrode",
         "battery_types": []
       },
+      "silicon": {
+        "relation": "hasNegativeElectrode",
+        "node_type": "SiliconBasedElectrode",
+        "battery_types": []
+      },
+      "si": {
+        "relation": "hasNegativeElectrode",
+        "node_type": "SiliconBasedElectrode",
+        "battery_types": []
+      },
       "hard-carbon": {
         "relation": "hasNegativeElectrode",
         "node_type": "HardCarbonElectrode",
         "battery_types": []
       },
       "lithium": {
+        "relation": "hasNegativeElectrode",
+        "node_type": "LithiumElectrode",
+        "battery_types": [
+          "LithiumMetalBattery"
+        ]
+      },
+      "lithium-metal": {
         "relation": "hasNegativeElectrode",
         "node_type": "LithiumElectrode",
         "battery_types": [

--- a/src/battinfo/transform/json_to_jsonld.py
+++ b/src/battinfo/transform/json_to_jsonld.py
@@ -186,7 +186,15 @@ def _entity_mapping(field: str, value: Any) -> dict[str, Any] | None:
     key = _normalize_term(value)
     if key is None:
         return None
-    return _entity_type_map().get(field, {}).get(key)
+    field_map = _entity_type_map().get(field, {})
+    hit = field_map.get(key)
+    if hit is not None:
+        return hit
+    # The map keys use hyphens ("hard-carbon", "silicon-graphite", "li-metal");
+    # accept the same term written with spaces, underscores, commas or slashes
+    # ("hard carbon", "silicon, graphite", "silicon/graphite").
+    variant = re.sub(r"[\s_,/]+", "-", key)
+    return field_map.get(variant) if variant != key else None
 
 
 def _load_mapping_file(*parts: str) -> dict[str, Any]:
@@ -1463,11 +1471,21 @@ def _apply_specification_composition(battery: dict[str, Any], specification: dic
             prop_nodes = _descriptor_property_nodes(electrode_data.get("property"))
             if prop_nodes:
                 electrode_node["hasProperty"] = prop_nodes[0] if len(prop_nodes) == 1 else prop_nodes
+        basis = specification.get(basis_field)
+        basis_label = basis.strip() if isinstance(basis, str) else ""
         if isinstance(node_type, str) and node_type:
             electrode_node["@type"] = node_type
         elif electrode_node:
             # Composition present but the basis has no specific EMMO electrode class.
             electrode_node["@type"] = "Electrode"
+        elif basis_label and basis_label.lower() != "unknown" and not mapping:
+            # An unrecognised basis string (no entity mapping at all): emit a
+            # generic labeled electrode so it is never dropped from the linked
+            # data (it survives in the record's *_electrode_basis field). Bases
+            # that map only to a battery class (e.g. NCA) already carry that
+            # information in the cell @type, so they need no electrode node.
+            electrode_node["@type"] = "Electrode"
+            electrode_node["skos:prefLabel"] = basis_label
         if electrode_node:
             battery[relation] = electrode_node
 

--- a/tests/test_electrode_basis_jsonld.py
+++ b/tests/test_electrode_basis_jsonld.py
@@ -1,0 +1,74 @@
+"""Electrode basis is never lost in the JSON-LD projection.
+
+A cell spec's positive/negative electrode basis must surface as a
+hasPositiveElectrode / hasNegativeElectrode node: a specific EMMO electrode
+class when the basis maps, and a labeled generic Electrode otherwise — so no
+basis string is silently dropped. Separator variants (spaces, commas, slashes)
+of the mapped terms are accepted.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.transform import to_jsonld  # noqa: E402
+
+
+def _negative_electrode(basis: str) -> dict | None:
+    record = {
+        "schema_version": "0.1.0",
+        "cell_spec": {
+            "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+            "name": "X", "model": "X",
+            "manufacturer": {"type": "Organization", "name": "A"},
+            "cell_format": "cylindrical", "chemistry": "Li-ion",
+            "positive_electrode_basis": "LFP",
+            "negative_electrode_basis": basis,
+        },
+    }
+    # to_jsonld validates its own output and raises on an unmapped @type, so a
+    # returned graph already proves every emitted electrode class resolves.
+    return to_jsonld(record, target="domain-battery")["@graph"][0].get("hasNegativeElectrode")
+
+
+def _types(node: dict | None) -> list[str]:
+    if not node:
+        return []
+    t = node.get("@type", [])
+    return t if isinstance(t, list) else [t]
+
+
+@pytest.mark.parametrize(
+    "basis,expected",
+    [
+        ("graphite", "GraphiteElectrode"),
+        ("hard carbon", "HardCarbonElectrode"),   # space accepted for hard-carbon
+        ("hard-carbon", "HardCarbonElectrode"),
+        ("silicon", "SiliconBasedElectrode"),      # bare silicon != silicon-graphite
+        ("si", "SiliconBasedElectrode"),
+        ("silicon-graphite", "SiliconGraphiteElectrode"),
+        ("silicon, graphite", "SiliconGraphiteElectrode"),  # comma accepted
+        ("silicon/graphite", "SiliconGraphiteElectrode"),   # slash accepted
+        ("lithium metal", "LithiumElectrode"),
+        ("LTO", "LithiumTitanateElectrode"),
+    ],
+)
+def test_mapped_basis_gets_specific_electrode_class(basis: str, expected: str) -> None:
+    assert expected in _types(_negative_electrode(basis))
+
+
+def test_unmapped_basis_gets_labeled_generic_electrode() -> None:
+    node = _negative_electrode("some custom anode")
+    assert _types(node) == ["Electrode"]
+    assert node is not None and node.get("skos:prefLabel") == "some custom anode"
+
+
+@pytest.mark.parametrize("basis", ["unknown", "Unknown", "", "   "])
+def test_unknown_or_empty_basis_emits_no_electrode(basis: str) -> None:
+    assert _negative_electrode(basis) is None

--- a/web/lib/jsonld.generated.ts
+++ b/web/lib/jsonld.generated.ts
@@ -496,6 +496,7 @@ export const jsonldGallery: {
           "@type": "@id"
         },
         "SiliconGraphiteElectrode": "electrochemistry:electrochemistry_e8c39ecc_29d1_4172_996e_d5b05dc88015",
+        "SiliconBasedElectrode": "electrochemistry:electrochemistry_79e12290_d1e5_4c41_916c_18f1e4d7fb51",
         "HardCarbonElectrode": "electrochemistry:electrochemistry_6235cc7c_2eee_432a_93af_47d7e05db007",
         "LithiumElectrode": "electrochemistry:electrochemistry_55775b50_b9d9_4d68_8cb5_38fcd7b9b54d",
         "LithiumIonTitanateBattery": "battery:battery_fd811dc3_8c37_4741_a099_78e26e4110ef",

--- a/web/lib/showcase.generated.ts
+++ b/web/lib/showcase.generated.ts
@@ -515,6 +515,7 @@ export const showcase: {
           "@type": "@id"
         },
         "SiliconGraphiteElectrode": "electrochemistry:electrochemistry_e8c39ecc_29d1_4172_996e_d5b05dc88015",
+        "SiliconBasedElectrode": "electrochemistry:electrochemistry_79e12290_d1e5_4c41_916c_18f1e4d7fb51",
         "HardCarbonElectrode": "electrochemistry:electrochemistry_6235cc7c_2eee_432a_93af_47d7e05db007",
         "LithiumElectrode": "electrochemistry:electrochemistry_55775b50_b9d9_4d68_8cb5_38fcd7b9b54d",
         "LithiumIonTitanateBattery": "battery:battery_fd811dc3_8c37_4741_a099_78e26e4110ef",

--- a/web/public/jsonld/cell-spec.jsonld
+++ b/web/public/jsonld/cell-spec.jsonld
@@ -295,6 +295,7 @@
       "@type": "@id"
     },
     "SiliconGraphiteElectrode": "electrochemistry:electrochemistry_e8c39ecc_29d1_4172_996e_d5b05dc88015",
+    "SiliconBasedElectrode": "electrochemistry:electrochemistry_79e12290_d1e5_4c41_916c_18f1e4d7fb51",
     "HardCarbonElectrode": "electrochemistry:electrochemistry_6235cc7c_2eee_432a_93af_47d7e05db007",
     "LithiumElectrode": "electrochemistry:electrochemistry_55775b50_b9d9_4d68_8cb5_38fcd7b9b54d",
     "LithiumIonTitanateBattery": "battery:battery_fd811dc3_8c37_4741_a099_78e26e4110ef",

--- a/web/public/jsonld/showcase-cell-spec.jsonld
+++ b/web/public/jsonld/showcase-cell-spec.jsonld
@@ -295,6 +295,7 @@
       "@type": "@id"
     },
     "SiliconGraphiteElectrode": "electrochemistry:electrochemistry_e8c39ecc_29d1_4172_996e_d5b05dc88015",
+    "SiliconBasedElectrode": "electrochemistry:electrochemistry_79e12290_d1e5_4c41_916c_18f1e4d7fb51",
     "HardCarbonElectrode": "electrochemistry:electrochemistry_6235cc7c_2eee_432a_93af_47d7e05db007",
     "LithiumElectrode": "electrochemistry:electrochemistry_55775b50_b9d9_4d68_8cb5_38fcd7b9b54d",
     "LithiumIonTitanateBattery": "battery:battery_fd811dc3_8c37_4741_a099_78e26e4110ef",


### PR DESCRIPTION
A cell spec's electrode basis could disappear from the JSON-LD. The composition emitter only produced a `hasPositiveElectrode`/`hasNegativeElectrode` node when the basis mapped to a specific EMMO electrode class or carried structured composition data. A bare basis string that did not map — a custom label, or a mapped term written with spaces or commas — emitted nothing, so it survived only in the record's `*_electrode_basis` field, not in the linked data.

This was found while checking whether the web Create tool's JSON-LD matched the package: the package handled the common chemistries (LFP, NMC, LCO, LMFP, graphite, LTO, Li-metal) but dropped the rest.

Three changes so a basis is never dropped:

- `_entity_mapping` accepts the hyphenated map keys written with spaces, commas or slashes, so `hard carbon` matches `hard-carbon` and `silicon, graphite` / `silicon/graphite` match `silicon-graphite`.
- Added `silicon` and `si` -> `SiliconBasedElectrode`, and `lithium-metal` -> `LithiumElectrode`, to the negative-electrode-basis map.
- For a basis that maps to no entity at all, emit a generic `Electrode` node labeled with the basis via `skos:prefLabel`, so it is never dropped. Bases that map only to a battery class (e.g. NCA) still emit no electrode node, since the cell `@type` already carries them.

On the silicon naming: EMMO has no `SiliconElectrode` class. The existing single-material silicon class is `SiliconBasedElectrode` (matching `CarbonBasedElectrode`, `TinBasedElectrode`, …), and the composite stays `SiliconGraphiteElectrode`. If a distinct `SiliconElectrode` term is wanted, that is an EMMO domain-battery addition, not a change here.

Regenerated the emmo-labels vocab and the web JSON-LD/showcase artifacts — the only change there is the new `SiliconBasedElectrode` context term; no node data changed. Regression test in `tests/test_electrode_basis_jsonld.py` covers the mapped classes, the separator variants, the labeled generic fallback, and that unknown/empty still emit nothing. Full suite: 1424 passed, 3 skipped.
