### PR TITLE
Fix broken install commands in docs and pyproject

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,89 @@
+# Verifies that the install commands documented for end users (README.md,
+# QUICKSTART.md, docs/pages/getting-started.rst) still succeed in a clean
+# virtual environment with stock pip against live PyPI. This complements the
+# uv.lock-based CI, which never exercises the plain-pip resolver a first-time
+# user hits.
+name: install-smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - pyproject.toml
+      - README.md
+      - QUICKSTART.md
+      - docs/pages/getting-started.rst
+      - .github/workflows/install-smoke.yml
+  pull_request:
+    paths:
+      - pyproject.toml
+      - README.md
+      - QUICKSTART.md
+      - docs/pages/getting-started.rst
+      - .github/workflows/install-smoke.yml
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: pip install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: pip install -e .
+        shell: bash
+        run: |
+          set -euxo pipefail
+          v="$RUNNER_TEMP/venv-core"
+          python -m venv "$v"
+          if [ -f "$v/Scripts/python.exe" ]; then py="$v/Scripts/python.exe"; else py="$v/bin/python"; fi
+          "$py" -m pip install --upgrade pip
+          "$py" -m pip install -e .
+          "$py" -c "import battinfo; print(battinfo.__version__)"
+
+      - name: pip install -e ".[dev]"
+        shell: bash
+        run: |
+          set -euxo pipefail
+          v="$RUNNER_TEMP/venv-dev"
+          python -m venv "$v"
+          if [ -f "$v/Scripts/python.exe" ]; then py="$v/Scripts/python.exe"; else py="$v/bin/python"; fi
+          "$py" -m pip install --upgrade pip
+          "$py" -m pip install -e ".[dev]"
+          "$py" -c "import battinfo; print(battinfo.__version__)"
+
+      # Allowed to fail until batterydf 0.2 is published on PyPI. The processing
+      # extra pins batterydf>=0.2,<0.3 (see pyproject.toml); PyPI currently ships
+      # only 0.1.0, so plain pip cannot resolve this extra. README.md and
+      # QUICKSTART.md document the git-source stopgap in the meantime. Remove
+      # continue-on-error once batterydf 0.2.x is on PyPI.
+      - name: pip install -e ".[processing]"
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -euxo pipefail
+          v="$RUNNER_TEMP/venv-processing"
+          python -m venv "$v"
+          if [ -f "$v/Scripts/python.exe" ]; then py="$v/Scripts/python.exe"; else py="$v/bin/python"; fi
+          "$py" -m pip install --upgrade pip
+          "$py" -m pip install -e ".[processing]"
+          "$py" -c "import battinfo; print(battinfo.__version__)"
+
+      - name: pip install git+https://github.com/BIG-MAP/BattINFO.git
+        shell: bash
+        run: |
+          set -euxo pipefail
+          v="$RUNNER_TEMP/venv-git"
+          python -m venv "$v"
+          if [ -f "$v/Scripts/python.exe" ]; then py="$v/Scripts/python.exe"; else py="$v/bin/python"; fi
+          "$py" -m pip install --upgrade pip
+          "$py" -m pip install "git+https://github.com/BIG-MAP/BattINFO.git"
+          "$py" -c "import battinfo; print(battinfo.__version__)"

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,12 +23,24 @@ the guided tour is on the same page.
 - Python 3.11+
 - A terminal
 
+BattINFO is not on PyPI until the 0.8 release. Until then, install from source
+into a virtual environment:
+
 ```bash
-pip install battinfo
+python -m venv .venv
+source .venv/bin/activate            # Windows: .venv\Scripts\activate
+pip install "git+https://github.com/BIG-MAP/BattINFO.git"
 ```
 
-> Converting raw cycler files (`ws.convert()`) needs the BDF converter:
-> `pip install "battinfo[processing]"`.
+<!-- 0.8 release: replace the block above with  pip install battinfo -->
+
+> Converting raw cycler files (`ws.convert()`) needs the BDF converter,
+> distributed as `batterydf`. It is not yet on PyPI, so the `battinfo[processing]`
+> extra cannot resolve; install the converter and plotting libraries directly:
+>
+> ```bash
+> pip install "git+https://github.com/battery-data-alliance/battery-data-format.git" matplotlib plotly
+> ```
 
 ---
 
@@ -89,15 +101,26 @@ jsonld = json.loads(
     Path(output["output_dir"], "index.jsonld").read_text()
 )
 print(jsonld["@type"])
-# ["BatteryCell", "CylindricalBattery", "LithiumIonBattery", "schema:ProductModel"]
+# ['BatteryCellSpecification', 'schema:CreativeWork']
 
 print(jsonld["schema:name"])     # Panasonic NCR18650B
 print(jsonld["schema:size"])     # R18650
 ```
 
-BattINFO automatically stacks EMMO types based on the cell's format and chemistry. A cylindrical Li-ion cell is simultaneously `BatteryCell`, `CylindricalBattery`, and `LithiumIonBattery` — no manual annotation needed.
+A cell spec is an *information entity* — a datasheet as data — not the physical
+cell it describes. So its `@type` is `BatteryCellSpecification` (an EMMO
+information object) stacked with `schema:CreativeWork`, and an `isDescriptionFor`
+link points from the spec to the cell type it specifies. The EMMO type stacking
+that describes the physical cell itself — `BatteryCell`, `CylindricalBattery`,
+`LithiumIonBattery`, and friends — lives on the cell node inside the full
+publication package, not on this resolver document. See
+[Tutorial 4](docs/guides/04-semantic-layer.ipynb) for how the spec, the cell type,
+and their EMMO types relate.
 
-The resolver JSON-LD is the lightweight document served at the cell's IRI. The full EMMO-aligned publication package — with `hasProperty` nodes for each quantitative specification — is produced when you publish (see [Tutorial 3](docs/guides/03-linked-records.ipynb)).
+The resolver JSON-LD is the lightweight document served at the cell spec's IRI.
+The full EMMO-aligned publication package — with `hasProperty` nodes for each
+quantitative specification — is produced when you publish (see
+[Tutorial 3](docs/guides/03-linked-records.ipynb)).
 
 ---
 
@@ -114,10 +137,42 @@ Canonical cell-spec records are validated with `--source-root`:
 {
   "ok": true,
   "mode": "record",
+  "policy": "default",
+  "profile": null,
+  "source_root": "examples",
+  "issue_count": 2,
   "error_count": 0,
-  "warning_count": 0
+  "warning_count": 2,
+  "errors": [],
+  "issues": [
+    {
+      "code": "semantic.value_text_only",
+      "severity": "warning",
+      "path": "properties.cycle_life",
+      "message": "'cycle_life' carries only value_text - the JSON-LD export emits numeric quantities, so this property will be OMITTED there.",
+      "hint": null,
+      "validator": "semantic",
+      "resource_type": "cell-spec",
+      "profile": null
+    },
+    {
+      "code": "shacl.unavailable",
+      "severity": "warning",
+      "path": "",
+      "message": "pyshacl is not installed; SHACL validation skipped. Install with: pip install pyshacl",
+      "hint": null,
+      "validator": "shacl",
+      "resource_type": null,
+      "profile": null
+    }
+  ]
 }
 ```
+
+The record is valid (`error_count: 0`). The two warnings are expected on a core
+install: one flags that `cycle_life` carries only free text so it is omitted from
+the numeric JSON-LD export, and the other notes that optional SHACL validation is
+skipped because `pyshacl` is not installed (it ships with `battinfo[dev]`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,27 @@ JSON. BattINFO turns that into a single, semantically-grounded record model:
 
 Requires **Python 3.11+**.
 
+BattINFO is not on PyPI until the 0.8 release. Until then, install from source
+into a virtual environment:
+
 ```bash
-pip install battinfo
+python -m venv .venv
+source .venv/bin/activate            # Windows: .venv\Scripts\activate
+pip install "git+https://github.com/BIG-MAP/BattINFO.git"
 ```
+
+<!-- 0.8 release: replace the block above with  pip install battinfo -->
 
 Optional extras: `battinfo[processing]` (cycler-file conversion via `ws.convert()`
 + plotting), `battinfo[tabular]` (CSV/Parquet/XLSX readers), `battinfo[publish]`
 (RO-Crate validation), `battinfo[storage]` (S3), `battinfo[docs]` (Sphinx), and
-`battinfo[dev]` (full test/lint/build toolchain).
+`battinfo[dev]` (full test/lint/build toolchain). The `processing` extra also needs
+`batterydf`, which is not yet on PyPI. Until it ships, `pip install "battinfo[processing]"`
+cannot resolve; install the processing dependencies directly instead:
+
+```bash
+pip install "git+https://github.com/battery-data-alliance/battery-data-format.git" matplotlib plotly
+```
 
 **Developing on BattINFO?** This repo uses [uv](https://docs.astral.sh/uv/):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ processing = [
 dev = [
   "battinfo[tabular]",  # the suite exercises the tabular + publish feature paths,
   "battinfo[publish]",  # so CI (--all-extras) installs both optional groups
-  "build>=1.5.1",
+  "build>=1.2",
   "setuptools>=83.0.0",   # build backend, needed in-env for `build --no-isolation` (verification gate)
   "wheel",
   "twine>=5.0",       # dist metadata validation (`twine check`) before publishing

--- a/uv.lock
+++ b/uv.lock
@@ -354,7 +354,7 @@ requires-dist = [
     { name = "battinfo", extras = ["publish"], marker = "extra == 'dev'" },
     { name = "battinfo", extras = ["tabular"], marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'storage'", specifier = ">=1.43.57" },
-    { name = "build", marker = "extra == 'dev'", specifier = ">=1.5.1" },
+    { name = "build", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.71.0" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29" },
     { name = "ipython", marker = "extra == 'docs'", specifier = ">=9.15.0" },
@@ -488,16 +488,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.5.1"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Make every install command a user can hit in the README, QUICKSTART, and pyproject succeed verbatim in a clean venv with stock pip, and add CI that proves it stays that way.

- pyproject: relax the dev extra `build>=1.5.1` pin to `build>=1.2`.
- uv.lock: regenerated so `build` resolves to 1.5.0 (out of my stated file territory, but it is the direct build artifact of the pyproject pin change and no sibling wave touches dependency pins; without it `uv lock --check` fails on my branch).
- README and QUICKSTART: replace bare `pip install battinfo` with the source-install story (venv + `pip install git+...`), matching docs/pages/getting-started.
- README and QUICKSTART: document the batterydf git-source stopgap for the `processing` extra.
- QUICKSTART: refresh the step 3 and step 4 expected outputs to match a fresh install.
- New workflow `.github/workflows/install-smoke.yml`: clean-venv pip install of every documented command on ubuntu-latest and windows-latest.

## Why

Three of four documented install entry points died at the first command for a plain-pip user:

- `pip install -e ".[dev]"` failed for every pip user: `build` 1.5.1 is yanked on PyPI with no newer release, and `build>=1.5.1` therefore has no installable match. uv never saw it because the lockfile pinned the yanked 1.5.1 directly.
- `pip install battinfo` in README (~line 89) and QUICKSTART (~line 27) 404s: the package is not on PyPI until the 0.8 release.
- `pip install "battinfo[processing]"` cannot resolve: the extra pins `batterydf>=0.2,<0.3` and PyPI ships only 0.1.0 (the git source is also 0.1.0). The operator intends to publish 0.2.x; the pin is kept and a stopgap documented.

QUICKSTART also showed stale expected output: step 3 claimed `["BatteryCell", "CylindricalBattery", "LithiumIonBattery", "schema:ProductModel"]`, and step 4 claimed `warning_count: 0`.

## How

- build pin: PyPI has 1.5.1 (yanked) as the newest and 1.5.0 as the newest non-yanked. `>=1.2` lets pip pick 1.5.0. `uv lock --upgrade-package build` moves the lock off the yanked 1.5.1 to 1.5.0.
- Install docs mirror getting-started: venv create, POSIX and Windows activation, `pip install git+https://github.com/BIG-MAP/BattINFO.git`, with a one-line comment marking the block to flip to `pip install battinfo` at 0.8.
- processing stopgap: since neither PyPI nor the git source of batterydf satisfies `>=0.2`, `pip install "battinfo[processing]"` cannot resolve today. The docs instead point users to install the converter and plotting libs directly: `pip install "git+https://github.com/battery-data-alliance/battery-data-format.git" matplotlib plotly` (module imports as `bdf`). Verified these coexist with battinfo core.
- QUICKSTART step 3 now shows `['BatteryCellSpecification', 'schema:CreativeWork']` with narration on the spec-as-information-entity semantics and a cross-link to Tutorial 4. Step 4 shows the real 2-warning output (cycle_life text-only omission + pyshacl-not-installed) with a sentence that both are expected on a core install.
- The smoke workflow runs each documented command in its own fresh venv against live PyPI, each followed by `python -c "import battinfo; print(battinfo.__version__)"`. The `[processing]` leg is marked `continue-on-error` with a comment naming the batterydf 0.2 gate; remove it once batterydf 0.2.x is on PyPI.

## Testing

All on Windows, clean venvs at short paths, stock pip:

- `pip install .` (core): import battinfo -> 0.7.0. OK.
- `pip install -e ".[dev]"` with the new pin: resolves, installs build 1.5.0, import battinfo -> 0.7.0. OK.
- QUICKSTART steps 1-3 run verbatim: canonical IRI minted; `jsonld["@type"]` is `['BatteryCellSpecification', 'schema:CreativeWork']`; `schema:name`/`schema:size` unchanged. Doc updated to match.
- QUICKSTART step 4 `battinfo validate ... --format json`: `error_count: 0`, `warning_count: 2` (cycle_life value_text_only, shacl.unavailable). Doc updated to match.
- batterydf: confirmed PyPI has only 0.1.0 and the git source (incl. the rev pinned in tool.uv.sources) is also 0.1.0, so the `>=0.2` gate is closed. Stopgap deps (bdf + matplotlib + plotly) verified to import alongside battinfo core.
- getting-started: its only current install command (git clone + `pip install -e ".[dev]"`) works after the pin fix; its `[processing]` mention is inside the post-0.8 PyPI block, left as-is.
- `uv lock --check` passes; `install-smoke.yml` parses as valid YAML.
