### PR TITLE
Fix web machine entry point, exemplar, emitter drift, and jargon links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
         run: npm run check:agreement
       - name: JSON-LD workbench core checks
         run: npm run check:workbench
+      - name: Create-page emitter terms match the records context
+        run: npm run check:create-model
       - name: Build
         run: npm run build
 

--- a/scripts/gen_web_examples.py
+++ b/scripts/gen_web_examples.py
@@ -95,19 +95,19 @@ def snippet_cell_spec():
     from battinfo import CellSpec
 
     spec = CellSpec(
-        # In the workspace flow the IRI is minted for you at ws.save();
-        # standalone, you set it (or let publish() mint it).
-        id="https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-        manufacturer="Samsung SDI",
-        model="INR21700-50E",
+        # The published flagship IRI: dereference it (Accept: application/ld+json)
+        # to get this exact record. In the workspace flow the IRI is minted for
+        # you at ws.save(); standalone, you set it (or let publish() mint it).
+        id="https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+        manufacturer="A123",
+        model="ANR26650M1-B",
         format="cylindrical",
         chemistry="Li-ion",
-        positive_electrode_basis="NMC",
-        negative_electrode_basis="graphite",
+        positive_electrode_basis="LFP",
         properties={
-            "nominal_capacity": {"value": 5.0, "unit": "Ah"},
-            "nominal_voltage": {"value": 3.6, "unit": "V"},
-            "mass": {"value": 68.0, "unit": "g"},
+            "nominal_capacity": {"value": 2.5, "unit": "Ah"},
+            "nominal_voltage": {"value": 3.3, "unit": "V"},
+            "mass": {"value": 76.0, "unit": "g"},
         },
         source={"type": "datasheet", "retrieved_at": 1750000000},
     )
@@ -330,11 +330,18 @@ TIME_KEYS = {
 }
 FIXED_TIME = 1750000000
 
+# Real, published IRIs to preserve verbatim through normalization: these
+# dereference today, so an example that shows one must keep it (the cell-spec
+# showcase is the flagship, not a placeholder).
+KEEP_UIDS = {"pge5-wer6-2q82-v9k0"}
+
 
 def normalize(record: dict) -> dict:
     text = json.dumps(record, ensure_ascii=False)
     seen: dict[str, str] = {}
     for uid in UID_RE.findall(text):
+        if uid in KEEP_UIDS:
+            continue
         if uid not in seen:
             if len(seen) >= len(PLACEHOLDER_UIDS):
                 raise RuntimeError("placeholder uid pool exhausted")

--- a/web/app/about/page.tsx
+++ b/web/app/about/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { site } from "@/lib/site";
 
@@ -8,7 +9,22 @@ export const metadata: Metadata = {
     "Where BattINFO comes from, what it is for, and the ecosystem it belongs to, the EMMO battery ontology, the Battery Genome, and open battery-data infrastructure.",
 };
 
-const ecosystem = [
+// Glossary link on a term's first on-page use, matching the landing page.
+const glossaryHref = `${site.reference}/pages/glossary.html`;
+function G({ children }: { children: ReactNode }) {
+  return (
+    <a
+      href={glossaryHref}
+      target="_blank"
+      rel="noreferrer"
+      className="text-brandtext underline hover:text-brandtext"
+    >
+      {children}
+    </a>
+  );
+}
+
+const ecosystem: { name: string; href: string; role: ReactNode }[] = [
   {
     name: "EMMO domain-battery",
     href: site.emmo,
@@ -32,9 +48,14 @@ const ecosystem = [
   {
     name: "Battery Data Alliance",
     href: "https://pypi.org/project/batterydf/",
-    role: "Home of the Battery Data Format (BDF), the tidy tabular layer BattINFO converts raw cycler files into.",
+    role: (
+      <>
+        Home of the Battery Data Format (<G>BDF</G>), the tidy tabular layer
+        BattINFO converts raw cycler files into.
+      </>
+    ),
   },
-] as const;
+];
 
 export default function AboutPage() {
   return (
@@ -53,9 +74,9 @@ export default function AboutPage() {
           tool or team can pick it up without asking.
         </p>
         <p>
-          We did not invent our own world. We build on open standards (EMMO,
-          JSON-LD, JSON Schema, schema.org, DCAT, PROV) and make them usable by
-          someone with a datasheet and an afternoon.
+          We did not invent our own world. We build on open standards (<G>EMMO</G>,
+          JSON-LD, JSON Schema, schema.org, <G>DCAT</G>, <G>PROV</G>) and make
+          them usable by someone with a datasheet and an afternoon.
         </p>
         <p>
           <Link href="/federation" className="font-semibold text-brandtext hover:text-brandtext">

--- a/web/app/publish/page.tsx
+++ b/web/app/publish/page.tsx
@@ -48,7 +48,16 @@ export default function PublishPage() {
           </p>
           <div className="mt-6 rounded-lg border border-border bg-surface px-4 py-3">
             <p className="font-mono text-sm text-brandtext">
-              raw files → BDF tables → {provenanceChain} → JSON-LD → DOI + registry
+              raw files →{" "}
+              <a
+                href={`${site.reference}/pages/glossary.html`}
+                target="_blank"
+                rel="noreferrer"
+                className="underline hover:text-brandtext"
+              >
+                BDF
+              </a>{" "}
+              tables → {provenanceChain} → JSON-LD → DOI + registry
             </p>
           </div>
           <div className="mt-6">

--- a/web/lib/create-model.ts
+++ b/web/lib/create-model.ts
@@ -17,6 +17,13 @@
 import { RECORDS_CONTEXT_URL } from "./records-context.generated";
 import { validateRecord, type Issue } from "./validate";
 
+// The canonical schema_version every emitted record is stamped with. Single
+// source so the playground never teaches a version the package has moved past;
+// scripts/check-create-model-terms.ts pins it to the synced example corpus
+// (lib/examples.generated.ts, in turn synced from examples/** = the package
+// SSoT), so a corpus re-stamp fails CI until this is bumped too.
+export const SCHEMA_VERSION = "0.2.0";
+
 export interface DraftProperty {
   key: string;
   value: string;
@@ -117,15 +124,19 @@ function withContext(body: Record<string, unknown>): Record<string, unknown> {
 }
 
 // --- vocab maps --------------------------------------------------------------
-const FORMAT_CLASS: Record<string, string> = {
+// These class maps and the property `term`s below are all @type tokens the
+// emitter puts into JSON-LD; every one must resolve in the hosted records
+// context. scripts/check-create-model-terms.ts audits them against the
+// vendored context so this table cannot drift from the package silently.
+export const FORMAT_CLASS: Record<string, string> = {
   coin: "CoinCell", cylindrical: "CylindricalBattery", pouch: "PouchCell", prismatic: "PrismaticBattery",
 };
-const CHEMISTRY_CLASS: Record<string, string> = {
+export const CHEMISTRY_CLASS: Record<string, string> = {
   "Li-ion": "LithiumIonBattery", "Li-metal": "LithiumMetalBattery", "Na-ion": "SodiumIonBattery", Alkaline: "AlkalineCell",
 };
 // Basis label -> EMMO electrode class, mirroring the battinfo transform's
 // entity_type_map (keys matched case-insensitively, separators normalized).
-const BASIS_ELECTRODE: Record<string, string> = {
+export const BASIS_ELECTRODE: Record<string, string> = {
   lfp: "LithiumIronPhosphateElectrode",
   nmc: "LithiumNickelManganeseCobaltOxideElectrode",
   nmc811: "LithiumNickelManganeseCobaltOxideElectrode",
@@ -141,7 +152,7 @@ const BASIS_ELECTRODE: Record<string, string> = {
   "li-metal": "LithiumElectrode",
   lto: "LithiumTitanateElectrode",
 };
-const SUBSTANCE: Record<string, string> = {
+export const SUBSTANCE: Record<string, string> = {
   LFP: "LithiumIronPhosphate",
   NMC: "LithiumNickelManganeseCobaltOxide",
   graphite: "Graphite",
@@ -149,7 +160,7 @@ const SUBSTANCE: Record<string, string> = {
   LiPF6: "LithiumHexafluorophosphate",
   EC: "EthyleneCarbonate",
 };
-const MATERIAL_ROLE: Record<string, string> = {
+export const MATERIAL_ROLE: Record<string, string> = {
   active_material: "ActiveMaterial", binder: "Binder", conductive_additive: "ConductiveAdditive",
 };
 
@@ -229,9 +240,11 @@ const CELL_SPEC_PROPS: PropDef[] = [
   { key: "discharging_cutoff_voltage", label: "Discharge cutoff (lower)", units: ["V", "mV"], section: "spec" },
   { key: "specific_energy", label: "Specific energy", units: ["Wh/kg"], section: "spec" },
   { key: "energy_density", label: "Energy density", units: ["Wh/L"], section: "spec" },
-  // Current ratings
-  { key: "continuous_charging_current", label: "Max continuous charge current", units: ["A", "mA"], section: "spec", term: "MaximumContinuousChargingCurrent" },
-  { key: "continuous_discharging_current", label: "Max continuous discharge current", units: ["A", "mA"], section: "spec", term: "MaximumContinuousDischargingCurrent" },
+  // Current ratings. The canonical key and the JSON-LD term must denote the
+  // same EMMO concept: maximum_continuous_charging_current <-> the PascalCase
+  // MaximumContinuousChargingCurrent class, both defined in the records context.
+  { key: "maximum_continuous_charging_current", label: "Max continuous charge current", units: ["A", "mA"], section: "spec", term: "MaximumContinuousChargingCurrent" },
+  { key: "maximum_continuous_discharging_current", label: "Max continuous discharge current", units: ["A", "mA"], section: "spec", term: "MaximumContinuousDischargingCurrent" },
   // Life, resistance, mass
   { key: "cycle_life", label: "Cycle life", units: ["cycles"], section: "spec" },
   { key: "internal_resistance", label: "Internal resistance", units: ["mΩ", "Ω"], section: "spec" },
@@ -353,7 +366,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.chemistry) spec.chemistry = v.chemistry;
       if (v.positiveBasis) spec.positive_electrode_basis = v.positiveBasis;
       if (v.negativeBasis) spec.negative_electrode_basis = v.negativeBasis;
-      const specRecord: Record<string, unknown> = { schema_version: "0.1.0", cell_spec: spec };
+      const specRecord: Record<string, unknown> = { schema_version: SCHEMA_VERSION, cell_spec: spec };
       const sp = propBlock(inSection(props, "spec"));
       if (Object.keys(sp).length) specRecord.properties = sp;
 
@@ -362,7 +375,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.serial_number) instance.serial_number = v.serial_number;
       if (v.manufactured_at) instance.manufactured_at = v.manufactured_at;
       if (v.expires_at) instance.expires_at = v.expires_at;
-      const instanceRecord: Record<string, unknown> = { schema_version: "0.1.0", cell_instance: instance };
+      const instanceRecord: Record<string, unknown> = { schema_version: SCHEMA_VERSION, cell_instance: instance };
       const mp = propBlock(inSection(props, "instance"));
       if (Object.keys(mp).length) instanceRecord.measured = mp;
       return [specRecord, instanceRecord];
@@ -453,7 +466,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.chemistry_family) spec.chemistry_family = v.chemistry_family;
       const sp = propBlock(inSection(props, "spec"));
       if (Object.keys(sp).length) spec.property = sp;
-      const specRecord = { schema_version: "0.1.0", material_spec: spec };
+      const specRecord = { schema_version: SCHEMA_VERSION, material_spec: spec };
 
       const instance: Record<string, unknown> = {};
       if (v.instanceName) instance.name = v.instanceName;
@@ -462,7 +475,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.received_date) instance.received_date = v.received_date;
       const mp = propBlock(inSection(props, "instance"));
       if (Object.keys(mp).length) instance.property = mp;
-      const instanceRecord = { schema_version: "0.1.0", material: instance };
+      const instanceRecord = { schema_version: SCHEMA_VERSION, material: instance };
       return [specRecord, instanceRecord];
     },
     toPython: (v, props) => {
@@ -477,7 +490,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.received_date) instance.received_date = v.received_date;
       const mp = propBlock(inSection(props, "instance"));
       if (Object.keys(mp).length) instance.property = mp;
-      lines.push(...pyInstanceRecord("material_lot", { schema_version: "0.1.0", material: instance }));
+      lines.push(...pyInstanceRecord("material_lot", { schema_version: SCHEMA_VERSION, material: instance }));
       return lines.join("\n");
     },
     toJsonLd: (v, props) => {
@@ -541,7 +554,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.name) spec.name = v.name;
       if (v.polarity) spec.polarity = v.polarity;
       if (v.collector) spec.current_collector = { name: v.collector };
-      const specRecord = { schema_version: "0.1.0", electrode_spec: spec };
+      const specRecord = { schema_version: SCHEMA_VERSION, electrode_spec: spec };
 
       const instance: Record<string, unknown> = {};
       if (v.instanceName) instance.name = v.instanceName;
@@ -550,7 +563,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.manufactured_at) instance.manufactured_at = v.manufactured_at;
       const mp = propBlock(inSection(props, "instance"));
       if (Object.keys(mp).length) instance.property = mp;
-      const instanceRecord = { schema_version: "0.1.0", electrode: instance };
+      const instanceRecord = { schema_version: SCHEMA_VERSION, electrode: instance };
       return [specRecord, instanceRecord];
     },
     toPython: (v, props) => {
@@ -570,7 +583,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.manufactured_at) instance.manufactured_at = v.manufactured_at;
       const mp = propBlock(inSection(props, "instance"));
       if (Object.keys(mp).length) instance.property = mp;
-      lines.push(...pyInstanceRecord("electrode_unit", { schema_version: "0.1.0", electrode: instance }));
+      lines.push(...pyInstanceRecord("electrode_unit", { schema_version: SCHEMA_VERSION, electrode: instance }));
       return lines.join("\n");
     },
     toJsonLd: (v, props) => {
@@ -631,7 +644,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (solvents.length) spec.solvent_mixture = { component: solvents.map((name) => ({ name })) };
       const sp = propBlock(inSection(props, "spec"));
       if (Object.keys(sp).length) spec.property = sp;
-      const specRecord = { schema_version: "0.1.0", electrolyte_spec: spec };
+      const specRecord = { schema_version: SCHEMA_VERSION, electrolyte_spec: spec };
 
       const instance: Record<string, unknown> = {};
       if (v.instanceName) instance.name = v.instanceName;
@@ -640,7 +653,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.manufactured_at) instance.manufactured_at = v.manufactured_at;
       const mp = propBlock(inSection(props, "instance"));
       if (Object.keys(mp).length) instance.property = mp;
-      const instanceRecord = { schema_version: "0.1.0", electrolyte: instance };
+      const instanceRecord = { schema_version: SCHEMA_VERSION, electrolyte: instance };
       return [specRecord, instanceRecord];
     },
     toPython: (v, props) => {
@@ -661,7 +674,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.manufactured_at) instance.manufactured_at = v.manufactured_at;
       const mp = propBlock(inSection(props, "instance"));
       if (Object.keys(mp).length) instance.property = mp;
-      lines.push(...pyInstanceRecord("electrolyte_batch", { schema_version: "0.1.0", electrolyte: instance }));
+      lines.push(...pyInstanceRecord("electrolyte_batch", { schema_version: SCHEMA_VERSION, electrolyte: instance }));
       return lines.join("\n");
     },
     toJsonLd: (v, props) => {
@@ -726,7 +739,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.name) spec.name = v.name;
       if (v.kind) spec.kind = v.kind;
       if (v.version) spec.version = v.version;
-      const specRecord: Record<string, unknown> = { schema_version: "0.1.0", test_spec: spec };
+      const specRecord: Record<string, unknown> = { schema_version: SCHEMA_VERSION, test_spec: spec };
       const sc = propBlock(inSection(props, "spec"));
       if (Object.keys(sc).length) specRecord.conditions = sc;
 
@@ -737,7 +750,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.status) run.status = v.status;
       const mc = propBlock(inSection(props, "instance"));
       if (Object.keys(mc).length) run.conditions = mc;
-      const runRecord = { schema_version: "0.1.0", test: run };
+      const runRecord = { schema_version: SCHEMA_VERSION, test: run };
       return [specRecord, runRecord];
     },
     toPython: (v, props) => {
@@ -745,7 +758,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.name) spec.name = v.name;
       if (v.kind) spec.kind = v.kind;
       if (v.version) spec.version = v.version;
-      const protocol: Record<string, unknown> = { schema_version: "0.1.0", test_spec: spec };
+      const protocol: Record<string, unknown> = { schema_version: SCHEMA_VERSION, test_spec: spec };
       const sc = propBlock(inSection(props, "spec"));
       if (Object.keys(sc).length) protocol.conditions = sc;
       const lines = [
@@ -792,7 +805,7 @@ export const OBJECT_TYPES: ObjectDef[] = [
       if (v.name) body.name = v.name;
       if (v.access_url) body.access_url = v.access_url;
       if (v.description) body.description = v.description;
-      return { schema_version: "0.1.0", dataset: body };
+      return { schema_version: SCHEMA_VERSION, dataset: body };
     },
     toPython: (v) => [
       "from battinfo import Dataset",

--- a/web/lib/examples.ts
+++ b/web/lib/examples.ts
@@ -54,4 +54,7 @@ print(result.canonical_iri)
 
 export const installSnippet = `python -m venv .venv
 # until the 0.8 release lands on PyPI, install from source:
-.venv/bin/pip install git+https://github.com/BIG-MAP/BattINFO.git`;
+# macOS / Linux:
+.venv/bin/pip install git+https://github.com/BIG-MAP/BattINFO.git
+# Windows (PowerShell / cmd):
+.venv\\Scripts\\pip install git+https://github.com/BIG-MAP/BattINFO.git`;

--- a/web/lib/showcase.generated.ts
+++ b/web/lib/showcase.generated.ts
@@ -180,35 +180,34 @@ export const showcase: {
     "title": "A cell spec",
     "tagline": "The product datasheet, as data: identity, format, chemistry, and rated properties with units that resolve to EMMO.",
     "recordType": "cell-spec",
-    "code": "from battinfo import CellSpec\n\nspec = CellSpec(\n    # In the workspace flow the IRI is minted for you at ws.save();\n    # standalone, you set it (or let publish() mint it).\n    id=\"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\",\n    manufacturer=\"Samsung SDI\",\n    model=\"INR21700-50E\",\n    format=\"cylindrical\",\n    chemistry=\"Li-ion\",\n    positive_electrode_basis=\"NMC\",\n    negative_electrode_basis=\"graphite\",\n    properties={\n        \"nominal_capacity\": {\"value\": 5.0, \"unit\": \"Ah\"},\n        \"nominal_voltage\": {\"value\": 3.6, \"unit\": \"V\"},\n        \"mass\": {\"value\": 68.0, \"unit\": \"g\"},\n    },\n    source={\"type\": \"datasheet\", \"retrieved_at\": 1750000000},\n)\nrecord = spec.to_record()",
+    "code": "from battinfo import CellSpec\n\nspec = CellSpec(\n    # The published flagship IRI: dereference it (Accept: application/ld+json)\n    # to get this exact record. In the workspace flow the IRI is minted for\n    # you at ws.save(); standalone, you set it (or let publish() mint it).\n    id=\"https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0\",\n    manufacturer=\"A123\",\n    model=\"ANR26650M1-B\",\n    format=\"cylindrical\",\n    chemistry=\"Li-ion\",\n    positive_electrode_basis=\"LFP\",\n    properties={\n        \"nominal_capacity\": {\"value\": 2.5, \"unit\": \"Ah\"},\n        \"nominal_voltage\": {\"value\": 3.3, \"unit\": \"V\"},\n        \"mass\": {\"value\": 76.0, \"unit\": \"g\"},\n    },\n    source={\"type\": \"datasheet\", \"retrieved_at\": 1750000000},\n)\nrecord = spec.to_record()",
     "record": {
       "schema_version": "0.2.0",
       "cell_spec": {
-        "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-        "short_id": "7d9k2m",
-        "identifier": "cell-spec:7d9k-2m4p-8t3x-6nq5",
-        "name": "Samsung SDI INR21700-50E",
-        "model": "INR21700-50E",
+        "id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+        "short_id": "pge5we",
+        "identifier": "cell-spec:pge5-wer6-2q82-v9k0",
+        "name": "A123 ANR26650M1-B",
+        "model": "ANR26650M1-B",
         "manufacturer": {
           "type": "Organization",
-          "name": "Samsung SDI"
+          "name": "A123"
         },
         "cell_format": "cylindrical",
         "chemistry": "Li-ion",
-        "positive_electrode_basis": "NMC",
-        "negative_electrode_basis": "graphite"
+        "positive_electrode_basis": "LFP"
       },
       "properties": {
         "nominal_capacity": {
-          "value": 5.0,
+          "value": 2.5,
           "unit": "Ah"
         },
         "nominal_voltage": {
-          "value": 3.6,
+          "value": 3.3,
           "unit": "V"
         },
         "mass": {
-          "value": 68.0,
+          "value": 76.0,
           "unit": "g"
         }
       },
@@ -224,24 +223,23 @@ export const showcase: {
         "BatteryCellSpecification",
         "schema:CreativeWork"
       ],
-      "@id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-      "schema:identifier": "7d9k-2m4p-8t3x-6nq5",
-      "schema:name": "Samsung SDI INR21700-50E",
-      "schema:model": "INR21700-50E",
+      "@id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+      "schema:identifier": "pge5-wer6-2q82-v9k0",
+      "schema:name": "A123 ANR26650M1-B",
+      "schema:model": "ANR26650M1-B",
       "schema:manufacturer": {
         "@type": "schema:Organization",
-        "schema:name": "Samsung SDI"
+        "schema:name": "A123"
       },
-      "schema:url": "https://www.battery-genome.org/registry/spec/7d9k-2m4p-8t3x-6nq5",
+      "schema:url": "https://www.battery-genome.org/registry/spec/pge5-wer6-2q82-v9k0",
       "isDescriptionFor": {
         "@type": [
           "BatteryCell",
           "CylindricalBattery",
           "LithiumIonBattery",
-          "LithiumIonNickelManganeseCobaltOxideBattery",
-          "LithiumIonGraphiteBattery"
+          "LithiumIonIronPhosphateBattery"
         ],
-        "skos:prefLabel": "Samsung SDI INR21700-50E"
+        "skos:prefLabel": "A123 ANR26650M1-B"
       },
       "schema:schemaVersion": "0.2.0",
       "hasProperty": [
@@ -253,7 +251,7 @@ export const showcase: {
           "skos:prefLabel": "NominalCapacity",
           "hasNumericalPart": {
             "@type": "RealData",
-            "hasNumberValue": 5.0
+            "hasNumberValue": 2.5
           },
           "hasMeasurementUnit": "https://w3id.org/emmo#AmpereHour"
         },
@@ -265,7 +263,7 @@ export const showcase: {
           "skos:prefLabel": "NominalVoltage",
           "hasNumericalPart": {
             "@type": "RealData",
-            "hasNumberValue": 3.6
+            "hasNumberValue": 3.3
           },
           "hasMeasurementUnit": "https://w3id.org/emmo#Volt"
         },
@@ -277,16 +275,13 @@ export const showcase: {
           "skos:prefLabel": "Mass",
           "hasNumericalPart": {
             "@type": "RealData",
-            "hasNumberValue": 68.0
+            "hasNumberValue": 76.0
           },
           "hasMeasurementUnit": "https://w3id.org/emmo#Gram"
         }
       ],
       "hasPositiveElectrode": {
-        "@type": "LithiumNickelManganeseCobaltOxideElectrode"
-      },
-      "hasNegativeElectrode": {
-        "@type": "GraphiteElectrode"
+        "@type": "LithiumIronPhosphateElectrode"
       },
       "dcterms:source": {
         "@type": "prov:Entity",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
     "sync:schemas": "node scripts/sync-schemas.mjs",
     "sync:context": "node scripts/sync-context.mjs",
     "check:agreement": "tsx scripts/check-agreement.ts",
-    "check:workbench": "tsx scripts/check-jsonld-workbench.ts"
+    "check:workbench": "tsx scripts/check-jsonld-workbench.ts",
+    "check:create-model": "tsx scripts/check-create-model-terms.ts"
   },
   "dependencies": {
     "@vercel/analytics": "^1.3.1",

--- a/web/public/jsonld/showcase-cell-spec.jsonld
+++ b/web/public/jsonld/showcase-cell-spec.jsonld
@@ -4,24 +4,23 @@
     "BatteryCellSpecification",
     "schema:CreativeWork"
   ],
-  "@id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
-  "schema:identifier": "7d9k-2m4p-8t3x-6nq5",
-  "schema:name": "Samsung SDI INR21700-50E",
-  "schema:model": "INR21700-50E",
+  "@id": "https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0",
+  "schema:identifier": "pge5-wer6-2q82-v9k0",
+  "schema:name": "A123 ANR26650M1-B",
+  "schema:model": "ANR26650M1-B",
   "schema:manufacturer": {
     "@type": "schema:Organization",
-    "schema:name": "Samsung SDI"
+    "schema:name": "A123"
   },
-  "schema:url": "https://www.battery-genome.org/registry/spec/7d9k-2m4p-8t3x-6nq5",
+  "schema:url": "https://www.battery-genome.org/registry/spec/pge5-wer6-2q82-v9k0",
   "isDescriptionFor": {
     "@type": [
       "BatteryCell",
       "CylindricalBattery",
       "LithiumIonBattery",
-      "LithiumIonNickelManganeseCobaltOxideBattery",
-      "LithiumIonGraphiteBattery"
+      "LithiumIonIronPhosphateBattery"
     ],
-    "skos:prefLabel": "Samsung SDI INR21700-50E"
+    "skos:prefLabel": "A123 ANR26650M1-B"
   },
   "schema:schemaVersion": "0.2.0",
   "hasProperty": [
@@ -33,7 +32,7 @@
       "skos:prefLabel": "NominalCapacity",
       "hasNumericalPart": {
         "@type": "RealData",
-        "hasNumberValue": 5.0
+        "hasNumberValue": 2.5
       },
       "hasMeasurementUnit": "https://w3id.org/emmo#AmpereHour"
     },
@@ -45,7 +44,7 @@
       "skos:prefLabel": "NominalVoltage",
       "hasNumericalPart": {
         "@type": "RealData",
-        "hasNumberValue": 3.6
+        "hasNumberValue": 3.3
       },
       "hasMeasurementUnit": "https://w3id.org/emmo#Volt"
     },
@@ -57,16 +56,13 @@
       "skos:prefLabel": "Mass",
       "hasNumericalPart": {
         "@type": "RealData",
-        "hasNumberValue": 68.0
+        "hasNumberValue": 76.0
       },
       "hasMeasurementUnit": "https://w3id.org/emmo#Gram"
     }
   ],
   "hasPositiveElectrode": {
-    "@type": "LithiumNickelManganeseCobaltOxideElectrode"
-  },
-  "hasNegativeElectrode": {
-    "@type": "GraphiteElectrode"
+    "@type": "LithiumIronPhosphateElectrode"
   },
   "dcterms:source": {
     "@type": "prov:Entity",

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -21,13 +21,16 @@ a browser gets HTML.
 ## Examples
 - Worked records (Python / canonical JSON / JSON-LD): https://battinfo.org/examples
 - Raw JSON-LD artifacts: https://battinfo.org/jsonld/showcase-{slug}.jsonld (Content-Type: application/ld+json)
+- Live record to bootstrap from (a persistent IRI you can dereference today): https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0
 
 ## Authoring and consumption
 - The Python package is the SDK: https://github.com/BIG-MAP/BattINFO
 - CLI verdicts match the browser and the registry gate (same schemas, drift-checked in CI): `battinfo validate --format json`
-- Registry submission + listing API exposes an OpenAPI document at the service's `/openapi.json`.
+- Registry submission + listing API, base URL https://battinfo-registry.onrender.com, exposes an OpenAPI document at the service's `/openapi.json` (https://battinfo-registry.onrender.com/openapi.json).
 
 ## Notes for autonomous agents
 - Type a record by its top-level discriminator key + `schema_version`; accept `0.1.0`, `1.0.0`, and `0.2.0`.
-- Quantities are typed, never strings: `{"@type": [...], "hasNumericalPart": {"hasNumberValue": N}, "hasMeasurementUnit": "<EMMO unit IRI>"}`.
+- Two record dialects exist, and each carries a different `@context` — do not apply one context to the other:
+  - Canonical dialect: what a `spec/*` IRI serves under `Accept: application/ld+json`. Quantities are plain `{"value": N, "unit": "<symbol>"}` (e.g. `{"unit": "mm", "value": 26.0}`) and the document ships its OWN inline `@context` (`@vocab https://w3id.org/battinfo/ns#`). Use that served context. The records context below maps NONE of the canonical `value`/`unit` keys, so applying it to a canonical record yields an empty graph.
+  - EMMO emission dialect: what `record_to_jsonld` and the showcase `/jsonld/*` artifacts emit, and what the records context (context/records/v1.json) is for. Quantities are typed nodes, never strings: `{"@type": [...], "hasNumericalPart": {"hasNumberValue": N}, "hasMeasurementUnit": "<EMMO unit IRI>"}`.
 - During the soft launch, some record IRIs resolve to an auth-gated HTML landing page for browsers; machine content negotiation (`application/ld+json`, `text/turtle`) is unauthenticated.

--- a/web/scripts/check-create-model-terms.ts
+++ b/web/scripts/check-create-model-terms.ts
@@ -1,0 +1,84 @@
+// Emitter term-drift guard (CI): every JSON-LD @type token the Create-page
+// emitter (lib/create-model.ts) can produce must resolve in the hosted records
+// context. The context is the same document the package ships
+// (src/battinfo/data/context/records.context.v1.json), vendored into
+// lib/records-context.generated.ts. Without this check the hand-rolled web
+// emitter can silently name a term the context does not define — e.g. emitting
+// a property under a class that denotes a different canonical key — and produce
+// JSON-LD that expands to the wrong IRI or none at all.
+//
+//   Run: npm run check:create-model   (tsx; repo-side only, never bundled)
+
+import {
+  OBJECT_TYPES,
+  SCHEMA_VERSION,
+  FORMAT_CLASS,
+  CHEMISTRY_CLASS,
+  BASIS_ELECTRODE,
+  SUBSTANCE,
+  MATERIAL_ROLE,
+} from "../lib/create-model";
+import { recordsContext } from "../lib/records-context.generated";
+import { cellSpecCanonical } from "../lib/examples.generated";
+
+const context = (recordsContext as { "@context": Record<string, unknown> })["@context"];
+const defined = new Set(Object.keys(context));
+
+// A token is either a bare context term (e.g. "nominal_capacity",
+// "MaximumContinuousChargingCurrent") or a CURIE (e.g. "schema:CreativeWork",
+// "battinfo:DischargeCapacity"). A CURIE resolves iff its prefix is defined.
+function resolves(token: string): boolean {
+  if (token.includes(":")) return defined.has(token.split(":", 1)[0]);
+  return defined.has(token);
+}
+
+// Collect every @type token the emitter's configurable tables can emit: the
+// property term map (term ?? key for each PropDef) and the class maps.
+const tokens: { where: string; token: string }[] = [];
+
+for (const obj of OBJECT_TYPES) {
+  for (const prop of obj.properties ?? []) {
+    tokens.push({ where: `${obj.key}.properties[${prop.key}]`, token: prop.term ?? prop.key });
+  }
+}
+const classMaps: [string, Record<string, string>][] = [
+  ["FORMAT_CLASS", FORMAT_CLASS],
+  ["CHEMISTRY_CLASS", CHEMISTRY_CLASS],
+  ["BASIS_ELECTRODE", BASIS_ELECTRODE],
+  ["SUBSTANCE", SUBSTANCE],
+  ["MATERIAL_ROLE", MATERIAL_ROLE],
+];
+for (const [name, map] of classMaps) {
+  for (const [key, value] of Object.entries(map)) {
+    tokens.push({ where: `${name}[${key}]`, token: value });
+  }
+}
+
+const failures = tokens
+  .filter((t) => !resolves(t.token))
+  .map((t) => `${t.where} -> "${t.token}" is not a term in records.context.v1.json`);
+
+// schema_version: the emitter's single stamp must equal the synced example
+// corpus (examples.generated.ts, synced from examples/** = the package SSoT),
+// and every record the builders emit must carry that stamp — no stray literal.
+const corpusVersion = (cellSpecCanonical as { schema_version: string }).schema_version;
+if (SCHEMA_VERSION !== corpusVersion) {
+  failures.push(`SCHEMA_VERSION "${SCHEMA_VERSION}" != example corpus schema_version "${corpusVersion}" (cellSpecCanonical)`);
+}
+for (const obj of OBJECT_TYPES) {
+  const emitted = obj.toRecord(obj.defaults, obj.defaultProperties ?? []);
+  const records = Array.isArray(emitted) ? emitted : [emitted];
+  for (const record of records) {
+    const stamped = (record as { schema_version?: unknown }).schema_version;
+    if (stamped !== undefined && stamped !== SCHEMA_VERSION) {
+      failures.push(`${obj.key}.toRecord emits schema_version ${JSON.stringify(stamped)}, expected "${SCHEMA_VERSION}"`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`Emitter drift check FAILED (${failures.length} problem(s), ${tokens.length} @type tokens checked):`);
+  for (const f of failures) console.error(`  ${f}`);
+  process.exit(1);
+}
+console.log(`Emitter drift check passed: ${tokens.length} @type tokens resolve in the records context; schema_version "${SCHEMA_VERSION}" matches the example corpus and every emitted record.`);


### PR DESCRIPTION
## What
Fixes on the battinfo.org surface for machine and newcomer consumers:

1. `web/public/llms.txt`: states the registry base URL
   (`https://battinfo-registry.onrender.com`, with the concrete
   `/openapi.json`) next to the OpenAPI mention; adds the flagship IRI
   `spec/pge5-wer6-2q82-v9k0` as a live bootstrap example; and distinguishes the
   two record dialects (canonical `{"value","unit"}` served at spec IRIs with
   its own inline `@vocab ns#` context, vs the EMMO emission dialect the records
   context is for) so an agent does not apply the records context to a canonical
   record and get an empty graph.
2. Re-points the cell-spec showcase exemplar `@id` from the dead
   `spec/7d9k-2m4p-8t3x-6nq5` to the published flagship
   `spec/pge5-wer6-2q82-v9k0`, and reconciles its content (A123 ANR26650M1-B,
   LFP) to that record so dereferencing the `@id` returns matching data.
3. Adds a Windows install variant (`.venv\Scripts\pip`) beside the POSIX line in
   the shared `installSnippet` (rendered on both the landing page and `/docs`).
   The "not on PyPI until 0.8" caveat is unchanged.
4. Fixes the Create-page emitter term drift in `web/lib/create-model.ts`: the
   `continuous_charging_current` / `continuous_discharging_current` keys are
   renamed to `maximum_continuous_charging_current` /
   `maximum_continuous_discharging_current` so the canonical record key denotes
   the same EMMO concept as the emitted `MaximumContinuous*Current` `@type`.
   Adds `scripts/check-create-model-terms.ts` (wired into CI and `check:create-model`),
   a drift check asserting every `@type` token the emitter can produce resolves
   in the packaged records context.
5. Additional (from a sibling finding): replaces the 15 hardcoded
   `schema_version "0.1.0"` stamps in `create-model.ts` with a single
   `SCHEMA_VERSION` constant set to `0.2.0`. The drift check pins that constant
   to the synced example corpus (`cellSpecCanonical`, synced from `examples/**`)
   and asserts every emitted record carries it, so a corpus re-stamp fails CI
   until the emitter is bumped too.
6. Adds glossary links on first use of EMMO, DCAT, PROV (on `/about`) and BDF
   (on `/about` and `/publish`), matching the landing page's glossary pattern.

## Why
- llms.txt was the machine entry point but gave no way to reach the registry
  service and conflated two incompatible quantity dialects (a verified
  empty-graph failure mode).
- The showcase exemplar taught "IRIs persist" and then handed agents a 404.
- The POSIX-only install path silently fails on Windows copy-paste.
- The emitter named a property under a term for a different canonical key, and
  nothing stopped the hand-rolled term table (or the version stamp) from
  diverging from the package again.
- `/about` and `/publish` dropped acronyms bare where the landing page links
  them.

## How
- Content/markup edits in `web/public/llms.txt`, `web/lib/examples.ts`,
  `web/app/about/page.tsx`, `web/app/publish/page.tsx`.
- `web/lib/create-model.ts`: key rename, `SCHEMA_VERSION` constant, and exported
  vocab maps so the drift check can audit them.
- New `web/scripts/check-create-model-terms.ts` + `check:create-model` npm
  script, run in CI.
- Out-of-`web/` touches, flagged for review: `scripts/gen_web_examples.py`
  (the generator of the committed showcase artifacts) is the durable source of
  the cell-spec exemplar; its `snippet_cell_spec` now authors the flagship and
  `normalize()` keeps the real flagship IRI verbatim. The committed
  `web/lib/showcase.generated.ts` + `web/public/jsonld/showcase-cell-spec.jsonld`
  were regenerated from it (editing only the committed output would have drifted
  from the generator and failed `tests/test_web_generated.py`). One line added
  to `.github/workflows/ci.yml` to run the new drift check.

## Testing
- `npm ci`, `npm run build` green (all 17 routes prerender).
- `npm run check:agreement` (109 records), `npm run check:workbench`,
  `npm run sync:context -- --check` green.
- `npm run check:create-model`: passes at 67 `@type` tokens; verified it FAILS
  when a term is flipped (`Density` -> `DensityDRIFT`) and when a stray
  `schema_version "0.1.0"` literal is reintroduced, and passes again on restore.
- llms.txt link walk: every URL 200 except `GET /` on the registry root (a bare
  404 — that is the registry's own Phase 5.4 gap, out of this territory; the
  concrete `/openapi.json` under the base URL is 200). All resolvable showcase
  `@id`s 200.
- `next lint` is broken on this repo under Next 16 (`next lint` was removed;
  it treats `lint` as a project-dir arg). It is not in the CI web job; ESLint
  runs inside `next build`, which is green. Left as-is (pre-existing).

## Notes / follow-ups (out of scope)
- The `showcase-test` and `showcase-dataset` `@id`s still 404: no test/dataset
  record is published, and re-pointing them at the cell-spec flagship would be
  semantically wrong. Making them resolve is corpus re-emission beyond the
  flagship (#298), explicitly excluded from this plan. Left as illustrative.
- `web/lib/jsonld.generated.ts` untouched (owned by a sibling agent).