### PR TITLE
examples: the flagship A123 record carries its published IRI (0.2.0)

### DIFF
--- a/docs/guides/01-concepts.ipynb
+++ b/docs/guides/01-concepts.ipynb
@@ -127,9 +127,9 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5',\n",
-       " 'short_id': '7d9k2m',\n",
-       " 'identifier': 'cell-spec:7d9k-2m4p-8t3x-6nq5',\n",
+       "{'id': 'https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0',\n",
+       " 'short_id': 'pge5we',\n",
+       " 'identifier': 'cell-spec:pge5-wer6-2q82-v9k0',\n",
        " 'name': 'A123 ANR26650M1-B',\n",
        " 'model': 'ANR26650M1-B',\n",
        " 'manufacturer': {'type': 'Organization',\n",
@@ -314,8 +314,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IRI: https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\n",
-      "UID: 7d9k-2m4p-8t3x-6nq5\n"
+      "IRI: https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0\n",
+      "UID: pge5-wer6-2q82-v9k0\n"
      ]
     }
    ],

--- a/docs/guides/05-descriptors.ipynb
+++ b/docs/guides/05-descriptors.ipynb
@@ -396,7 +396,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cell ID: https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\n",
+      "Cell ID: https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0\n",
       "Model: ANR26650M1-B\n"
      ]
     }
@@ -406,7 +406,7 @@
     "\n",
     "# Use the known IRI for the A123 ANR26650M1-B example cell spec.\n",
     "# For new records: publish a CellSpec first to get the IRI, then use it here.\n",
-    "A123_IRI = \"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\"\n",
+    "A123_IRI = \"https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0\"\n",
     "\n",
     "spec = cell_description(\n",
     "    id=A123_IRI,\n",
@@ -623,7 +623,7 @@
       "          \"LithiumIonGraphiteBattery\"\n",
       "        ]\n",
       "      },\n",
-      "      \"@id\": \"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\",\n",
+      "      \"@id\": \"https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0\",\n",
       "      \"schema:name\": \"A123 Systems ANR26650M1-B\",\n",
       "      \"schema:model\": \"ANR26650M1-B\",\n",
       "      \"schema:manufacturer\": {\n",
@@ -1118,7 +1118,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IRI:          https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\n",
+      "IRI:          https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0\n",
       "Record keys:  ['schema_version', 'cell_spec', 'properties', 'provenance', 'notes', 'construction', 'positive_electrode', 'negative_electrode', 'electrolyte', 'separator']\n"
      ]
     }

--- a/docs/how-battinfo-is-built.md
+++ b/docs/how-battinfo-is-built.md
@@ -75,7 +75,7 @@ A record is one JSON file: a `schema_version`, one discriminator key holding
 the body (`"cell_spec": {...}`), and a `provenance` block (which also carries
 `battinfo_version`, stamping which library build wrote it). Files live under a
 *source root* (`examples/<type>/…` in this repo; `.battinfo/records/…` in a
-workspace). IRIs like `https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq8`
+workspace). IRIs like `https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0`
 are minted **deterministically** from each record's natural identity
 (manufacturer :: model :: … for a spec), so re-running an identical ingest
 lands on the same files instead of duplicating them.

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -9,7 +9,7 @@ https://w3id.org/battinfo/<namespace>/<uid>
                            namespace  (Crockford Base32)
 ```
 
-Example: `https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5`
+Example: `https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0`
 
 ## The three promises
 
@@ -30,7 +30,7 @@ Example: `https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5`
 The 16-character UID uses the **Crockford Base32 alphabet**
 (`0-9 a-h j k m n p-t v-z`) — no `i`, `l`, `o`, or `u`, so a UID survives
 being read aloud, handwritten on a cell wrapper, or retyped from a photo. It
-is displayed in four dash-separated groups (`7d9k-2m4p-8t3x-6nq5`); the first
+is displayed in four dash-separated groups (`pge5-wer6-2q82-v9k0`); the first
 six characters form the `short_id` used in filenames and for matching data
 files to cells (`ws.add("test", datasets="glob")`).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Here is a minimal example that creates a canonical cell-spec record and publishe
          {
            "schema_version": "0.1.0",
            "cell_spec": {
-             "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+             "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
              "name": "A123 ANR26650M1-B",
              "model": "ANR26650M1-B",
              "manufacturer": { "type": "Organization", "name": "A123" },
@@ -63,7 +63,7 @@ Here is a minimal example that creates a canonical cell-spec record and publishe
 
          {
            "@context": "https://w3id.org/battinfo/context/domain-battery.jsonld",
-           "@id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+           "@id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
            "@type": ["BatteryCell", "CylindricalBattery", "LithiumIonBattery"],
            "skos:prefLabel": "A123 ANR26650M1-B",
            "manufacturer": { "@type": "Organization", "name": "A123" },

--- a/docs/internal/cli-spec.md
+++ b/docs/internal/cli-spec.md
@@ -174,7 +174,7 @@ JSON mode (`--format json`) for all query commands:
   "offset": 0,
   "items": [
     {
-      "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+      "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
       "short_id": "7d9k2m",
       "manufacturer": "A123",
       "model_name": "ANR26650M1-B"
@@ -208,7 +208,7 @@ Output contract:
 {
   "status": "created",
   "id": "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8",
-  "cell_spec_id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+  "cell_spec_id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
   "path": "examples/cell-instance/cell-3m6k-9t2p-7x4h-9nq8.json"
 }
 ```

--- a/docs/internal/instance-test-dataset-workflow.md
+++ b/docs/internal/instance-test-dataset-workflow.md
@@ -109,7 +109,7 @@ Example commands:
 ```powershell
 battinfo validate examples/cell-spec/research/a123-anr26650m1-b.detailed.example.json
 
-battinfo save cell-instance --cell-spec-id https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5 --uid 3m6k9t2p7x4h9nq8 --source-type lab
+battinfo save cell-instance --cell-spec-id https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0 --uid 3m6k9t2p7x4h9nq8 --source-type lab
 
 battinfo save test --cell-id https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8 --name "Baseline cycling" --kind cycling --uid 5p7v2n8k4m3t6q9r
 
@@ -119,7 +119,7 @@ battinfo save dataset --title "Baseline cycling dataset" --related-cell-id https
 Query commands over the linked chain:
 
 ```powershell
-battinfo query cell-instance --cell-spec-id https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5 --has-dataset true --format json
+battinfo query cell-instance --cell-spec-id https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0 --has-dataset true --format json
 
 battinfo query tests --cell-id https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8 --format json
 

--- a/examples/cell-instance/cell-3m6k-9t2p-7x4h-9nq8.json
+++ b/examples/cell-instance/cell-3m6k-9t2p-7x4h-9nq8.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "cell_instance": {
     "id": "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8",
-    "cell_spec_id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+    "cell_spec_id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
     "short_id": "3m6k9t",
     "serial_number": "SN0001"
   },

--- a/examples/cell-spec/A123__ANR26650M1-B.json
+++ b/examples/cell-spec/A123__ANR26650M1-B.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "cell_spec": {
-    "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-    "short_id": "7d9k2m",
-    "identifier": "cell-spec:7d9k-2m4p-8t3x-6nq5",
+    "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+    "short_id": "pge5we",
+    "identifier": "cell-spec:pge5-wer6-2q82-v9k0",
     "name": "A123 ANR26650M1-B",
     "model": "ANR26650M1-B",
     "manufacturer": {
@@ -94,15 +94,6 @@
       "unit": "A",
       "raw": {
         "text": "Recommended Fast Charge Method to 80% SOC 10A to 3.6V CC, 12 min",
-        "page": 1,
-        "confidence": 0.8
-      }
-    },
-    "nominal_continuous_charging_current": {
-      "value": 2.5,
-      "unit": "A",
-      "raw": {
-        "text": "Recommended Standard Charge Method 2.5A to 3.6V CCCV, 60 min",
         "page": 1,
         "confidence": 0.8
       }

--- a/src/battinfo/data/examples/cell-instance/cell-3m6k-9t2p-7x4h-9nq8.json
+++ b/src/battinfo/data/examples/cell-instance/cell-3m6k-9t2p-7x4h-9nq8.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "cell_instance": {
     "id": "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8",
-    "cell_spec_id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+    "cell_spec_id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
     "short_id": "3m6k9t",
     "serial_number": "SN0001"
   },

--- a/src/battinfo/data/examples/cell-spec/A123__ANR26650M1-B.json
+++ b/src/battinfo/data/examples/cell-spec/A123__ANR26650M1-B.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "cell_spec": {
-    "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-    "short_id": "7d9k2m",
-    "identifier": "cell-spec:7d9k-2m4p-8t3x-6nq5",
+    "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+    "short_id": "pge5we",
+    "identifier": "cell-spec:pge5-wer6-2q82-v9k0",
     "name": "A123 ANR26650M1-B",
     "model": "ANR26650M1-B",
     "manufacturer": {
@@ -94,15 +94,6 @@
       "unit": "A",
       "raw": {
         "text": "Recommended Fast Charge Method to 80% SOC 10A to 3.6V CC, 12 min",
-        "page": 1,
-        "confidence": 0.8
-      }
-    },
-    "nominal_continuous_charging_current": {
-      "value": 2.5,
-      "unit": "A",
-      "raw": {
-        "text": "Recommended Standard Charge Method 2.5A to 3.6V CCCV, 60 min",
         "page": 1,
         "confidence": 0.8
       }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,10 +156,10 @@ def test_template_cell_spec_and_create_cell_instance(tmp_path: Path) -> None:
         iec_code="IFpR26650",
         country_of_origin="United States",
         year=2012,
-        uid="7d9k2m4p8t3x6nq5",
+        uid="pge5wer62q82v9k0",
         source_file="A123__ANR26650M1-B.pdf",
     )
-    assert cell_spec["cell_spec"]["id"] == "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5"
+    assert cell_spec["cell_spec"]["id"] == "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0"
     assert cell_spec["cell_spec"]["model"] == "ANR26650M1-B"
     assert cell_spec["cell_spec"]["iec_code"] == "IFpR26650"
     assert cell_spec["cell_spec"]["country_of_origin"] == "United States"
@@ -188,7 +188,7 @@ def test_query_cell_specs_exposes_iec_code(tmp_path: Path) -> None:
         iec_code="IFpR26650",
         country_of_origin="United States",
         year=2012,
-        uid="7d9k2m4p8t3x6nq5",
+        uid="pge5wer62q82v9k0",
         source_file="A123__ANR26650M1-B.pdf",
     )
     save_cell_spec(record, source_root=tmp_path)
@@ -593,7 +593,7 @@ def test_promote_staging_cell_spec_preserves_double_hyphen_record_id(tmp_path: P
 def test_save_test_protocol_and_test_with_protocol_reference(tmp_path: Path) -> None:
     cell_spec = save_cell_spec(
         CellSpec(
-            uid="7d9k2m4p8t3x6nq5",
+            uid="pge5wer62q82v9k0",
             manufacturer="A123",
             model_name="ANR26650M1-B",
             chemistry="Li-ion",

--- a/tests/test_cli_query_create_publish.py
+++ b/tests/test_cli_query_create_publish.py
@@ -406,9 +406,9 @@ def test_save_test_protocol_and_test_with_protocol_id(tmp_path: Path) -> None:
             {
                 "schema_version": "0.1.0",
                 "cell_spec": {
-                    "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-                    "short_id": "7d9k2m",
-                    "identifier": "cell-spec:7d9k-2m4p-8t3x-6nq5",
+                    "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+                    "short_id": "pge5we",
+                    "identifier": "cell-spec:pge5-wer6-2q82-v9k0",
                     "name": "A123 ANR26650M1-B",
                     "model": "ANR26650M1-B",
                     "manufacturer": {
@@ -441,7 +441,7 @@ def test_save_test_protocol_and_test_with_protocol_id(tmp_path: Path) -> None:
             "save",
             "cell-instance",
             "--cell-spec-id",
-            "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
+            "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
             "--uid",
             "3m6k9t2p7x4h9nq8",
             "--source-root",

--- a/tests/test_validation_semantic.py
+++ b/tests/test_validation_semantic.py
@@ -41,9 +41,9 @@ def test_semantic_validation_rejects_unit_mismatch_for_specs() -> None:
     assert any(issue.code == "semantic.unit_mismatch" for issue in report.errors)
 
 
-def test_semantic_validation_rejects_unit_mismatch_for_nominal_continuous_current_specs() -> None:
+def test_semantic_validation_rejects_unit_mismatch_for_continuous_current_specs() -> None:
     doc = _load_json("src/battinfo/data/examples/cell-spec/A123__ANR26650M1-B.json")
-    doc["properties"]["nominal_continuous_charging_current"]["unit"] = "V"
+    doc["properties"]["maximum_continuous_charging_current"]["unit"] = "V"
     report = validate_semantic_report(doc, policy=STRICT_SEMANTIC)
     assert not report.ok
     assert any(issue.code == "semantic.unit_mismatch" for issue in report.errors)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -144,7 +144,7 @@ def test_workspace_loads_cell_spec_from_validated_json_record(tmp_path: Path) ->
     assert len(workspace.cell_specs) == 1
     assert cell_spec.manufacturer == "A123"
     assert cell_spec.model == "ANR26650M1-B"
-    assert cell_spec.id == "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5"
+    assert cell_spec.id == "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0"
     assert cell_spec.iec_code == "IFpR26650"
     assert cell_spec.country_of_origin == "United States"
     assert cell_spec.year == 2012

--- a/web/lib/examples.generated.ts
+++ b/web/lib/examples.generated.ts
@@ -4,11 +4,11 @@
 
 // The full canonical record, verbatim from examples/**.
 export const cellSpecCanonical = {
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "cell_spec": {
-    "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-    "short_id": "7d9k2m",
-    "identifier": "cell-spec:7d9k-2m4p-8t3x-6nq5",
+    "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+    "short_id": "pge5we",
+    "identifier": "cell-spec:pge5-wer6-2q82-v9k0",
     "name": "A123 ANR26650M1-B",
     "model": "ANR26650M1-B",
     "manufacturer": {
@@ -103,15 +103,6 @@ export const cellSpecCanonical = {
         "confidence": 0.8
       }
     },
-    "nominal_continuous_charging_current": {
-      "value": 2.5,
-      "unit": "A",
-      "raw": {
-        "text": "Recommended Standard Charge Method 2.5A to 3.6V CCCV, 60 min",
-        "page": 1,
-        "confidence": 0.8
-      }
-    },
     "maximum_continuous_charging_current": {
       "value": 2.5,
       "unit": "A",
@@ -188,7 +179,7 @@ export const cellSpecCanonical = {
 // A friendly authored-input teaser derived from the canonical record, so its
 // values can never drift from the source record.
 export const cellSpecInput = {
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "cell_spec": {
     "name": "A123 ANR26650M1-B",
     "model": "ANR26650M1-B",

--- a/web/lib/examples.ts
+++ b/web/lib/examples.ts
@@ -50,7 +50,7 @@ result = publish(
     destination="local",
 )
 print(result.canonical_iri)
-# https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5`;
+# https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0`;
 
 export const installSnippet = `python -m venv .venv
 # until the 0.8 release lands on PyPI, install from source:

--- a/web/lib/jsonld.generated.ts
+++ b/web/lib/jsonld.generated.ts
@@ -19,11 +19,11 @@ export const jsonldGallery: {
     "sourceFile": "examples/cell-spec/A123__ANR26650M1-B.json",
     "highlight": "EMMO @type stacking: one cylindrical LFP cell is simultaneously a BatteryCell, a CylindricalBattery, and a LithiumIronPhosphateBattery — no manual annotation.",
     "record": {
-      "schema_version": "0.1.0",
+      "schema_version": "0.2.0",
       "cell_spec": {
-        "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-        "short_id": "7d9k2m",
-        "identifier": "cell-spec:7d9k-2m4p-8t3x-6nq5",
+        "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+        "short_id": "pge5we",
+        "identifier": "cell-spec:pge5-wer6-2q82-v9k0",
         "name": "A123 ANR26650M1-B",
         "model": "ANR26650M1-B",
         "manufacturer": {
@@ -118,15 +118,6 @@ export const jsonldGallery: {
             "confidence": 0.8
           }
         },
-        "nominal_continuous_charging_current": {
-          "value": 2.5,
-          "unit": "A",
-          "raw": {
-            "text": "Recommended Standard Charge Method 2.5A to 3.6V CCCV, 60 min",
-            "page": 1,
-            "confidence": 0.8
-          }
-        },
         "maximum_continuous_charging_current": {
           "value": 2.5,
           "unit": "A",
@@ -205,15 +196,15 @@ export const jsonldGallery: {
         "BatteryCellSpecification",
         "schema:CreativeWork"
       ],
-      "@id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-      "schema:identifier": "7d9k-2m4p-8t3x-6nq5",
+      "@id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+      "schema:identifier": "pge5-wer6-2q82-v9k0",
       "schema:name": "A123 ANR26650M1-B",
       "schema:model": "ANR26650M1-B",
       "schema:manufacturer": {
         "@type": "schema:Organization",
         "schema:name": "A123"
       },
-      "schema:url": "https://www.battery-genome.org/registry/spec/7d9k-2m4p-8t3x-6nq5",
+      "schema:url": "https://www.battery-genome.org/registry/spec/pge5-wer6-2q82-v9k0",
       "isDescriptionFor": {
         "@type": [
           "BatteryCell",
@@ -235,7 +226,7 @@ export const jsonldGallery: {
         "schema:name": "United States"
       },
       "schema:releaseDate": "2012-01-01",
-      "schema:schemaVersion": "0.1.0",
+      "schema:schemaVersion": "0.2.0",
       "hasProperty": [
         {
           "@type": [
@@ -330,18 +321,6 @@ export const jsonldGallery: {
           "hasNumericalPart": {
             "@type": "RealData",
             "hasNumberValue": 10.0
-          },
-          "hasMeasurementUnit": "https://w3id.org/emmo#Ampere"
-        },
-        {
-          "@type": [
-            "NominalContinuousChargingCurrent",
-            "ConventionalProperty"
-          ],
-          "skos:prefLabel": "NominalContinuousChargingCurrent",
-          "hasNumericalPart": {
-            "@type": "RealData",
-            "hasNumberValue": 2.5
           },
           "hasMeasurementUnit": "https://w3id.org/emmo#Ampere"
         },

--- a/web/public/jsonld/cell-spec.jsonld
+++ b/web/public/jsonld/cell-spec.jsonld
@@ -4,15 +4,15 @@
     "BatteryCellSpecification",
     "schema:CreativeWork"
   ],
-  "@id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-  "schema:identifier": "7d9k-2m4p-8t3x-6nq5",
+  "@id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+  "schema:identifier": "pge5-wer6-2q82-v9k0",
   "schema:name": "A123 ANR26650M1-B",
   "schema:model": "ANR26650M1-B",
   "schema:manufacturer": {
     "@type": "schema:Organization",
     "schema:name": "A123"
   },
-  "schema:url": "https://www.battery-genome.org/registry/spec/7d9k-2m4p-8t3x-6nq5",
+  "schema:url": "https://www.battery-genome.org/registry/spec/pge5-wer6-2q82-v9k0",
   "isDescriptionFor": {
     "@type": [
       "BatteryCell",
@@ -34,7 +34,7 @@
     "schema:name": "United States"
   },
   "schema:releaseDate": "2012-01-01",
-  "schema:schemaVersion": "0.1.0",
+  "schema:schemaVersion": "0.2.0",
   "hasProperty": [
     {
       "@type": [
@@ -129,18 +129,6 @@
       "hasNumericalPart": {
         "@type": "RealData",
         "hasNumberValue": 10.0
-      },
-      "hasMeasurementUnit": "https://w3id.org/emmo#Ampere"
-    },
-    {
-      "@type": [
-        "NominalContinuousChargingCurrent",
-        "ConventionalProperty"
-      ],
-      "skos:prefLabel": "NominalContinuousChargingCurrent",
-      "hasNumericalPart": {
-        "@type": "RealData",
-        "hasNumberValue": 2.5
       },
       "hasMeasurementUnit": "https://w3id.org/emmo#Ampere"
     },


### PR DESCRIPTION
Fixes the last launch gate (#297) and the example version stamps (#301).

The A123 ANR26650M1-B example carried a hand-assigned uid (`spec/7d9k-2m4p-8t3x-6nq5`) that never resolved — while the same cell has been published in the registry as `spec/pge5-wer6-2q82-v9k0` all along. Publishing the example would have minted a duplicate identity; the fix is alignment. (Verified first that 7d9k is NOT the deterministic identity mint — the fresh mint for this identity is a third uid entirely — so the swap touches no minting machinery.)

What changed:

- The shipped example (both trees) carries the published IRI with matching `short_id`/`identifier`, stamps `schema_version: 0.2.0`, and drops `nominal_continuous_charging_current` — an uncurated candidate key whose datasheet value is already captured by the curated `maximum_continuous_charging_current` (the steward review's "schema-valid but semantically unmapped" example, ahead of #299).
- The cell-instance example's `cell_spec_id` chain, the /validate sample, docs (identifiers, index quickstart illustration, guides 1 + 5, internal specs), and the web gallery all follow.
- Fictional showcase records (Samsung SDI et al.) keep their placeholder uids by design — only the real A123 surfaces point at the real registry record.
- Tests aligned: fixtures that author the A123 use its published uid; the unit-mismatch test moved to the curated current key.

Testing: full suite green apart from the 14 known pre-existing environment failures in this worktree (diffed against pristine main); web drift tests, 109-record agreement check, workbench checks, typecheck, and build all pass; strict docs build passes; the IRI dereferences live (200 for ld+json and HTML).

Note for the #298 operator session: what `spec/pge5-wer6-2q82-v9k0` serves today is the legacy-shaped archive — re-emission (and optionally a content version-bump to this curated example) makes the dereferenced document match what the docs show.

Closes #297. Closes #301.