### PR TITLE
Fix [unchanged] misreport with contributors; teach vent part type

### DIFF
--- a/docs/engineering-cell-description.md
+++ b/docs/engineering-cell-description.md
@@ -107,9 +107,10 @@ grounded in the DIGIBAT Discovery-Benchmark and the Cell Design Tool:
 The cylindrical example is authored through `create_component_spec("housing", …)`,
 passes `battinfo validate`, emits a `CylindricalCase` node, and is stamped at the
 current `schema_version`. Its case `@type` is derived from `cell_format`
-(`cylindrical` → `CylindricalCase`). The safety vent has no dedicated part type or
-EMMO class yet, so it is carried as an `other` part with its role in the comment —
-the label is preserved, pending an upstream `SafetyVent` term.
+(`cylindrical` → `CylindricalCase`). The safety vent is carried as a `vent`
+part — a dedicated `parts[].type` value. It has no EMMO class yet, so it is
+emitted with its authored label and a `semantic.hardware_part_unmapped` warning,
+pending an upstream `SafetyVent` term.
 
 The **jelly-roll** geometry of a wound cell is authored on the cell-spec's
 `construction` block (the `CellConstruction` fields above: `winding_turns`,

--- a/examples/housing-spec/housing-spec-k2q4-dk79-g890-7veq.json
+++ b/examples/housing-spec/housing-spec-k2q4-dk79-g890-7veq.json
@@ -50,9 +50,9 @@
     ],
     "parts": [
       {
-        "type": "other",
+        "type": "vent",
         "material": "Aluminium",
-        "comment": "Safety vent (CID / burst membrane) in the top cap. No dedicated part type / EMMO class yet; carried as 'other'."
+        "comment": "Safety vent (CID / burst membrane) in the top cap."
       }
     ]
   },

--- a/src/battinfo/_workspace.py
+++ b/src/battinfo/_workspace.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import mimetypes
 import shutil
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
@@ -1577,6 +1577,7 @@ class Workspace:
         resolve_references: bool = False,
         validation_policy: str = "strict",
         build_index: bool = True,
+        stamp: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         target_root = _as_path(source_root) if source_root is not None else self.source_root
         finalized = self._finalize()
@@ -1590,6 +1591,7 @@ class Workspace:
                 mode=mode,
                 resolve_references=resolve_references,
                 validation_policy=validation_policy,
+                stamp=stamp,
             )
 
         if build_index:
@@ -1609,6 +1611,7 @@ class Workspace:
         mode: str,
         resolve_references: bool,
         validation_policy: str,
+        stamp: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         return {
             "cell_specs": [
@@ -1618,6 +1621,7 @@ class Workspace:
                     mode=mode,
                     resolve_references=resolve_references,
                     validation_policy=validation_policy,
+                    stamp=stamp,
                 )
                 for item in finalized["cell_specs"]
             ],
@@ -1628,6 +1632,7 @@ class Workspace:
                     mode=mode,
                     resolve_references=resolve_references,
                     validation_policy=validation_policy,
+                    stamp=stamp,
                 )
                 for item in finalized["cells"]
             ],
@@ -1638,6 +1643,7 @@ class Workspace:
                     mode=mode,
                     resolve_references=resolve_references,
                     validation_policy=validation_policy,
+                    stamp=stamp,
                 )
                 for item in finalized["test_specs"]
             ],
@@ -1648,6 +1654,7 @@ class Workspace:
                     mode=mode,
                     resolve_references=resolve_references,
                     validation_policy=validation_policy,
+                    stamp=stamp,
                 )
                 for item in finalized["tests"]
             ],
@@ -1658,6 +1665,7 @@ class Workspace:
                     mode=mode,
                     resolve_references=resolve_references,
                     validation_policy=validation_policy,
+                    stamp=stamp,
                 )
                 for item in finalized["datasets"]
             ],

--- a/src/battinfo/api/_records.py
+++ b/src/battinfo/api/_records.py
@@ -6,6 +6,7 @@ import the public surface from ``battinfo.api``, not from this module.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -1331,6 +1332,7 @@ def save_record(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save one canonical BattINFO resource into local source storage and optional resolver artifacts.
 
@@ -1358,6 +1360,15 @@ def save_record(
 
     if resolve_references:
         _resolve_references_for_save(doc, source_root_path)
+
+    # Apply any caller-supplied stamp (e.g. workspace contributor/funding) to the
+    # candidate BEFORE the content comparison and write, so a byte-identical
+    # re-save of an already-stamped record is correctly seen as unchanged (and is
+    # not needlessly rewritten). Applying it here — rather than rewriting the file
+    # after the fact — keeps the content_changed decision and the on-disk bytes in
+    # agreement.
+    if stamp is not None:
+        stamp(doc)
 
     if existing_path is not None and mode_normalized == REGISTER_MODE_CREATE_ONLY:
         if duplicate_policy_normalized == DUPLICATE_POLICY_RETURN_EXISTING:
@@ -1398,7 +1409,13 @@ def save_record(
     # Inside a bulk session the per-file fsync is skipped: the batch is
     # re-runnable (identical re-saves are no-ops), so a power loss is repaired
     # by re-running the ingest, not by 6 ms of fsync per record.
-    _write_json(target_path, doc, durable=cache is None)
+    #
+    # An in-place upsert whose content did not change (ignoring volatile
+    # timestamps) is a genuine no-op: leave the file — and its mtime — untouched
+    # rather than churning identical bytes on every save. The record is still
+    # registered with the bulk cache so the index is rebuilt as usual.
+    if not (existing_path is not None and mode_normalized == REGISTER_MODE_UPSERT and not content_changed):
+        _write_json(target_path, doc, durable=cache is None)
     if cache is not None:
         cache.record_saved(entity_id, target_path, entity_type)
 
@@ -1431,6 +1448,7 @@ def save_cell_spec(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save a cell-spec from either draft payload or canonical record.
 
@@ -1456,6 +1474,7 @@ def save_cell_spec(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     if isinstance(draft, Mapping) and isinstance(draft.get("cell_spec"), Mapping):
         return save_record(
@@ -1471,6 +1490,7 @@ def save_cell_spec(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     spec = draft if isinstance(draft, CellSpecificationBundle) else CellSpecificationBundle(**dict(draft))
     record = _record_from_cell_spec(spec)
@@ -1487,6 +1507,7 @@ def save_cell_spec(
         validate=validate,
         validation_policy=validation_policy,
         dry_run=dry_run,
+        stamp=stamp,
     )
 
 
@@ -1504,6 +1525,7 @@ def save_cell_instance(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save a cell-instance from either draft payload or canonical record.
 
@@ -1529,6 +1551,7 @@ def save_cell_instance(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     if isinstance(draft, Mapping) and isinstance(draft.get("cell_instance"), Mapping):
         return save_record(
@@ -1544,6 +1567,7 @@ def save_cell_instance(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     instance = draft if isinstance(draft, CellInstanceBundle) else CellInstanceBundle(**dict(draft))
     record = _record_from_cell_instance(instance)
@@ -1560,6 +1584,7 @@ def save_cell_instance(
         validate=validate,
         validation_policy=validation_policy,
         dry_run=dry_run,
+        stamp=stamp,
     )
 
 
@@ -1577,6 +1602,7 @@ def save_dataset(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save a dataset from either draft payload or canonical record."""
     from battinfo.bundle import Dataset as DatasetBundle
@@ -1596,6 +1622,7 @@ def save_dataset(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     if isinstance(draft, Mapping) and isinstance(draft.get("dataset"), Mapping):
         return save_record(
@@ -1611,6 +1638,7 @@ def save_dataset(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     dataset = draft if isinstance(draft, DatasetBundle) else DatasetBundle(**dict(draft))
     record = _record_from_dataset(dataset)
@@ -1627,6 +1655,7 @@ def save_dataset(
         validate=validate,
         validation_policy=validation_policy,
         dry_run=dry_run,
+        stamp=stamp,
     )
 
 
@@ -1644,6 +1673,7 @@ def save_test(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save a test from either draft payload or canonical record."""
     from battinfo.bundle import Test as TestBundle
@@ -1663,6 +1693,7 @@ def save_test(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     if isinstance(draft, Mapping) and isinstance(draft.get("test"), Mapping):
         return save_record(
@@ -1678,6 +1709,7 @@ def save_test(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     test = draft if isinstance(draft, TestBundle) else TestBundle(**dict(draft))
     record = _record_from_test(test)
@@ -1694,6 +1726,7 @@ def save_test(
         validate=validate,
         validation_policy=validation_policy,
         dry_run=dry_run,
+        stamp=stamp,
     )
 
 
@@ -1711,6 +1744,7 @@ def save_test_spec(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save a test protocol from either draft payload or canonical record."""
     from battinfo.bundle import TestSpec
@@ -1730,6 +1764,7 @@ def save_test_spec(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     if isinstance(draft, Mapping) and isinstance(draft.get("test_spec"), Mapping):
         return save_record(
@@ -1745,6 +1780,7 @@ def save_test_spec(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     spec = draft if isinstance(draft, TestSpec) else TestSpec(**dict(draft))
     record = _record_from_test_protocol(spec)
@@ -1761,6 +1797,7 @@ def save_test_spec(
         validate=validate,
         validation_policy=validation_policy,
         dry_run=dry_run,
+        stamp=stamp,
     )
 
 

--- a/src/battinfo/data/examples/housing-spec/housing-spec-k2q4-dk79-g890-7veq.json
+++ b/src/battinfo/data/examples/housing-spec/housing-spec-k2q4-dk79-g890-7veq.json
@@ -50,9 +50,9 @@
     ],
     "parts": [
       {
-        "type": "other",
+        "type": "vent",
         "material": "Aluminium",
-        "comment": "Safety vent (CID / burst membrane) in the top cap. No dedicated part type / EMMO class yet; carried as 'other'."
+        "comment": "Safety vent (CID / burst membrane) in the top cap."
       }
     ]
   },

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -1547,33 +1548,50 @@ class AuthoringWorkspace:
         ref = self._get_project()
         return ref.funding_block() if ref else None
 
-    def _stamp_project_funding(self, result: dict) -> int:
-        """Stamp the workspace's ``funding`` block onto every record just written.
+    def _record_stamp(self) -> tuple[Callable[[dict], None] | None, dict[str, int]]:
+        """Build the callback that stamps funding + contributors onto a candidate record.
 
-        Called by :meth:`save` after the records are serialized.  Re-stamps the
-        full set each save, so records authored before the project was assigned
-        are back-filled on the next save.  No-op when no project is set (existing
-        records are left untouched — clearing the project does not strip them).
+        The callback mutates a record document in place and is applied by
+        :meth:`save` *before* each record is written (via ``save_record``'s
+        ``stamp`` hook), rather than rewriting the file afterwards.  Doing it on
+        the candidate keeps the content-change decision and the on-disk bytes in
+        agreement: a re-save whose stamped result is byte-identical is reported as
+        ``unchanged`` and is not rewritten.
+
+        The funding block is set when absent; each contributor (a ``Person``
+        carrying the ORCID in ``same_as``) is appended if its ORCID is not already
+        listed.  Both are idempotent and back-fill records authored before the
+        project/contributor was set.  Returns ``(None, counters)`` when neither a
+        project nor a contributor is set.  ``counters`` is updated as the callback
+        runs so :meth:`save` can report how many records the funding block reached.
         """
         block = self._funding_block()
-        if block is None:
-            return 0
-        stamped = 0
-        for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs"):
-            for item in result.get(key, []):
-                path = item.get("path") if isinstance(item, dict) else str(item)
-                if not path:
-                    continue
-                p = Path(path)
-                if not p.exists():
-                    continue
-                record = json.loads(p.read_text(encoding="utf-8"))
-                if record.get("funding") == block:
-                    continue
-                record["funding"] = block
-                _atomic_write_text(p, json.dumps(record, indent=2, ensure_ascii=False) + "\n")
-                stamped += 1
-        return stamped
+        people = [(r.orcid_url, r.person_block()) for r in self._get_contributors()]
+        counters = {"funding": 0, "contributor": 0}
+        if block is None and not people:
+            return None, counters
+
+        def stamp(doc: dict) -> None:
+            if block is not None and doc.get("funding") != block:
+                doc["funding"] = block
+                counters["funding"] += 1
+            if people:
+                contributors = doc.get("contributor")
+                if not isinstance(contributors, list):
+                    contributors = []
+                present = {c.get("same_as") for c in contributors if isinstance(c, dict)}
+                added = False
+                for orcid_url, person in people:
+                    if orcid_url in present:
+                        continue
+                    contributors.append(person)
+                    present.add(orcid_url)
+                    added = True
+                if added:
+                    doc["contributor"] = contributors
+                    counters["contributor"] += 1
+
+        return stamp, counters
 
     def contributor(
         self,
@@ -1701,52 +1719,6 @@ class AuthoringWorkspace:
             if r.affiliation:
                 print(f"    {r.summary()} affiliation: {r.affiliation}")
         print("  Saved to .battinfo/workspace.json; stamped onto records on ws.save().")
-
-    def _stamp_contributor(self, result: dict) -> int:
-        """Stamp every workspace contributor onto each record's ``contributor`` list.
-
-        Mirrors :meth:`_stamp_project_funding`: each contributor (a ``Person`` with
-        the ORCID in ``same_as``) is added, in call order, to the top-level
-        ``contributor`` array of every record written, so contributions of any kind
-        are attributable. Idempotent (a record already listing an ORCID is not
-        re-added, so re-saving never duplicates) and back-fills records authored
-        before the contributor was set. No-op when no contributor is set.
-
-        Returns the count of record files modified.
-        """
-        refs = self._get_contributors()
-        if not refs:
-            return 0
-        people = [(r.orcid_url, r.person_block()) for r in refs]
-        stamped = 0
-        for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs"):
-            for item in result.get(key, []):
-                path = item.get("path") if isinstance(item, dict) else str(item)
-                if not path:
-                    continue
-                p = Path(path)
-                if not p.exists():
-                    continue
-                record = json.loads(p.read_text(encoding="utf-8"))
-                contributors = record.get("contributor")
-                if not isinstance(contributors, list):
-                    contributors = []
-                present = {
-                    c.get("same_as") for c in contributors if isinstance(c, dict)
-                }
-                added = False
-                for orcid_url, person in people:
-                    if orcid_url in present:
-                        continue
-                    contributors.append(person)
-                    present.add(orcid_url)
-                    added = True
-                if not added:
-                    continue
-                record["contributor"] = contributors
-                _atomic_write_text(p, json.dumps(record, indent=2, ensure_ascii=False) + "\n")
-                stamped += 1
-        return stamped
 
     def convert(self, pattern: str | None = None, fmt: str = "csv") -> builtins.list[Path]:
         """Convert raw cycler files to BDF (Battery Data Format).
@@ -2424,11 +2396,29 @@ class AuthoringWorkspace:
         any record that already exists, so a fresh authoring run cannot silently
         overwrite records left by a previous session.
         """
+        # Stamp the workspace's funding project (grant) and every contributor
+        # (ORCID) onto each record as it is written, for attribution. Applying the
+        # stamp to the candidate before it is saved — rather than rewriting the
+        # file afterwards — lets an unchanged, already-stamped re-save report
+        # [unchanged] and skip the write entirely.
+        stamp_fn, stamp_counts = self._record_stamp()
         result = self._ws.save(
             mode=mode,
             resolve_references=False,
             validation_policy=validation_policy,
+            stamp=stamp_fn,
         )
+        # How many records the funding block actually reached this save: every
+        # candidate is stamped, but only newly-created or genuinely-changed records
+        # are written — an unchanged re-save reaches zero, so it prints nothing.
+        stamped = 0
+        if stamp_counts["funding"]:
+            for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs"):
+                for item in result.get(key, []):
+                    if isinstance(item, dict) and (
+                        item.get("status") == "created" or item.get("content_changed")
+                    ):
+                        stamped += 1
         # Track the exact files written so submit() only sends this session's work.
         self._session_paths = set()
         for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs"):
@@ -2436,11 +2426,6 @@ class AuthoringWorkspace:
                 p = item.get("path") if isinstance(item, dict) else str(item)
                 if p:
                     self._session_paths.add(Path(p))
-
-        # Stamp the workspace's funding project (grant) onto every record written,
-        # and the contributor (ORCID) onto every dataset, for attribution.
-        stamped = self._stamp_project_funding(result)
-        self._stamp_contributor(result)
 
         # Build id -> human name from the finalized in-memory objects so the
         # confirmation shows what was written, not just counts.

--- a/tests/test_pkg_silent_loss.py
+++ b/tests/test_pkg_silent_loss.py
@@ -389,6 +389,62 @@ def test_identical_resave_reports_unchanged(tmp_path: Path, capsys) -> None:
     assert "[updated]" not in out
 
 
+def _record_files(ws: AuthoringWorkspace) -> list[Path]:
+    root = ws._ws.source_root
+    return sorted(p for p in root.rglob("*.json") if "index" not in p.name)
+
+
+def test_identical_resave_with_contributor_reports_unchanged(tmp_path: Path, capsys) -> None:
+    # Regression: a contributor (ORCID) stamped on every record used to make a
+    # byte-identical re-save print [updated] and needlessly rewrite each file,
+    # because the stamp was applied after the content comparison. The stamp is now
+    # applied to the candidate before the comparison, so the re-save is a true
+    # no-op: [unchanged], identical bytes, and untouched mtimes.
+    ws = _new_ws(tmp_path)
+    ws.contributor("0000-0002-1825-0097", name="Jane Researcher")
+    ws.save()
+    files = _record_files(ws)
+    assert files
+    before = {p: (p.read_bytes(), p.stat().st_mtime_ns) for p in files}
+
+    capsys.readouterr()  # drop the first save's output
+    ws.save()  # byte-identical re-save
+    out = capsys.readouterr().out
+    assert "[unchanged]" in out
+    assert "[updated]" not in out
+
+    after = {p: (p.read_bytes(), p.stat().st_mtime_ns) for p in files}
+    assert after == before, "an unchanged re-save must not rewrite record files"
+
+
+def test_resave_with_contributor_and_real_change_reports_updated(tmp_path: Path, capsys) -> None:
+    # A genuine edit to an already-stamped record still reports [updated].
+    ws = _new_ws(tmp_path)
+    ws.contributor("0000-0002-1825-0097", name="Jane Researcher")
+    ws.save()
+
+    ws._ws.cell_specs[0].name = "Renamed cell spec"  # genuine content change
+    capsys.readouterr()
+    ws.save()
+    out = capsys.readouterr().out
+    assert "[updated]" in out
+
+
+def test_adding_second_contributor_reports_updated(tmp_path: Path, capsys) -> None:
+    # Adding a contributor between saves legitimately changes the record bytes, so
+    # the re-save must report [updated], not [unchanged].
+    ws = _new_ws(tmp_path)
+    ws.contributor("0000-0002-1825-0097", name="Jane Researcher")
+    ws.save()
+
+    ws.contributor("0000-0001-5109-3700", name="Second Author")
+    capsys.readouterr()
+    ws.save()
+    out = capsys.readouterr().out
+    assert "[updated]" in out
+    assert "[unchanged]" not in out
+
+
 # ── Item 8: error-text fixes (phantom command + key-request URL) ────────────────
 
 def test_save_gate_message_uses_real_command() -> None:

--- a/tests/test_ws_contributor.py
+++ b/tests/test_ws_contributor.py
@@ -157,8 +157,10 @@ def test_save_stamps_contributor_on_every_record(tmp_path: Path) -> None:
 def test_interrupted_contributor_stamp_leaves_records_valid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The contributor stamp rewrites canonical record files in place; an
-    # interrupted stamp must never leave a truncated/half-written record (R-5).
+    # The contributor stamp is applied to each record as it is written; an
+    # interrupted write must never leave a truncated/half-written record (R-5).
+    # A no-op re-save writes nothing, so force a genuine change (a second
+    # contributor) to exercise the write path.
     ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
     _populate(ws, tmp_path)
     ws.contributor(ORCID, name="Jane Researcher")
@@ -168,13 +170,14 @@ def test_interrupted_contributor_stamp_leaves_records_valid(
     assert record_files
 
     def boom(*args, **kwargs):
-        raise OSError("simulated crash during contributor stamp")
+        raise OSError("simulated crash while writing a stamped record")
 
-    monkeypatch.setattr("battinfo.ws._atomic_write_text", boom)
+    ws.contributor("0000-0001-5109-3700", name="Second Author")  # forces a rewrite
+    monkeypatch.setattr("battinfo._jsonio.atomic_write_text", boom)
     with pytest.raises(OSError):
         ws.save(validation_policy="strict")
 
-    # Every record on disk is still valid JSON — never truncated by the failed stamp.
+    # Every record on disk is still valid JSON — never truncated by the failed write.
     for p in record_files:
         json.loads(p.read_text(encoding="utf-8"))
 
@@ -182,7 +185,9 @@ def test_interrupted_contributor_stamp_leaves_records_valid(
 def test_interrupted_funding_stamp_leaves_records_valid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Same R-5 guarantee for the funding (project) stamp path (ws.py:_stamp_project_funding).
+    # Same R-5 guarantee for the funding (project) stamp, which shares the record
+    # write path. A no-op re-save writes nothing, so change the funding block to
+    # force every record to be rewritten.
     ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
     _populate(ws, tmp_path)
     ws._set_project(ProjectRef(identifier="101103997", name="DigiBatt", funder="EU"))
@@ -192,9 +197,10 @@ def test_interrupted_funding_stamp_leaves_records_valid(
     assert record_files
 
     def boom(*args, **kwargs):
-        raise OSError("simulated crash during funding stamp")
+        raise OSError("simulated crash while writing a stamped record")
 
-    monkeypatch.setattr("battinfo.ws._atomic_write_text", boom)
+    ws._set_project(ProjectRef(identifier="999999", name="Other", funder="EU"))  # forces a rewrite
+    monkeypatch.setattr("battinfo._jsonio.atomic_write_text", boom)
     with pytest.raises(OSError):
         ws.save(validation_policy="strict")
 


### PR DESCRIPTION
## What
Two fixes from the 0.8 gate verification:

1. A byte-identical `ws.save()` re-save with a workspace contributor set now reports `[unchanged]` (it printed `[updated]` for every record) and no longer rewrites the files.
2. The engineering-cell-description docs page and the cylindrical housing-spec example now use the dedicated `parts[].type == "vent"` added in #318 instead of the old `"other"` workaround.

## Why
1. `ws.save` decided changed/unchanged by comparing the candidate document *before* the contributor stamp against the already-stamped on-disk file, then re-stamped the same bytes afterwards. The net file was byte-identical but every record was reported `[updated]` and rewritten (two writes, bumped mtime) on every save.
2. #318 made `vent` a first-class `HardwarePart` type, but the docs and example still taught carrying a safety vent as an `other` part.

## How
- Thread an optional `stamp` callback through `save_record` and the record-type save wrappers (`_workspace._save_finalized`). The workspace applies its funding + contributor stamp to each candidate *before* the content comparison and write, so `content_changed` and the on-disk bytes agree.
- Skip the physical write for a genuine no-op upsert (`existing_path`, `mode=upsert`, `content_changed=False`); the record is still registered with the bulk cache so the index is rebuilt.
- Replace the post-save `_stamp_project_funding` / `_stamp_contributor` file-rewriters with a single `_record_stamp()` callback builder; the funding "stamped onto N" line now counts only records actually created or changed.
- Example: `parts[].type` `other` -> `vent`, drop the workaround comment; keep `schema_version` 0.2.0; re-sync the packaged mirror via `scripts/sync_examples.py`. Docs: rewrite the vent passage to describe `vent` as current capability (it still emits a `semantic.hardware_part_unmapped` warning, pending an upstream `SafetyVent` EMMO term).

## Testing
- `uv run pytest`: 1601 passed, 1 skipped.
- `uv run ruff check` and `uv run mypy`: clean.
- `sphinx-build -W`: build succeeded.
- `scripts/sync_examples.py --check`: in sync. `battinfo validate` on the example: passes.
- New regression tests in `tests/test_pkg_silent_loss.py`: with-contributor byte-identical re-save reports `[unchanged]` with unchanged bytes/mtime; a real edit with a contributor set still reports `[updated]`; adding a second contributor reports `[updated]`. Updated the two crash-safety tests in `tests/test_ws_contributor.py` to target the record write path (`battinfo._jsonio.atomic_write_text`) and force a genuine change.

Note: unrelated `scripts/assemble_context.py --check` reports pre-existing `records.context.json` drift on clean `main`, untouched here. The web JSON-LD/showcase generators do not reference the housing example, so no web mirror regeneration is required.