### PR TITLE
Guide 6: exercise ws.license in the executed cells

### DIFF
--- a/docs/guides/06-publish-your-data.ipynb
+++ b/docs/guides/06-publish-your-data.ipynb
@@ -4,7 +4,26 @@
    "cell_type": "markdown",
    "id": "1cb77488",
    "metadata": {},
-   "source": "# Guide 6 — Publish your first dataset\n\n**The tutorial version of the [publishing journey](https://battinfo.org/publish):** you start\nwith a raw cycler export and finish with validated, linked records, a citable archive, and a\nplace in the Battery Genome registry. Every code cell here executes in CI, against the sample\nNeware CSV that ships with the repository — swap in your own files and the recipe is identical.\n\nThe five stages:\n\n1. **Convert** — instrument files → tidy BDF tables\n2. **Identify** — name the physical cells you tested\n3. **Link** — attach each test and its data to its cell\n4. **Save & validate** — canonical records with stable IRIs\n5. **Publish** — a DOI on Zenodo + the registry review queue\n\n**Prerequisites:** Stage 1 uses the `processing` extra — the `batterydf` BDF converter. BattINFO is not on PyPI until the 0.8 release, so install from source (see [Installation](../pages/getting-started.rst)); `batterydf` is not on PyPI yet either, so `pip install \"battinfo[processing]\"` cannot resolve it. Clone the repo and run `uv sync --all-extras` (how this notebook is executed in CI), or `pip install -e .` plus the processing dependencies directly: `pip install \"git+https://github.com/battery-data-alliance/battery-data-format.git\" matplotlib plotly`. Stage 5 needs credentials and is guarded so the notebook runs fully offline without them.\n\n*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
+   "source": [
+    "# Guide 6 — Publish your first dataset\n",
+    "\n",
+    "**The tutorial version of the [publishing journey](https://battinfo.org/publish):** you start\n",
+    "with a raw cycler export and finish with validated, linked records, a citable archive, and a\n",
+    "place in the Battery Genome registry. Every code cell here executes in CI, against the sample\n",
+    "Neware CSV that ships with the repository — swap in your own files and the recipe is identical.\n",
+    "\n",
+    "The five stages:\n",
+    "\n",
+    "1. **Convert** — instrument files → tidy BDF tables\n",
+    "2. **Identify** — name the physical cells you tested\n",
+    "3. **Link** — attach each test and its data to its cell\n",
+    "4. **Save & validate** — canonical records with stable IRIs\n",
+    "5. **Publish** — a DOI on Zenodo + the registry review queue\n",
+    "\n",
+    "**Prerequisites:** Stage 1 uses the `processing` extra — the `batterydf` BDF converter. BattINFO is not on PyPI until the 0.8 release, so install from source (see [Installation](../pages/getting-started.rst)); `batterydf` is not on PyPI yet either, so `pip install \"battinfo[processing]\"` cannot resolve it. Clone the repo and run `uv sync --all-extras` (how this notebook is executed in CI), or `pip install -e .` plus the processing dependencies directly: `pip install \"git+https://github.com/battery-data-alliance/battery-data-format.git\" matplotlib plotly`. Stage 5 needs credentials and is guarded so the notebook runs fully offline without them.\n",
+    "\n",
+    "*New words? The [plain-language glossary](../pages/glossary.md) decodes EMMO, IRI, JSON-LD, and the rest in two sentences each.*"
+   ]
   },
   {
    "cell_type": "code",
@@ -12,10 +31,10 @@
    "id": "e43cee13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:13:50.724786Z",
-     "iopub.status.busy": "2026-07-30T16:13:50.724786Z",
-     "iopub.status.idle": "2026-07-30T16:13:52.477824Z",
-     "shell.execute_reply": "2026-07-30T16:13:52.477824Z"
+     "iopub.execute_input": "2026-08-01T02:09:26.537710Z",
+     "iopub.status.busy": "2026-08-01T02:09:26.537710Z",
+     "iopub.status.idle": "2026-08-01T02:09:30.124578Z",
+     "shell.execute_reply": "2026-08-01T02:09:30.124578Z"
     }
    },
    "outputs": [],
@@ -59,10 +78,10 @@
    "id": "e2c1ddca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:13:52.477824Z",
-     "iopub.status.busy": "2026-07-30T16:13:52.477824Z",
-     "iopub.status.idle": "2026-07-30T16:14:23.080556Z",
-     "shell.execute_reply": "2026-07-30T16:14:23.078547Z"
+     "iopub.execute_input": "2026-08-01T02:09:30.124578Z",
+     "iopub.status.busy": "2026-08-01T02:09:30.124578Z",
+     "iopub.status.idle": "2026-08-01T02:10:02.645140Z",
+     "shell.execute_reply": "2026-08-01T02:10:02.644133Z"
     }
    },
    "outputs": [
@@ -76,7 +95,7 @@
       "    (reader plugin: neware_csv -- if that looks wrong, the file was likely detected as the wrong instrument format)\n",
       "    Fix: ws.bdf_columns() lists the canonical names, then ws.convert_csv('neware-sample.csv', hints={'<source column>': '<bdf name>'}).\n",
       "\n",
-      "Converted 1 file(s) -> <repo>\\docs\\guides\\_scratch\\guide-06\\bdf\n",
+      "Converted 1 file(s) -> C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\waveG6\\docs\\guides\\_scratch\\guide-06\\bdf\n",
       "  DATA-LOSS WARNING: 1 file(s) had unmapped source columns (details above) -- the converted files do NOT contain those columns.\n",
       "\n",
       "BDF columns: test_time_second,voltage_volt,current_ampere,unix_time_second,cycle_count,step_id,step_time_second,step_charging_capacity_ah,step_discharging_capacity_ah\n"
@@ -109,10 +128,10 @@
    "id": "c7d97399",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:14:23.082566Z",
-     "iopub.status.busy": "2026-07-30T16:14:23.082566Z",
-     "iopub.status.idle": "2026-07-30T16:14:26.727511Z",
-     "shell.execute_reply": "2026-07-30T16:14:26.727511Z"
+     "iopub.execute_input": "2026-08-01T02:10:02.648139Z",
+     "iopub.status.busy": "2026-08-01T02:10:02.648139Z",
+     "iopub.status.idle": "2026-08-01T02:10:04.923454Z",
+     "shell.execute_reply": "2026-08-01T02:10:04.923454Z"
     }
    },
    "outputs": [
@@ -164,10 +183,10 @@
    "id": "d9a22b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:14:26.727511Z",
-     "iopub.status.busy": "2026-07-30T16:14:26.727511Z",
-     "iopub.status.idle": "2026-07-30T16:14:26.749906Z",
-     "shell.execute_reply": "2026-07-30T16:14:26.749906Z"
+     "iopub.execute_input": "2026-08-01T02:10:04.923454Z",
+     "iopub.status.busy": "2026-08-01T02:10:04.923454Z",
+     "iopub.status.idle": "2026-08-01T02:10:04.941107Z",
+     "shell.execute_reply": "2026-08-01T02:10:04.941107Z"
     }
    },
    "outputs": [
@@ -229,10 +248,10 @@
    "id": "241ee167",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:14:26.752373Z",
-     "iopub.status.busy": "2026-07-30T16:14:26.752373Z",
-     "iopub.status.idle": "2026-07-30T16:14:29.137667Z",
-     "shell.execute_reply": "2026-07-30T16:14:29.135918Z"
+     "iopub.execute_input": "2026-08-01T02:10:04.941107Z",
+     "iopub.status.busy": "2026-08-01T02:10:04.941107Z",
+     "iopub.status.idle": "2026-08-01T02:10:08.835378Z",
+     "shell.execute_reply": "2026-08-01T02:10:08.834371Z"
     }
    },
    "outputs": [
@@ -240,6 +259,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Workspace license: cc-by-4.0\n",
+      "  Saved to .battinfo/workspace.json; stamped onto records on ws.save().\n",
       "Workspace contributor: Ada Lovelace (https://orcid.org/0000-0002-1825-0097)\n",
       "  Saved to .battinfo/workspace.json; stamped onto records on ws.save().\n",
       "Workspace contributors (2):\n",
@@ -252,21 +273,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Saved 4 record(s) under <repo>\\docs\\guides\\_scratch\\guide-06\\.battinfo\\records:\n",
+      "Saved 4 record(s) under C:\\Users\\simonc\\Documents\\Github-local\\battery-genome\\waveG6\\docs\\guides\\_scratch\\guide-06\\.battinfo\\records:\n",
       "  cell spec   Molicel INR21700-P45B                [created]  .battinfo\\records\\cell-spec\\cell-spec-fpdr-z1qt-23v0-stzx.json\n",
       "  cell        S1                                   [created]  .battinfo\\records\\cell-instance\\cell-d6tp-jgqy-a3s9-4qem.json\n",
       "  test        S1 cycling                           [created]  .battinfo\\records\\test\\test-9f4c-mxny-yhym-2zh4.json\n",
-      "  dataset     S1 data                              [created]  .battinfo\\records\\dataset\\dataset-4pkb-x4v6-mqb9-tq2w.json\n",
+      "  dataset     S1 data                              [created]  .battinfo\\records\\dataset\\dataset-txxc-azrb-p0q0-55ft.json\n",
       "\n",
       "  Next: ws.list(verbose=True) to inspect, or ws.publish() to publish.\n",
       "cell-instance/cell-d6tp-jgqy-a3s9-4qem.json\n",
       "cell-spec/cell-spec-fpdr-z1qt-23v0-stzx.json\n",
-      "dataset/dataset-4pkb-x4v6-mqb9-tq2w.json\n",
+      "dataset/dataset-txxc-azrb-p0q0-55ft.json\n",
       "test/test-9f4c-mxny-yhym-2zh4.json\n"
      ]
     }
    ],
    "source": [
+    "# The workspace default license — stamped onto every record from here on.\n",
+    "ws.license(\"cc-by-4.0\")\n",
+    "\n",
     "# Credit both authors by ORCID — contributors accumulate across calls.\n",
     "ws.contributor(\"0000-0002-1825-0097\", name=\"Ada Lovelace\")\n",
     "ws.contributor(\"0000-0001-5109-3700\", name=\"Alan Turing\")\n",
@@ -284,10 +308,10 @@
    "id": "03b2dfb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:14:29.137667Z",
-     "iopub.status.busy": "2026-07-30T16:14:29.137667Z",
-     "iopub.status.idle": "2026-07-30T16:14:29.167084Z",
-     "shell.execute_reply": "2026-07-30T16:14:29.167084Z"
+     "iopub.execute_input": "2026-08-01T02:10:08.839378Z",
+     "iopub.status.busy": "2026-08-01T02:10:08.838377Z",
+     "iopub.status.idle": "2026-08-01T02:10:08.847157Z",
+     "shell.execute_reply": "2026-08-01T02:10:08.846151Z"
     }
    },
    "outputs": [
@@ -305,7 +329,7 @@
       "...\n",
       "provenance: {\n",
       "  \"source_type\": \"measurement\",\n",
-      "  \"retrieved_at\": 1785428066,\n",
+      "  \"retrieved_at\": 1785550205,\n",
       "  \"battinfo_version\": \"0.7.0\"\n",
       "}\n"
      ]
@@ -358,10 +382,10 @@
    "id": "5e115f9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:14:29.170842Z",
-     "iopub.status.busy": "2026-07-30T16:14:29.170842Z",
-     "iopub.status.idle": "2026-07-30T16:14:29.177670Z",
-     "shell.execute_reply": "2026-07-30T16:14:29.177670Z"
+     "iopub.execute_input": "2026-08-01T02:10:08.851674Z",
+     "iopub.status.busy": "2026-08-01T02:10:08.850666Z",
+     "iopub.status.idle": "2026-08-01T02:10:08.858902Z",
+     "shell.execute_reply": "2026-08-01T02:10:08.857895Z"
     }
    },
    "outputs": [
@@ -376,12 +400,12 @@
    ],
    "source": [
     "# DOI path (primary) — Zenodo only, no registry key needed.\n",
-    "# creators credit the authors on the deposit; a click on Zenodo (or publish=True)\n",
-    "# mints the DOI. Here we leave a reviewable draft.\n",
+    "# The deposit inherits the workspace license from Stage 4; creators credit the\n",
+    "# authors on the deposit. A click on Zenodo (or publish=True) mints the DOI.\n",
+    "# Here we leave a reviewable draft.\n",
     "if os.environ.get(\"ZENODO_SANDBOX_TOKEN\"):\n",
     "    deposit = ws.zenodo(\n",
     "        sandbox=True,\n",
-    "        license=\"cc-by-4.0\",\n",
     "        creators=[\n",
     "            {\"name\": \"Lovelace, Ada\", \"orcid\": \"0000-0002-1825-0097\"},\n",
     "            {\"name\": \"Turing, Alan\", \"orcid\": \"0000-0001-5109-3700\"},\n",
@@ -399,10 +423,10 @@
    "id": "7f208a76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T16:14:29.181713Z",
-     "iopub.status.busy": "2026-07-30T16:14:29.177670Z",
-     "iopub.status.idle": "2026-07-30T16:14:29.185940Z",
-     "shell.execute_reply": "2026-07-30T16:14:29.185940Z"
+     "iopub.execute_input": "2026-08-01T02:10:08.862903Z",
+     "iopub.status.busy": "2026-08-01T02:10:08.862903Z",
+     "iopub.status.idle": "2026-08-01T02:10:08.868754Z",
+     "shell.execute_reply": "2026-08-01T02:10:08.868754Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
What
Adds the ws.license("cc-by-4.0") call to Guide 6's Stage 4 code cell, removes the now-redundant explicit license= from the guarded Stage 5 ws.zenodo call so the deposit demonstrates workspace-default inheritance, and re-executes the notebook so committed outputs are real.

Why
The license documentation landed in the Stage 4/5 markdown while ws.license was still unmerged, so the code cells lagged the prose: records in the executed walkthrough saved without a license and the Zenodo cell contradicted the stated precedence. This was the declared follow-up from the quickstart-truth PR.

How
Two cell edits plus a full nbconvert re-execution in the uv --all-extras environment; no markdown changes.

Testing
Notebook re-executed end to end offline; Stage 4 output now shows the workspace license stamp. uv run pytest -k "notebook or snippet": 10 passed.