### PR TITLE
fix: regenerate records.context.v1.json (main CI is red after #294)

### DIFF
--- a/src/battinfo/data/context/records.context.v1.json
+++ b/src/battinfo/data/context/records.context.v1.json
@@ -295,6 +295,7 @@
       "@type": "@id"
     },
     "SiliconGraphiteElectrode": "electrochemistry:electrochemistry_e8c39ecc_29d1_4172_996e_d5b05dc88015",
+    "SiliconBasedElectrode": "electrochemistry:electrochemistry_79e12290_d1e5_4c41_916c_18f1e4d7fb51",
     "HardCarbonElectrode": "electrochemistry:electrochemistry_6235cc7c_2eee_432a_93af_47d7e05db007",
     "LithiumElectrode": "electrochemistry:electrochemistry_55775b50_b9d9_4d68_8cb5_38fcd7b9b54d",
     "LithiumIonTitanateBattery": "battery:battery_fd811dc3_8c37_4741_a099_78e26e4110ef",


### PR DESCRIPTION
`main` is red after #294 merged: `test_generated_context_is_in_sync` fails because the committed `records.context.v1.json` is stale.

Cause: merge-order drift, not a code bug. #293 (electrode-basis mappings) changed `gen_context.py`'s inputs; #294's committed context was generated before #293 landed. On the merged `main` the generator emits more terms (the electrode/substance/method block) than the committed file.

Fix: regenerated with `scripts/gen_context.py` (374 terms). Single file changed; `tests/test_hosted_context.py` passes locally (4/4). Merge to turn `main` green.