### PR TITLE
validate: surface unmapped property keys on component records too

### DIFF
--- a/src/battinfo/validate/semantic.py
+++ b/src/battinfo/validate/semantic.py
@@ -427,10 +427,36 @@ def _curated_property_map() -> dict[str, str]:
     return {m["key"]: m.get("class_iri", "") for m in doc.get("mappings", [])}
 
 
+@lru_cache(maxsize=1)
+def _component_property_terms() -> frozenset[str]:
+    """Property keys the component emitters resolve WITHOUT the curated map.
+
+    Imported from the transform itself (fraction keys and the descriptor /
+    coating term tables), so this set can never drift from what the JSON-LD
+    emitters actually accept.
+    """
+    from battinfo.transform.json_to_jsonld import (
+        _DESCRIPTOR_COATING_PROPERTY_TERMS,
+        _DESCRIPTOR_PROPERTY_TERMS,
+        _FRACTION_PROPERTY_TERMS,
+    )
+
+    return frozenset(
+        {
+            *_FRACTION_PROPERTY_TERMS,
+            *_DESCRIPTOR_PROPERTY_TERMS,
+            *_DESCRIPTOR_COATING_PROPERTY_TERMS,
+        }
+    )
+
+
 def _validate_property_mappability(
     specs: Mapping[str, Any],
     issues: list[ValidationIssue],
     resource_type: str | None,
+    *,
+    path_prefix: str = "properties",
+    extra_known: frozenset[str] = frozenset(),
 ) -> None:
     """Warn where a schema-valid property will not survive the JSON-LD export.
 
@@ -444,16 +470,20 @@ def _validate_property_mappability(
         if not isinstance(value, Mapping):
             continue
         class_iri = prop_map.get(key)
+        if class_iri is None and key in extra_known:
+            continue
         if class_iri is None:
             _append_issue(
                 issues,
                 code="semantic.property_unmapped",
                 severity="warning",
-                path=f"properties.{key}",
+                path=f"{path_prefix}.{key}",
                 message=(
                     f"'{key}' is schema-valid but has no curated EMMO mapping - "
-                    "it will be OMITTED from the exported JSON-LD. File a mapping "
-                    "in assets/mappings/domain-battery/property_map.curated.json."
+                    "the JSON-LD export emits it under a non-canonical fallback "
+                    "term, which other tools will not recognize and which will "
+                    "not survive a round-trip import. File a mapping in "
+                    "assets/mappings/domain-battery/property_map.curated.json."
                 ),
                 resource_type=resource_type,
             )
@@ -469,7 +499,7 @@ def _validate_property_mappability(
                 issues,
                 code="semantic.value_text_only",
                 severity="warning",
-                path=f"properties.{key}",
+                path=f"{path_prefix}.{key}",
                 message=(
                     f"'{key}' carries only value_text - the JSON-LD export emits "
                     "numeric quantities, so this property will be OMITTED there."
@@ -482,7 +512,7 @@ def _validate_property_mappability(
                 issues,
                 code="semantic.property_alias_collision",
                 severity="warning",
-                path=f"properties.{keys[1]}",
+                path=f"{path_prefix}.{keys[1]}",
                 message=(
                     f"{keys} all map to the same EMMO class ({class_iri.rsplit('#', 1)[-1]}); "
                     "only one quantity node survives in JSON-LD - keep a single alias."
@@ -788,6 +818,36 @@ def validate_semantic_report(
         body = doc.get(body_key)
         if isinstance(body, Mapping) and isinstance(body.get("property"), Mapping):
             _validate_specs(body["property"], issues, resource_type, hard_issue_severity)
+
+    # Every component body's property block gets the mappability check, with
+    # the transform's descriptor/fraction keys treated as known (they resolve
+    # without the curated map). Coating properties resolve through the coating
+    # term table, so electrode coatings are checked too.
+    for body_key in (
+        "material_spec", "material",
+        "electrode_spec", "electrode",
+        "electrolyte_spec", "electrolyte",
+        "separator_spec", "separator",
+        "current_collector_spec", "current_collector",
+        "housing_spec", "housing",
+        "equipment_spec", "equipment", "channel",
+    ):
+        body = doc.get(body_key)
+        if not isinstance(body, Mapping):
+            continue
+        if isinstance(body.get("property"), Mapping):
+            _validate_property_mappability(
+                body["property"], issues, resource_type,
+                path_prefix=f"{body_key}.property",
+                extra_known=_component_property_terms(),
+            )
+        coating = body.get("coating")
+        if isinstance(coating, Mapping) and isinstance(coating.get("property"), Mapping):
+            _validate_property_mappability(
+                coating["property"], issues, resource_type,
+                path_prefix=f"{body_key}.coating.property",
+                extra_known=_component_property_terms(),
+            )
 
     dataset = doc.get("dataset")
     if isinstance(dataset, Mapping):

--- a/tests/test_validation_plausibility.py
+++ b/tests/test_validation_plausibility.py
@@ -219,7 +219,9 @@ class TestPropertyMappability:
         )
         issues = [i for i in report.issues if i.code == "semantic.property_unmapped"]
         assert len(issues) == 1 and issues[0].severity == "warning"
-        assert "OMITTED" in issues[0].message
+        # The message states what actually happens: a non-canonical fallback
+        # term is emitted (the property is not silently omitted).
+        assert "fallback" in issues[0].message
 
     def test_value_text_only_warns(self) -> None:
         report = validate_semantic_report(

--- a/tests/test_validation_semantic.py
+++ b/tests/test_validation_semantic.py
@@ -154,3 +154,58 @@ def test_semantic_validation_rejects_size_code_prefix_mismatch_for_format() -> N
     assert not report.ok
     assert any(issue.code == "semantic.size_code_prefix_mismatch" for issue in report.errors)
 
+# ── #299: unmapped property keys surface on COMPONENT records too ─────────────
+
+
+def test_component_property_unmapped_key_warns() -> None:
+    rec = {
+        "schema_version": "0.2.0",
+        "material_spec": {
+            "id": "https://w3id.org/battinfo/material-spec/aaaa-bbbb-cccc-dddd",
+            "name": "X",
+            "property": {
+                "made_up_prop": {"value": 1.0, "unit": "g"},
+                "density": {"value": 1.2, "unit": "g/cm3"},
+                "porosity": {"value": 40, "unit": "%"},
+            },
+        },
+        "provenance": {"source_type": "datasheet"},
+    }
+    report = validate_semantic_report(rec, policy=STRICT_SEMANTIC)
+    hits = [(i.severity, i.path) for i in report.issues if i.code == "semantic.property_unmapped"]
+    # density/porosity resolve through the transform's descriptor/fraction
+    # tables and must NOT warn; the invented key must.
+    assert hits == [("warning", "material_spec.property.made_up_prop")]
+
+
+def test_coating_property_unmapped_key_warns_with_coating_path() -> None:
+    rec = {
+        "schema_version": "0.2.0",
+        "electrode_spec": {
+            "id": "https://w3id.org/battinfo/electrode-spec/aaaa-bbbb-cccc-dddd",
+            "name": "E",
+            "coating": {
+                "property": {
+                    "loading": {"value": 6.6, "unit": "mg/cm2"},
+                    "thickness": {"value": 16, "unit": "um"},
+                    "junk_key": {"value": 1, "unit": "g"},
+                }
+            },
+        },
+        "provenance": {"source_type": "datasheet"},
+    }
+    report = validate_semantic_report(rec, policy=STRICT_SEMANTIC)
+    hits = [i.path for i in report.issues if i.code == "semantic.property_unmapped"]
+    assert hits == ["electrode_spec.coating.property.junk_key"]
+
+
+def test_property_unmapped_message_matches_transform_reality() -> None:
+    # The transform emits unmapped keys under a battinfo: fallback term — it
+    # does not omit them. The warning must say what actually happens.
+    doc = _load_json("src/battinfo/data/examples/cell-spec/A123__ANR26650M1-B.json")
+    doc["properties"]["frobnication_index"] = {"value": 1.0, "unit": "%"}
+    report = validate_semantic_report(doc, policy=STRICT_SEMANTIC)
+    issue = next(i for i in report.issues if i.code == "semantic.property_unmapped")
+    assert "fallback" in issue.message
+    assert "OMITTED" not in issue.message
+


### PR DESCRIPTION
Closes #299.

Reproducing the steward's scenario first: the cell-spec `properties` case already warns — `semantic.property_unmapped` fires today for an uncurated key on the A123 record (added by an earlier robustness pass; the browser stays schema-layer by design and says so). What remained were two real gaps:

- **Component records were silent.** A made-up key in any component `<body>.property` (material, electrode, electrolyte, separator, current-collector, housing, equipment, channel) — or in an electrode `coating.property` — validated clean, while the JSON-LD emitters fall back to a non-canonical term. The mappability check now runs on all component bodies and coatings. The known-key set (descriptor/fraction terms that resolve without the curated map) is imported from the transform's own tables, so the validator cannot drift from what the emitters actually accept.
- **The message lied.** It claimed the property "will be OMITTED"; the transform actually emits it under a `battinfo:` fallback term that other tools will not recognize and that does not survive round-trip import. The message now states what happens.

Issue paths name the real location (`material_spec.property.x`, `electrode_spec.coating.property.y`).

Testing: three new tests (component warn with exact path, coating path, message-truth); descriptor/fraction keys verified silent; existing mappability test updated to the truthful message. Full suite green apart from the 14 known pre-existing environment failures in this worktree.