### PR TITLE
web: bump sharp to >=0.35.0 and resolve showcase test/dataset @ids

### DIFF
--- a/scripts/gen_web_examples.py
+++ b/scripts/gen_web_examples.py
@@ -201,7 +201,10 @@ def snippet_test():
         serial_number="LAB-2026-0001",
     )
     test = Test(
-        id="https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt",
+        # A live IRI: dereference it (Accept: application/ld+json) and it
+        # resolves. Its archived payload predates this emission dialect; the
+        # showcase body below is the current gold-standard form.
+        id="https://w3id.org/battinfo/test/ygnc-b2j3-bc55-rbn1",
         cell=cell,                         # what you did, to which cell
         kind="capacity_check",
         protocol="C/10 constant-current discharge",
@@ -229,7 +232,10 @@ def snippet_dataset():
         cell=cell, kind="cycling", status="completed",
     )
     dataset = Dataset(
-        id="https://w3id.org/battinfo/dataset/0rp6-kncv-cyem-qwcd",
+        # A live IRI: dereference it (Accept: application/ld+json) and it
+        # resolves. Its archived payload predates this emission dialect; the
+        # showcase body below is the current gold-standard form.
+        id="https://w3id.org/battinfo/dataset/yssz-kccw-16g6-s21q",
         path="data/cycle-life-run",        # the folder with your measured files
         cell=cell,
         test=test,
@@ -332,8 +338,14 @@ FIXED_TIME = 1750000000
 
 # Real, published IRIs to preserve verbatim through normalization: these
 # dereference today, so an example that shows one must keep it (the cell-spec
-# showcase is the flagship, not a placeholder).
-KEEP_UIDS = {"pge5-wer6-2q82-v9k0"}
+# showcase is the flagship, not a placeholder). The test/dataset IRIs resolve
+# too; their archived payloads predate the current emission dialect, but the
+# showcase bodies remain the gold-standard form.
+KEEP_UIDS = {
+    "pge5-wer6-2q82-v9k0",   # flagship cell-spec
+    "ygnc-b2j3-bc55-rbn1",   # showcase-test @id
+    "yssz-kccw-16g6-s21q",   # showcase-dataset @id
+}
 
 
 def normalize(record: dict) -> dict:

--- a/web/lib/showcase.generated.ts
+++ b/web/lib/showcase.generated.ts
@@ -508,16 +508,16 @@ export const showcase: {
     "title": "A test",
     "tagline": "One execution of a procedure on one cell: instrument, status, and the link every dataset hangs off.",
     "recordType": "test",
-    "code": "from battinfo import Cell, CellSpec, Test\n\ncell = Cell(\n    id=\"https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7\",\n    cell_spec=CellSpec(\n        id=\"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\",\n        manufacturer=\"Samsung SDI\", model=\"INR21700-50E\",\n        format=\"cylindrical\", chemistry=\"Li-ion\",\n    ),\n    serial_number=\"LAB-2026-0001\",\n)\ntest = Test(\n    id=\"https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt\",\n    cell=cell,                         # what you did, to which cell\n    kind=\"capacity_check\",\n    protocol=\"C/10 constant-current discharge\",\n    instrument=\"Biologic VMP-300\",\n    status=\"completed\",\n)\nrecord = test.to_record()",
+    "code": "from battinfo import Cell, CellSpec, Test\n\ncell = Cell(\n    id=\"https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7\",\n    cell_spec=CellSpec(\n        id=\"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\",\n        manufacturer=\"Samsung SDI\", model=\"INR21700-50E\",\n        format=\"cylindrical\", chemistry=\"Li-ion\",\n    ),\n    serial_number=\"LAB-2026-0001\",\n)\ntest = Test(\n    # A live IRI: dereference it (Accept: application/ld+json) and it\n    # resolves. Its archived payload predates this emission dialect; the\n    # showcase body below is the current gold-standard form.\n    id=\"https://w3id.org/battinfo/test/ygnc-b2j3-bc55-rbn1\",\n    cell=cell,                         # what you did, to which cell\n    kind=\"capacity_check\",\n    protocol=\"C/10 constant-current discharge\",\n    instrument=\"Biologic VMP-300\",\n    status=\"completed\",\n)\nrecord = test.to_record()",
     "record": {
       "schema_version": "0.2.0",
       "test": {
-        "id": "https://w3id.org/battinfo/test/7d9k-2m4p-8t3x-6nq5",
-        "short_id": "7d9k2m",
-        "identifier": "test:7d9k-2m4p-8t3x-6nq5",
+        "id": "https://w3id.org/battinfo/test/ygnc-b2j3-bc55-rbn1",
+        "short_id": "ygncb2",
+        "identifier": "test:ygnc-b2j3-bc55-rbn1",
         "name": "LAB-2026-0001 C/10 constant-current discharge",
         "kind": "capacity_check",
-        "cell_id": "https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7",
+        "cell_id": "https://w3id.org/battinfo/cell/7d9k-2m4p-8t3x-6nq5",
         "status": "completed",
         "protocol_name": "C/10 constant-current discharge",
         "instrument_name": "Biologic VMP-300"
@@ -533,14 +533,14 @@ export const showcase: {
         "schema:Action",
         "prov:Activity"
       ],
-      "@id": "https://w3id.org/battinfo/test/7d9k-2m4p-8t3x-6nq5",
+      "@id": "https://w3id.org/battinfo/test/ygnc-b2j3-bc55-rbn1",
       "schema:name": "LAB-2026-0001 C/10 constant-current discharge",
       "schema:additionalType": "capacity_check",
       "schema:instrument": "Biologic VMP-300",
       "schema:measurementTechnique": "C/10 constant-current discharge",
       "schema:actionStatus": "completed",
       "hasTestObject": {
-        "@id": "https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7"
+        "@id": "https://w3id.org/battinfo/cell/7d9k-2m4p-8t3x-6nq5"
       }
     }
   },
@@ -549,19 +549,19 @@ export const showcase: {
     "title": "A dataset",
     "tagline": "The measured files, linked to the cell and test that produced them — the shape data portals understand (DCAT).",
     "recordType": "dataset",
-    "code": "from battinfo import Cell, CellSpec, Dataset, Test\n\ncell = Cell(\n    id=\"https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7\",\n    cell_spec=CellSpec(\n        id=\"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\",\n        manufacturer=\"Samsung SDI\", model=\"INR21700-50E\",\n        format=\"cylindrical\", chemistry=\"Li-ion\",\n    ),\n    serial_number=\"LAB-2026-0001\",\n)\ntest = Test(\n    id=\"https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt\",\n    cell=cell, kind=\"cycling\", status=\"completed\",\n)\ndataset = Dataset(\n    id=\"https://w3id.org/battinfo/dataset/0rp6-kncv-cyem-qwcd\",\n    path=\"data/cycle-life-run\",        # the folder with your measured files\n    cell=cell,\n    test=test,\n    name=\"INR21700-50E cycle-life dataset\",\n    license=\"CC-BY-4.0\",\n    access_url=\"https://doi.org/10.5281/zenodo.1234567\",  # where the data lives\n)\nrecord = dataset.to_record()",
+    "code": "from battinfo import Cell, CellSpec, Dataset, Test\n\ncell = Cell(\n    id=\"https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7\",\n    cell_spec=CellSpec(\n        id=\"https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5\",\n        manufacturer=\"Samsung SDI\", model=\"INR21700-50E\",\n        format=\"cylindrical\", chemistry=\"Li-ion\",\n    ),\n    serial_number=\"LAB-2026-0001\",\n)\ntest = Test(\n    id=\"https://w3id.org/battinfo/test/6nec-h262-tthy-4rnt\",\n    cell=cell, kind=\"cycling\", status=\"completed\",\n)\ndataset = Dataset(\n    # A live IRI: dereference it (Accept: application/ld+json) and it\n    # resolves. Its archived payload predates this emission dialect; the\n    # showcase body below is the current gold-standard form.\n    id=\"https://w3id.org/battinfo/dataset/yssz-kccw-16g6-s21q\",\n    path=\"data/cycle-life-run\",        # the folder with your measured files\n    cell=cell,\n    test=test,\n    name=\"INR21700-50E cycle-life dataset\",\n    license=\"CC-BY-4.0\",\n    access_url=\"https://doi.org/10.5281/zenodo.1234567\",  # where the data lives\n)\nrecord = dataset.to_record()",
     "record": {
       "schema_version": "0.2.0",
       "dataset": {
-        "id": "https://w3id.org/battinfo/dataset/7d9k-2m4p-8t3x-6nq5",
-        "short_id": "7d9k2m",
-        "identifier": "dataset:7d9k-2m4p-8t3x-6nq5",
+        "id": "https://w3id.org/battinfo/dataset/yssz-kccw-16g6-s21q",
+        "short_id": "ysszkc",
+        "identifier": "dataset:yssz-kccw-16g6-s21q",
         "name": "INR21700-50E cycle-life dataset",
         "license": "CC-BY-4.0",
         "access_url": "https://doi.org/10.5281/zenodo.1234567",
         "about": [
-          "https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7",
-          "https://w3id.org/battinfo/test/3w87-0ddf-ryjg-evxe"
+          "https://w3id.org/battinfo/cell/7d9k-2m4p-8t3x-6nq5",
+          "https://w3id.org/battinfo/test/y9xy-kr0v-y5tn-dfj7"
         ]
       },
       "provenance": {
@@ -571,7 +571,7 @@ export const showcase: {
     "jsonld": {
       "@context": "https://w3id.org/battinfo/context/records/v1.json",
       "@type": "http://www.w3.org/ns/dcat#Dataset",
-      "@id": "https://w3id.org/battinfo/dataset/7d9k-2m4p-8t3x-6nq5",
+      "@id": "https://w3id.org/battinfo/dataset/yssz-kccw-16g6-s21q",
       "dcterms:title": "INR21700-50E cycle-life dataset",
       "dcterms:license": {
         "@id": "CC-BY-4.0"
@@ -581,10 +581,10 @@ export const showcase: {
       },
       "dcterms:subject": [
         {
-          "@id": "https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7"
+          "@id": "https://w3id.org/battinfo/cell/7d9k-2m4p-8t3x-6nq5"
         },
         {
-          "@id": "https://w3id.org/battinfo/test/3w87-0ddf-ryjg-evxe"
+          "@id": "https://w3id.org/battinfo/test/y9xy-kr0v-y5tn-dfj7"
         }
       ]
     }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -529,19 +529,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -551,19 +551,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -577,9 +596,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -593,14 +612,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -612,14 +628,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -631,14 +644,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -650,14 +660,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -669,14 +676,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -688,14 +692,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -707,14 +708,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -726,14 +724,11 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -745,39 +740,33 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -785,99 +774,87 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -885,49 +862,43 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -935,38 +906,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -976,16 +963,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -995,16 +982,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1014,7 +1001,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1104,9 +1091,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1122,9 +1106,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1142,9 +1123,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,9 +1138,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2502,48 +2477,53 @@
       "license": "MIT"
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "typescript": "5.5.3"
   },
   "overrides": {
-    "postcss": "$postcss"
+    "postcss": "$postcss",
+    "sharp": ">=0.35.0"
   }
 }

--- a/web/public/jsonld/showcase-dataset.jsonld
+++ b/web/public/jsonld/showcase-dataset.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": "https://w3id.org/battinfo/context/records/v1.json",
   "@type": "http://www.w3.org/ns/dcat#Dataset",
-  "@id": "https://w3id.org/battinfo/dataset/7d9k-2m4p-8t3x-6nq5",
+  "@id": "https://w3id.org/battinfo/dataset/yssz-kccw-16g6-s21q",
   "dcterms:title": "INR21700-50E cycle-life dataset",
   "dcterms:license": {
     "@id": "CC-BY-4.0"
@@ -11,10 +11,10 @@
   },
   "dcterms:subject": [
     {
-      "@id": "https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7"
+      "@id": "https://w3id.org/battinfo/cell/7d9k-2m4p-8t3x-6nq5"
     },
     {
-      "@id": "https://w3id.org/battinfo/test/3w87-0ddf-ryjg-evxe"
+      "@id": "https://w3id.org/battinfo/test/y9xy-kr0v-y5tn-dfj7"
     }
   ]
 }

--- a/web/public/jsonld/showcase-test.jsonld
+++ b/web/public/jsonld/showcase-test.jsonld
@@ -5,13 +5,13 @@
     "schema:Action",
     "prov:Activity"
   ],
-  "@id": "https://w3id.org/battinfo/test/7d9k-2m4p-8t3x-6nq5",
+  "@id": "https://w3id.org/battinfo/test/ygnc-b2j3-bc55-rbn1",
   "schema:name": "LAB-2026-0001 C/10 constant-current discharge",
   "schema:additionalType": "capacity_check",
   "schema:instrument": "Biologic VMP-300",
   "schema:measurementTechnique": "C/10 constant-current discharge",
   "schema:actionStatus": "completed",
   "hasTestObject": {
-    "@id": "https://w3id.org/battinfo/cell/y9xy-kr0v-y5tn-dfj7"
+    "@id": "https://w3id.org/battinfo/cell/7d9k-2m4p-8t3x-6nq5"
   }
 }

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -20,7 +20,7 @@ a browser gets HTML.
 
 ## Examples
 - Worked records (Python / canonical JSON / JSON-LD): https://battinfo.org/examples
-- Raw JSON-LD artifacts: https://battinfo.org/jsonld/showcase-{slug}.jsonld (Content-Type: application/ld+json)
+- Raw JSON-LD artifacts: https://battinfo.org/jsonld/showcase-{slug}.jsonld (Content-Type: application/ld+json). Each artifact's top-level `@id` is a live persistent IRI you can dereference; the showcase bodies show the current EMMO emission dialect, while some of those archived records predate it.
 - Live record to bootstrap from (a persistent IRI you can dereference today): https://w3id.org/battinfo/spec/pge5-wer6-2q82-v9k0
 
 ## Authoring and consumption


### PR DESCRIPTION
## What
Two web-surface fixes:
1. Force `sharp` to `>=0.35.0` (installs 0.35.3) via an override in `web/package.json`.
2. Re-point the `@id` of `showcase-test.jsonld` and `showcase-dataset.jsonld` at live, resolving registry IRIs, and note the dialect boundary in `llms.txt`.

## Why
1. Dependabot alert #46 (HIGH): `sharp` shipped a libvips inheriting CVE-2026-33327/33328/35590/35591. `sharp` is a transitive optional dependency of Next.js (`next` -> optionalDependencies -> `sharp: ^0.34.5`), used for image optimization; first patched line is 0.35.0. Next's own range would not accept it, so an override is required.
2. The showcase-test and showcase-dataset `@id`s were placeholder IRIs that 404 (the #298 gap on the web surface). `llms.txt` routes agents to all three showcase artifacts as gold examples and expects the link walk to be all-200; showcase-cell-spec already carries the real flagship IRI.

## How
1. Added `"sharp": ">=0.35.0"` to `web/package.json` overrides; regenerated the lockfile. The whole chain moves to sharp 0.35.3 with `@img/sharp-libvips` 1.3.2 (libvips 8.18.3).
2. Path (a): real test and dataset records resolve today via content negotiation. Re-pointed each showcase `@id` at one — `test/ygnc-b2j3-bc55-rbn1` (kind capacity_check) and `dataset/yssz-kccw-16g6-s21q` — through the generator (`scripts/gen_web_examples.py`: `KEEP_UIDS` plus the snippet ids), not by hand-editing generated artifacts, then regenerated. The showcase bodies stay the current gold-standard EMMO emission dialect; those archived payloads predate it (known-open #298), and `llms.txt` now says so.

## Testing
- `npm ci` + `npm run build` green.
- `npm ls sharp` -> `sharp@0.35.3` (only path, under `next`); `npm audit` reports 0 vulnerabilities. Static build does not exercise runtime image optimization, so also loaded the installed binary directly (`require('sharp')`, libvips 8.18.3) and round-tripped a PNG encode to confirm the patched native path works.
- Drift/checks green: `tests/test_web_generated.py` (5 passed), `npm run check:create-model`, `check:agreement`, `check:workbench`; `sync:schemas` idempotent (no content diff).
- Scripted llms.txt link walk (every URL in llms.txt with `{slug}` expanded, plus each showcase artifact's top-level `@id`): 19 targets, all 200, 0 fail — including `test/ygnc-b2j3-bc55-rbn1` and `dataset/yssz-kccw-16g6-s21q`.
