### PR TITLE
Make materials first-class: kind vocabulary, deterministic ids, attribution, emission

### DIFF
--- a/assets/schemas/material-spec.schema.json
+++ b/assets/schemas/material-spec.schema.json
@@ -35,6 +35,15 @@
           "minLength": 1,
           "description": "Human-readable material name / grade (e.g. 'LFP', 'Graphite', 'NMC811', 'PVDF')."
         },
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required Level-1 MaterialKind key from the curated material_kinds vocabulary (e.g. 'graphite', 'lfp', 'nmc811'). The aggregation axis of the Battery Genome; resolves to the kind's chemical-substance class IRI. An unknown kind is rejected at save time. See battinfo.materials.material_kind_keys()."
+        },
+        "grade": {
+          "type": "string",
+          "description": "Manufacturer grade / product version (e.g. 'grade X', 'v2'). Part of spec identity together with manufacturer and product."
+        },
         "material_class": {
           "type": "string",
           "enum": [
@@ -172,6 +181,22 @@
       "items": {
         "type": "string"
       }
+    },
+    "funding": {
+      "$ref": "#/$defs/Funding"
+    },
+    "contributor": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Person"
+      },
+      "minItems": 1,
+      "description": "People who contributed this record to the platform (attribution/provenance). Each is a schema:Person; an ORCID may be given in same_as. Stamped by ws.save."
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1,
+      "description": "License under which this record is released, as an SPDX identifier (e.g. \"cc-by-4.0\") or a URL. Stamped from the workspace default (ws.license) and emitted as dcterms:license in JSON-LD."
     }
   },
   "$defs": {
@@ -227,6 +252,99 @@
           "$ref": "#/$defs/Organization"
         }
       ]
+    },
+    "Funding": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Funding project (grant) under which the record was produced. Maps to schema:funding / schema:Grant in JSON-LD.",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "type": {
+          "const": "Grant"
+        },
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "identifier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "acronym": {
+          "type": "string"
+        },
+        "program": {
+          "type": "string"
+        },
+        "funder": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "Organization"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "same_as": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    },
+    "Person": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "const": "Person"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "given_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "same_as": {
+          "type": "string",
+          "format": "uri"
+        },
+        "affiliation": {
+          "$ref": "#/$defs/Organization"
+        }
+      }
     },
     "MaterialRef": {
       "description": "Reference to another material by canonical material-spec IRI and/or a free-text name.",

--- a/assets/schemas/material.schema.json
+++ b/assets/schemas/material.schema.json
@@ -50,8 +50,23 @@
         "received_date": {
           "$ref": "#/$defs/FlexDate"
         },
+        "opened_date": {
+          "$ref": "#/$defs/FlexDate",
+          "description": "Date this lot was first opened / put into use."
+        },
         "expires_at": {
           "$ref": "#/$defs/FlexDate"
+        },
+        "amount": {
+          "$ref": "modules/common/quantity.schema.json",
+          "description": "Quantity of this lot on hand or consumed (e.g. mass in g, volume in mL)."
+        },
+        "storage": {
+          "type": "string",
+          "description": "Storage conditions for this lot (e.g. 'argon glovebox', 'dry room, -40 degC dew point')."
+        },
+        "processing": {
+          "$ref": "#/$defs/Processing"
         },
         "datasets": {
           "type": "array",
@@ -140,9 +155,50 @@
       "items": {
         "type": "string"
       }
+    },
+    "funding": {
+      "$ref": "#/$defs/Funding"
+    },
+    "contributor": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Person"
+      },
+      "minItems": 1,
+      "description": "People who contributed this record to the platform (attribution/provenance). Each is a schema:Person; an ORCID may be given in same_as. Stamped by ws.save."
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1,
+      "description": "License under which this record is released, as an SPDX identifier (e.g. \"cc-by-4.0\") or a URL. Stamped from the workspace default (ws.license) and emitted as dcterms:license in JSON-LD."
     }
   },
   "$defs": {
+    "Processing": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How this lot was processed into an electrode/coating. Processing is a property of the instance/build, NOT of the spec identity (aqueous vs NMP is not a distinct product).",
+      "properties": {
+        "route": {
+          "type": "string",
+          "enum": [
+            "aqueous",
+            "nmp",
+            "dry",
+            "other"
+          ],
+          "description": "Processing route: water-based (aqueous), NMP solvent-based, solvent-free (dry), or other."
+        },
+        "solvent": {
+          "type": "string",
+          "description": "Processing solvent (e.g. 'water', 'NMP')."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Free-text processing detail (mixing, drying, calendering, ...)."
+        }
+      }
+    },
     "UnixTime": {
       "type": "integer",
       "minimum": 0,
@@ -234,6 +290,99 @@
           "$ref": "#/$defs/Organization"
         }
       ]
+    },
+    "Funding": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Funding project (grant) under which the record was produced. Maps to schema:funding / schema:Grant in JSON-LD.",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "type": {
+          "const": "Grant"
+        },
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "identifier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "acronym": {
+          "type": "string"
+        },
+        "program": {
+          "type": "string"
+        },
+        "funder": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "Organization"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "same_as": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    },
+    "Person": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "const": "Person"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "given_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "same_as": {
+          "type": "string",
+          "format": "uri"
+        },
+        "affiliation": {
+          "$ref": "#/$defs/Organization"
+        }
+      }
     }
   }
 }

--- a/docs/material-spec.md
+++ b/docs/material-spec.md
@@ -19,8 +19,10 @@ A reusable material specification. Top-level key `material_spec`.
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `id` | ✓ | `https://w3id.org/battinfo/spec/{uid}` |
+| `id` | ✓ | `https://w3id.org/battinfo/spec/{uid}` — content-derived from (manufacturer, product, grade); re-authoring the same product is a no-op |
 | `name` | ✓ | Material grade, e.g. `"LFP"`, `"Graphite"`, `"NMC811"` |
+| `kind` | ✓ (at save) | Level-1 [MaterialKind](materials-model.md) key from the curated vocabulary (`graphite`, `lfp`, `nmc811`, …). The genome's aggregation axis; resolves to the kind's chemical-substance class IRI. Aliases resolve on input; an unknown kind is rejected at save. See `battinfo.materials.material_kind_keys()` |
+| `grade` | | Manufacturer grade / product version; part of spec identity |
 | `material_class` | | `active_material`, `binder`, `conductive_additive`, `current_collector`, `separator_material`, `electrolyte_salt`, `electrolyte_solvent`, `electrolyte_additive`, `metal_electrode`, `coating`, `other` |
 | `electrode_polarity` | | `positive` / `negative` / `none` (for active materials) |
 | `formula` | | Idealized composition, e.g. `LiFePO4`, `C`, `Zn`, `(C2H2F2)n` |
@@ -73,10 +75,28 @@ All `*_material_id` references are existence-checked against material-spec recor
 
 ### `material`
 
-A physical lot/batch realizing a spec. Top-level key `material`. Links to its spec via
-`material_spec_id`; carries lot facts (`lot_id`, `supplier`, `received_date`, measured
-`property`) and a `datasets[]` array linking the lot to its characterization data
-(XRD/SEM/ICP/PSD), each `{id, role}` existence-checked against `dataset` records.
+A physical lot/batch realizing a spec. Top-level key `material`. Its `id`
+(`https://w3id.org/battinfo/material/{uid}`) is content-derived from (spec_id, lot).
+Links to its spec via `material_spec_id` (required); carries lot facts (`lot_id`,
+`supplier`, `received_date`, `opened_date`, `expires_at`, `amount`, `storage`), a
+`processing` block, an OPEN measured `property` block for as-received
+characterisation (unmapped keys get the standard labeled-fallback + warning, not a
+closed vocabulary), and a `datasets[]` array linking the lot to its characterization
+data (XRD/SEM/ICP/PSD), each `{id, role}` existence-checked against `dataset` records.
+
+Processing lives HERE, never on the spec: aqueous vs NMP is not a distinct product.
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `material_spec_id` | ✓ | Level-2 spec IRI |
+| `lot_id` | | Lot / batch number (accepts `lot=` in `ws.add`); part of instance identity |
+| `processing` | | `{route: aqueous\|nmp\|dry\|other, solvent, detail}` |
+| `amount` | | Quantity on hand/consumed, `{value, unit}` |
+| `storage` | | Storage conditions, free text |
+| `property` | | OPEN as-received measurement map |
+
+Both `material-spec` and `material` carry record-level `contributor` / `license` /
+`funding`, stamped by `ws.save` exactly like every other record type.
 
 ## Bridge: embedded ↔ standalone
 

--- a/docs/materials-model.md
+++ b/docs/materials-model.md
@@ -1,0 +1,118 @@
+# Materials: kind, spec, instance
+
+Materials in BattINFO follow a **three-level model** — the spec + instance pattern
+every record family uses, with one universal level above it. It mirrors how cells
+work (chemistry/format vocabulary above `cell-spec` above `cell`).
+
+| Level | What it is | Form | Example |
+| --- | --- | --- | --- |
+| 1. **kind** | the *generic* material | curated vocabulary (not a record) | `graphite`, `nmc811`, `lfp` |
+| 2. **spec** | a *manufactured/synthesized product* | `material-spec` record | Targray NMC811, grade X |
+| 3. **instance** | an *actual lot/batch* | `material` record | lot `LOT-2026-04` |
+
+## Level 1 — MaterialKind (a curated vocabulary)
+
+Generic graphite is universal reference data: the genome's cross-dataset promise
+("all graphite half-cell OCVs") requires every publisher to converge on **one**
+identifier for graphite. So kinds are a **shipped, versioned, curated vocabulary**
+governed by PR — like the property vocabulary — **not** a user-authored record
+type. If level 1 were records, the corpus would grow fifty graphites.
+
+Each kind carries a canonical `key` (the ergonomic handle), a `label`, a `family`
+(`active_anode`, `active_cathode`, `binder`, `conductive_additive`,
+`electrolyte_solvent`, `electrolyte_salt`, `separator_material`,
+`current_collector_material`, `other`), an optional `formula`, tolerant-import
+`aliases` ("NMC 811", "LiNi0.8Mn0.1Co0.1O2", "Si/Gr"), and — the anchor — its
+`chemsub`: the material's **chemical-substance domain-ontology class IRI** (the EMMO
+ecosystem's `domain-chemical-substance`). The battinfo `key` is just the handle;
+`chemsub` is the semantic identity. Kinds missing from the ontology omit `chemsub`
+and go on the ontology-additions backlog (a labeled `ChemicalSubstance` fallback
+carries the node until the class is upstreamed). A kind may also carry curated,
+citable `reference_properties` (e.g. graphite 372 mAh/g) — the generic anchors the
+genome compares datasheet- and measurement-reported values against.
+
+```python
+import battinfo
+from battinfo.materials import material_kind, material_kind_keys, resolve_material_kind
+
+battinfo.material_kinds()                 # the whole vocabulary
+material_kind_keys()                      # the valid kind keys
+resolve_material_kind("NMC 811")          # -> "nmc811" (aliases resolve)
+material_kind("graphite")                 # the full entry (chemsub, emmo, refs)
+```
+
+The seed vocabulary bootstraps the contract; curation to the full set is a
+follow-up PR.
+
+## Level 2 — material-spec (first-class record)
+
+A manufactured or lab-synthesized product, equal in standing to `cell-spec`:
+
+- **Identity** — a deterministic, content-derived IRI minted like every other
+  engine type, from normalized **(manufacturer, product, grade)**. Re-authoring
+  the same product is a no-op, never a duplicate. Lab-synthesized materials use the
+  lab as manufacturer and the recipe/batch-family name as product. There is no
+  random-id path. **Processing is NOT part of spec identity** (see level 3).
+- **Required `kind`** — every spec names its level-1 kind (aliases welcome). This
+  is the query backbone; an unknown kind is rejected at save with the valid keys.
+- **Manufacturer as org link** — `manufacturer.id` → an `organization` record IRI,
+  name fallback tolerated.
+- **Properties** — datasheet values via the standard property mechanism, each
+  eligible for per-property provenance (value/unit/`co_type`/`conditions`).
+- **Attribution** — `contributor` / `license` / `funding` are allowed on the
+  schema and stamped by `ws.save`, exactly like every other record.
+
+## Level 3 — material (instance record)
+
+An actual batch/lot/portion realizing a spec:
+
+- **`spec` link** (required), `lot`/batch number, received/opened/expiry dates,
+  supplier reference, `amount`, `storage`.
+- **`processing`** — the route (`aqueous` | `nmp` | `dry` | `other`), solvent, and
+  free-text detail. **Processing lives here, on the build, not on the spec** —
+  aqueous vs NMP is not a distinct product.
+- **An OPEN property block** for as-received / as-characterized measurements —
+  unmapped keys get the standard labeled-fallback + warning, *not* a closed
+  vocabulary.
+- **Identity** — deterministic from **(spec_id, lot)**.
+
+## Blessed API
+
+```python
+ws = battinfo.workspace(".")
+ws.license("cc-by-4.0"); ws.contributor(orcid="0000-...")
+
+nmc = ws.add("material_spec", name="Targray NMC811", kind="nmc811",
+             manufacturer="Targray", grade="grade X",
+             property={"d50_particle_size": {"value": 11, "unit": "um"}})[0]
+
+ws.add("material", spec=nmc, lot="LOT-2026-04",
+       processing={"route": "nmp", "solvent": "NMP"}, storage="dry room")
+
+ws.save()   # writes + stamps contributor/license/funding onto both records
+```
+
+No `ws._ws` is required for materials.
+
+## Progressive-fidelity linkage into cells
+
+Electrode composition components (and electrolyte solvents/salts, separator
+materials) reference a material at whichever level you know:
+
+- a **kind key** — minimum ("the anode is graphite"), resolves to the vocabulary
+  IRI / EMMO class;
+- a **material-spec IRI** — better ("Targray NMC811 grade X");
+- a **material-instance IRI** — best ("this lot"), typically on the cell *build*.
+
+Express at the level you know and upgrade without re-modeling — the adoption funnel
+applied to materials. The transform renders whichever level is present as a
+properly-typed linked node; the link-integrity gate validates internal IRIs; and
+tolerant import maps free-text names through the alias table with warnings.
+
+> The full composition-linkage ladder (rewiring the cell-spec electrode/electrolyte
+> models onto material references end-to-end) lands in a follow-up PR; the bridge in
+> [`battinfo.materials`](material-spec.md#bridge-embedded--standalone) already lifts
+> embedded materials to standalone specs for dedup today.
+
+See the [material-spec / material field reference](material-spec.md) for the exact
+fields each record carries.

--- a/docs/pages/reference.rst
+++ b/docs/pages/reference.rst
@@ -26,6 +26,7 @@ One page per record family: the fields each carries, and how they link.
 .. toctree::
    :maxdepth: 1
 
+   ../materials-model
    ../material-spec
    ../component-specs
    ../cell-fleet

--- a/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
+++ b/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
     "short_id": "5ms19j",
     "name": "LFP",
+    "kind": "lfp",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiFePO4",

--- a/examples/material-spec/83bd-jmk7-2x47-s04a.json
+++ b/examples/material-spec/83bd-jmk7-2x47-s04a.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/83bd-jmk7-2x47-s04a",
     "short_id": "83bdjm",
     "name": "LNMO",
+    "kind": "lnmo",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.5Mn1.5O4",

--- a/examples/material-spec/8y74-2v75-76kr-t9by.json
+++ b/examples/material-spec/8y74-2v75-76kr-t9by.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/8y74-2v75-76kr-t9by",
     "short_id": "8y742v",
     "name": "Al2O3-coated NMC811",
+    "kind": "nmc811",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",

--- a/examples/material-spec/bkrw-7shb-tzbm-j664.json
+++ b/examples/material-spec/bkrw-7shb-tzbm-j664.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
     "short_id": "bkrw7s",
     "name": "PVDF",
+    "kind": "pvdf",
     "material_class": "binder",
     "formula": "(C2H2F2)n",
     "chemistry_family": "fluoropolymer",

--- a/examples/material-spec/efxx-b9yg-wh00-d23a.json
+++ b/examples/material-spec/efxx-b9yg-wh00-d23a.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/efxx-b9yg-wh00-d23a",
     "short_id": "efxxb9",
     "name": "EC",
+    "kind": "ec",
     "material_class": "electrolyte_solvent",
     "formula": "C3H4O3",
     "chemistry_family": "carbonate-solvent",

--- a/examples/material-spec/fpeg-3wg8-e6cs-2vn1.json
+++ b/examples/material-spec/fpeg-3wg8-e6cs-2vn1.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/fpeg-3wg8-e6cs-2vn1",
     "short_id": "fpeg3w",
     "name": "LiPF6",
+    "kind": "lipf6",
     "material_class": "electrolyte_salt",
     "formula": "LiPF6",
     "chemistry_family": "lithium-salt",

--- a/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
+++ b/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/fwnh-2wkq-n9wm-fdab",
     "short_id": "fwnh2w",
     "name": "MnO2",
+    "kind": "mno2",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "MnO2",

--- a/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
+++ b/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/gwck-k5kf-ae1f-gfgc",
     "short_id": "gwckk5",
     "name": "Graphite",
+    "kind": "graphite",
     "material_class": "active_material",
     "electrode_polarity": "negative",
     "formula": "C",

--- a/examples/material-spec/hy9g-22sd-czdb-nmm4.json
+++ b/examples/material-spec/hy9g-22sd-czdb-nmm4.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/hy9g-22sd-czdb-nmm4",
     "short_id": "hy9g22",
     "name": "EMC",
+    "kind": "emc",
     "material_class": "electrolyte_solvent",
     "formula": "C4H8O3",
     "chemistry_family": "carbonate-solvent",

--- a/examples/material-spec/k0dr-c32c-yrvy-bbfr.json
+++ b/examples/material-spec/k0dr-c32c-yrvy-bbfr.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/k0dr-c32c-yrvy-bbfr",
     "short_id": "k0drc3",
     "name": "Alumina",
+    "kind": "alumina",
     "material_class": "coating",
     "formula": "Al2O3",
     "chemistry_family": "ceramic-oxide",

--- a/examples/material-spec/kg0e-vqce-3439-bnfk.json
+++ b/examples/material-spec/kg0e-vqce-3439-bnfk.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/kg0e-vqce-3439-bnfk",
     "short_id": "kg0evq",
     "name": "Zinc",
+    "kind": "zinc",
     "material_class": "metal_electrode",
     "electrode_polarity": "negative",
     "formula": "Zn",

--- a/examples/material-spec/npa4-0dnw-evyh-hhdm.json
+++ b/examples/material-spec/npa4-0dnw-evyh-hhdm.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
     "short_id": "npa40d",
     "name": "NMC811",
+    "kind": "nmc811",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",

--- a/examples/material-spec/qwae-x6cg-c61k-njw7.json
+++ b/examples/material-spec/qwae-x6cg-c61k-njw7.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/qwae-x6cg-c61k-njw7",
     "short_id": "qwaex6",
     "name": "LMFP",
+    "kind": "lmfp",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiMn0.7Fe0.3PO4",

--- a/examples/material-spec/r5xt-4hrh-jm2k-yg4m.json
+++ b/examples/material-spec/r5xt-4hrh-jm2k-yg4m.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
     "short_id": "r5xt4h",
     "name": "Carbon black",
+    "kind": "carbon_black",
     "material_class": "conductive_additive",
     "formula": "C",
     "chemistry_family": "amorphous-carbon",

--- a/examples/material-spec/s2m9-ksma-nb61-8tpa.json
+++ b/examples/material-spec/s2m9-ksma-nb61-8tpa.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/s2m9-ksma-nb61-8tpa",
     "short_id": "s2m9ks",
     "name": "NMC622",
+    "kind": "nmc622",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.6Mn0.2Co0.2O2",

--- a/examples/material-spec/s9h8-dfbw-zs4k-2qk8.json
+++ b/examples/material-spec/s9h8-dfbw-zs4k-2qk8.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/s9h8-dfbw-zs4k-2qk8",
     "short_id": "s9h8df",
     "name": "KOH",
+    "kind": "koh",
     "material_class": "electrolyte_salt",
     "formula": "KOH",
     "chemistry_family": "alkali-hydroxide",

--- a/examples/material-spec/shzh-t2jt-wwqv-k54m.json
+++ b/examples/material-spec/shzh-t2jt-wwqv-k54m.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/shzh-t2jt-wwqv-k54m",
     "short_id": "shzht2",
     "name": "LCO",
+    "kind": "lco",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiCoO2",

--- a/scripts/migrate_material_ids.py
+++ b/scripts/migrate_material_ids.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""Re-mint random-id material records to deterministic content-derived ids.
+
+Before the first-class materials model, ``create_material_spec`` minted a random
+IRI on every call (readiness report H1), so existing corpora accumulated
+material-spec / material records whose ids carry no identity. This script re-mints
+them the way the engine now does — material-spec from (manufacturer, product,
+grade, kind); material instance from (spec_id, lot) — rewrites the record files,
+fixes cross-references (material instance -> spec; cell-spec electrode components'
+``material_spec_id`` / composition ``base_material_id``), and prints the
+old-id -> new-id map.
+
+It covers the RECORD-FILE side only. The registry supersede/backfill (so old IRIs
+resolve forever per IDENTIFIER_POLICY) is operated separately with the map this
+prints. It does NOT touch battinfo-records or any OCV branch — point it at a copy.
+
+Usage::
+
+    # dry run: print the id map, write nothing
+    python scripts/migrate_material_ids.py --source-root path/to/records
+
+    # apply: rewrite files (renamed to the new uid) and emit the map JSON
+    python scripts/migrate_material_ids.py --source-root path/to/records --write \\
+        --map-out material-id-map.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from battinfo.entities import stable_uid
+from battinfo.materials import resolve_material_kind
+
+_SPEC_BASE = "https://w3id.org/battinfo/spec/"
+_MATERIAL_BASE = "https://w3id.org/battinfo/material/"
+
+
+def _short_id(dashed_uid: str) -> str:
+    return dashed_uid.replace("-", "")[:6]
+
+
+def _org_name(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        name = value.get("name")
+        return name if isinstance(name, str) else None
+    return None
+
+
+def _spec_uid(body: dict) -> str:
+    """Deterministic uid for a material-spec body (mirrors api._components)."""
+    kind = resolve_material_kind(body.get("kind")) or resolve_material_kind(body.get("name")) or ""
+    manufacturer = _org_name(body.get("manufacturer"))
+    product = body.get("product_id") or body.get("name")
+    seed = "::".join(
+        [
+            "material-spec",
+            (manufacturer or "unknown-manufacturer").strip().lower(),
+            (product or "unknown-product").strip().lower(),
+            (body.get("grade") or "").strip().lower(),
+            kind,
+        ]
+    )
+    return stable_uid(seed)
+
+
+def _material_uid(body: dict, spec_id: str) -> str:
+    """Deterministic uid for a material instance body (mirrors api._components)."""
+    lot = body.get("lot_id") or body.get("batch_id") or body.get("name") or ""
+    return stable_uid("::".join(["material", spec_id.strip(), str(lot).strip()]))
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dump(path: Path, doc: dict) -> None:
+    path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def migrate(source_root: Path, *, write: bool) -> dict[str, str]:
+    id_map: dict[str, str] = {}
+
+    # ── Pass 1: material specs ──────────────────────────────────────────────
+    spec_dir = source_root / "material-spec"
+    spec_files = sorted(spec_dir.glob("*.json")) if spec_dir.exists() else []
+    for path in spec_files:
+        doc = _load(path)
+        body = doc.get("material_spec")
+        if not isinstance(body, dict):
+            continue
+        old_id = body.get("id", "")
+        new_uid = _spec_uid(body)
+        new_id = f"{_SPEC_BASE}{new_uid}"
+        # Backfill a resolved kind while we are here (required for authored specs).
+        resolved_kind = resolve_material_kind(body.get("kind")) or resolve_material_kind(body.get("name"))
+        if resolved_kind and body.get("kind") != resolved_kind:
+            body["kind"] = resolved_kind
+        if new_id != old_id:
+            id_map[old_id] = new_id
+            body["id"] = new_id
+            body["short_id"] = _short_id(new_uid)
+            if write:
+                _dump(path, doc)
+                path.rename(path.with_name(f"material-spec-{new_uid}.json"))
+        elif write:
+            _dump(path, doc)
+
+    # ── Pass 2: material instances (remap spec ref, then re-mint) ────────────
+    mat_dir = source_root / "material"
+    mat_files = sorted(mat_dir.glob("*.json")) if mat_dir.exists() else []
+    for path in mat_files:
+        doc = _load(path)
+        body = doc.get("material")
+        if not isinstance(body, dict):
+            continue
+        old_id = body.get("id", "")
+        spec_ref = body.get("material_spec_id", "")
+        spec_ref = id_map.get(spec_ref, spec_ref)
+        body["material_spec_id"] = spec_ref
+        new_uid = _material_uid(body, spec_ref)
+        new_id = f"{_MATERIAL_BASE}{new_uid}"
+        if new_id != old_id:
+            id_map[old_id] = new_id
+            body["id"] = new_id
+            body["short_id"] = _short_id(new_uid)
+            if write:
+                _dump(path, doc)
+                path.rename(path.with_name(f"material-{new_uid}.json"))
+        elif write:
+            _dump(path, doc)
+
+    # ── Pass 3: fix material references embedded in cell specs ───────────────
+    if id_map:
+        cs_dir = source_root / "cell-spec"
+        for path in sorted(cs_dir.glob("*.json")) if cs_dir.exists() else []:
+            doc = _load(path)
+            if _remap_refs(doc, id_map) and write:
+                _dump(path, doc)
+
+    return id_map
+
+
+def _remap_refs(node: object, id_map: dict[str, str]) -> bool:
+    """Recursively rewrite material_spec_id / base_material_id references."""
+    changed = False
+    if isinstance(node, dict):
+        for key in ("material_spec_id", "base_material_id"):
+            val = node.get(key)
+            if isinstance(val, str) and val in id_map:
+                node[key] = id_map[val]
+                changed = True
+        for value in node.values():
+            changed = _remap_refs(value, id_map) or changed
+    elif isinstance(node, list):
+        for item in node:
+            changed = _remap_refs(item, id_map) or changed
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-root", required=True, type=Path,
+                        help="Records root (containing material-spec/, material/, cell-spec/).")
+    parser.add_argument("--write", action="store_true",
+                        help="Rewrite record files in place (default: dry run).")
+    parser.add_argument("--map-out", type=Path, default=None,
+                        help="Write the old-id -> new-id map to this JSON file.")
+    args = parser.parse_args(argv)
+
+    if not args.source_root.exists():
+        print(f"source-root does not exist: {args.source_root}", file=sys.stderr)
+        return 2
+
+    id_map = migrate(args.source_root, write=args.write)
+    mode = "rewrote" if args.write else "would re-mint"
+    print(f"{mode} {len(id_map)} record id(s):")
+    for old, new in id_map.items():
+        print(f"  {old}  ->  {new}")
+    if args.map_out is not None:
+        args.map_out.write_text(json.dumps(id_map, indent=2) + "\n", encoding="utf-8")
+        print(f"id map written to {args.map_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/battinfo/__init__.py
+++ b/src/battinfo/__init__.py
@@ -27,6 +27,7 @@ from battinfo.api import (
 from battinfo.bundle import BattinfoBundle, Cell, CellSpec, Dataset, ProvenanceInfo, Test, TestSpec
 from battinfo.bundle_generated import SpecValue
 from battinfo.jsonld import record_to_jsonld
+from battinfo.materials import material_kinds
 from battinfo.publication import build_publication_package, load_publication_package
 from battinfo.publication import publish as publish_publication_package
 from battinfo.validate import validate_record, validate_record_report
@@ -49,6 +50,7 @@ __all__ = [
     "build_publication_package",
     "bulk_save_session",
     "load_publication_package",
+    "material_kinds",
     "publish",
     "publish_publication_package",
     "q",

--- a/src/battinfo/api/_components.py
+++ b/src/battinfo/api/_components.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import functools
 from pathlib import Path
-from typing import Any, Literal, Mapping
+from typing import Any, Callable, Literal, Mapping
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
@@ -54,6 +54,8 @@ class MaterialSpecInput(BaseModel):
     id: str | None = None
     uid: str | None = None
     name: str
+    kind: str | None = None
+    grade: str | None = None
     material_class: str | None = None
     electrode_polarity: str | None = None
     formula: str | None = None
@@ -83,10 +85,15 @@ class MaterialInput(BaseModel):
     uid: str | None = None
     material_spec_id: str
     name: str | None = None
-    lot_id: str | None = None
+    lot_id: str | None = Field(default=None, validation_alias=AliasChoices("lot_id", "lot"))
     batch_id: str | None = None
     supplier: str | dict[str, Any] | None = None
     received_date: int | str | None = None
+    opened_date: int | str | None = None
+    expires_at: int | str | None = None
+    amount: dict[str, Any] | None = None
+    storage: str | None = None
+    processing: dict[str, Any] | None = None
     dataset_ids: list[str] = Field(default_factory=list)
     property: dict[str, Any] = Field(default_factory=dict)
     source_type: Literal["datasheet", "manufacturer", "measurement", "lab", "literature", "manual", "other"] = "lab"
@@ -112,7 +119,62 @@ def _org_value(value: str | dict[str, Any] | None) -> dict[str, Any] | None:
     return None
 
 
+def _resolve_kind_or_raise(explicit: str | None, *fallback_names: str | None) -> str | None:
+    """Resolve a material ``kind`` to its canonical key.
+
+    An explicit kind that does not resolve is a hard error listing the valid
+    keys (the same UX as any controlled field). When no kind is given, fall back
+    to resolving the material name/product through the alias table (tolerant
+    authoring: ``create_material_spec(name="LFP")`` derives ``kind="lfp"``).
+    Returns ``None`` when nothing resolves, so the required-field schema check
+    reports the missing kind with the standard message.
+    """
+    from battinfo.materials import material_kind_keys, resolve_material_kind
+
+    if explicit is not None and str(explicit).strip():
+        resolved = resolve_material_kind(explicit)
+        if resolved is None:
+            raise ValueError(
+                f"Unknown material kind {explicit!r}. Valid kinds: "
+                f"{', '.join(material_kind_keys())}. "
+                "See battinfo.material_kind_keys() / battinfo.material_kinds()."
+            )
+        return resolved
+    for candidate in fallback_names:
+        resolved = resolve_material_kind(candidate)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _material_spec_identity_uid(draft: MaterialSpecInput, kind_key: str | None) -> str:
+    """Deterministic content-derived uid for a material spec (fixes H1).
+
+    Mirrors the engine's other five types: the IRI is minted from the spec's
+    identity — normalized (manufacturer, product, grade) — so re-authoring the
+    same product is a no-op, never a duplicate. Lab-synthesized materials use the
+    lab as manufacturer and the recipe/batch-family name as product. Processing
+    is NOT part of identity. There is no random-id path.
+    """
+    from battinfo.entities import stable_uid
+
+    org = _org_value(draft.manufacturer)
+    manufacturer = (org or {}).get("name") if org else None
+    product = draft.product_id or draft.name
+    seed = "::".join(
+        [
+            "material-spec",
+            (manufacturer or "unknown-manufacturer").strip().lower(),
+            (product or "unknown-product").strip().lower(),
+            (draft.grade or "").strip().lower(),
+            kind_key or "",
+        ]
+    )
+    return stable_uid(seed)
+
+
 def _record_from_material_spec(draft: MaterialSpecInput) -> dict[str, Any]:
+    kind_key = _resolve_kind_or_raise(draft.kind, draft.name, draft.product_id)
     if draft.id is not None:
         if not MATERIAL_SPEC_IRI_RE.fullmatch(draft.id):
             raise ValueError("material spec id must match https://w3id.org/battinfo/spec/{uid}.")
@@ -121,7 +183,13 @@ def _record_from_material_spec(draft: MaterialSpecInput) -> dict[str, Any]:
         entity_id = draft.id
         _, dashed_uid = _iri_tail(entity_id)
     else:
-        dashed_uid = _normalized_dashed_uid(draft.uid)
+        # Deterministic identity: an explicit uid is honored; otherwise the uid is
+        # derived from the spec's content so a re-run lands on the same IRI.
+        dashed_uid = (
+            _normalized_dashed_uid(draft.uid)
+            if draft.uid is not None
+            else _material_spec_identity_uid(draft, kind_key)
+        )
         entity_id = f"https://w3id.org/battinfo/spec/{dashed_uid}"
 
     spec: dict[str, Any] = {
@@ -129,6 +197,10 @@ def _record_from_material_spec(draft: MaterialSpecInput) -> dict[str, Any]:
         "short_id": dashed_uid.replace("-", "")[:6],
         "name": draft.name,
     }
+    if kind_key is not None:
+        spec["kind"] = kind_key
+    if draft.grade is not None:
+        spec["grade"] = draft.grade
     for field_name in (
         "material_class",
         "electrode_polarity",
@@ -180,7 +252,17 @@ def _record_from_material(draft: MaterialInput) -> dict[str, Any]:
         entity_id = draft.id
         _, dashed_uid = _iri_tail(entity_id)
     else:
-        dashed_uid = _normalized_dashed_uid(draft.uid)
+        # Deterministic identity from (spec_id, lot): re-authoring the same lot is
+        # a no-op. An explicit uid is honored; there is no random-id path.
+        if draft.uid is not None:
+            dashed_uid = _normalized_dashed_uid(draft.uid)
+        else:
+            from battinfo.entities import stable_uid
+
+            lot = draft.lot_id or draft.batch_id or draft.name or ""
+            dashed_uid = stable_uid(
+                "::".join(["material", draft.material_spec_id.strip(), lot.strip()])
+            )
         entity_id = f"https://w3id.org/battinfo/material/{dashed_uid}"
 
     material: dict[str, Any] = {
@@ -188,16 +270,22 @@ def _record_from_material(draft: MaterialInput) -> dict[str, Any]:
         "material_spec_id": draft.material_spec_id,
         "short_id": dashed_uid.replace("-", "")[:6],
     }
-    for field_name in ("name", "lot_id", "batch_id"):
+    for field_name in ("name", "lot_id", "batch_id", "storage"):
         value = getattr(draft, field_name)
         if value is not None:
             material[field_name] = value
     supplier = _org_value(draft.supplier)
     if supplier is not None:
         material["supplier"] = supplier
-    if draft.received_date is not None:
-        received = _to_unix_time(draft.received_date)
-        material["received_date"] = received if received is not None else draft.received_date
+    for date_field in ("received_date", "opened_date", "expires_at"):
+        raw = getattr(draft, date_field)
+        if raw is not None:
+            converted = _to_unix_time(raw)
+            material[date_field] = converted if converted is not None else raw
+    if draft.amount is not None:
+        material["amount"] = draft.amount
+    if draft.processing:
+        material["processing"] = draft.processing
     if draft.dataset_ids:
         for dataset_id in draft.dataset_ids:
             if not DATASET_IRI_RE.fullmatch(dataset_id):
@@ -276,6 +364,7 @@ def save_material_spec(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save a material-spec from either draft payload or canonical record."""
     if isinstance(draft, (str, Path)):
@@ -288,6 +377,7 @@ def save_material_spec(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     if isinstance(draft, MaterialSpecInput):
         record = _record_from_material_spec(draft)
@@ -306,6 +396,7 @@ def save_material_spec(
         validate=validate,
         validation_policy=validation_policy,
         dry_run=dry_run,
+        stamp=stamp,
     )
 
 
@@ -319,6 +410,7 @@ def save_material(
     validate: bool = True,
     validation_policy: ValidationPolicy | str = DEFAULT_POLICY,
     dry_run: bool = False,
+    stamp: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Save a material (instance) from either draft payload or canonical record."""
     if isinstance(draft, (str, Path)):
@@ -331,6 +423,7 @@ def save_material(
             validate=validate,
             validation_policy=validation_policy,
             dry_run=dry_run,
+            stamp=stamp,
         )
     if isinstance(draft, MaterialInput):
         record = _record_from_material(draft)
@@ -349,6 +442,7 @@ def save_material(
         validate=validate,
         validation_policy=validation_policy,
         dry_run=dry_run,
+        stamp=stamp,
     )
 
 

--- a/src/battinfo/data/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
+++ b/src/battinfo/data/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/5ms1-9jv8-hr54-mn4e",
     "short_id": "5ms19j",
     "name": "LFP",
+    "kind": "lfp",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiFePO4",

--- a/src/battinfo/data/examples/material-spec/83bd-jmk7-2x47-s04a.json
+++ b/src/battinfo/data/examples/material-spec/83bd-jmk7-2x47-s04a.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/83bd-jmk7-2x47-s04a",
     "short_id": "83bdjm",
     "name": "LNMO",
+    "kind": "lnmo",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.5Mn1.5O4",

--- a/src/battinfo/data/examples/material-spec/8y74-2v75-76kr-t9by.json
+++ b/src/battinfo/data/examples/material-spec/8y74-2v75-76kr-t9by.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/8y74-2v75-76kr-t9by",
     "short_id": "8y742v",
     "name": "Al2O3-coated NMC811",
+    "kind": "nmc811",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",

--- a/src/battinfo/data/examples/material-spec/bkrw-7shb-tzbm-j664.json
+++ b/src/battinfo/data/examples/material-spec/bkrw-7shb-tzbm-j664.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/bkrw-7shb-tzbm-j664",
     "short_id": "bkrw7s",
     "name": "PVDF",
+    "kind": "pvdf",
     "material_class": "binder",
     "formula": "(C2H2F2)n",
     "chemistry_family": "fluoropolymer",

--- a/src/battinfo/data/examples/material-spec/efxx-b9yg-wh00-d23a.json
+++ b/src/battinfo/data/examples/material-spec/efxx-b9yg-wh00-d23a.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/efxx-b9yg-wh00-d23a",
     "short_id": "efxxb9",
     "name": "EC",
+    "kind": "ec",
     "material_class": "electrolyte_solvent",
     "formula": "C3H4O3",
     "chemistry_family": "carbonate-solvent",

--- a/src/battinfo/data/examples/material-spec/fpeg-3wg8-e6cs-2vn1.json
+++ b/src/battinfo/data/examples/material-spec/fpeg-3wg8-e6cs-2vn1.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/fpeg-3wg8-e6cs-2vn1",
     "short_id": "fpeg3w",
     "name": "LiPF6",
+    "kind": "lipf6",
     "material_class": "electrolyte_salt",
     "formula": "LiPF6",
     "chemistry_family": "lithium-salt",

--- a/src/battinfo/data/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
+++ b/src/battinfo/data/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/fwnh-2wkq-n9wm-fdab",
     "short_id": "fwnh2w",
     "name": "MnO2",
+    "kind": "mno2",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "MnO2",

--- a/src/battinfo/data/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
+++ b/src/battinfo/data/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/gwck-k5kf-ae1f-gfgc",
     "short_id": "gwckk5",
     "name": "Graphite",
+    "kind": "graphite",
     "material_class": "active_material",
     "electrode_polarity": "negative",
     "formula": "C",

--- a/src/battinfo/data/examples/material-spec/hy9g-22sd-czdb-nmm4.json
+++ b/src/battinfo/data/examples/material-spec/hy9g-22sd-czdb-nmm4.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/hy9g-22sd-czdb-nmm4",
     "short_id": "hy9g22",
     "name": "EMC",
+    "kind": "emc",
     "material_class": "electrolyte_solvent",
     "formula": "C4H8O3",
     "chemistry_family": "carbonate-solvent",

--- a/src/battinfo/data/examples/material-spec/k0dr-c32c-yrvy-bbfr.json
+++ b/src/battinfo/data/examples/material-spec/k0dr-c32c-yrvy-bbfr.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/k0dr-c32c-yrvy-bbfr",
     "short_id": "k0drc3",
     "name": "Alumina",
+    "kind": "alumina",
     "material_class": "coating",
     "formula": "Al2O3",
     "chemistry_family": "ceramic-oxide",

--- a/src/battinfo/data/examples/material-spec/kg0e-vqce-3439-bnfk.json
+++ b/src/battinfo/data/examples/material-spec/kg0e-vqce-3439-bnfk.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/kg0e-vqce-3439-bnfk",
     "short_id": "kg0evq",
     "name": "Zinc",
+    "kind": "zinc",
     "material_class": "metal_electrode",
     "electrode_polarity": "negative",
     "formula": "Zn",

--- a/src/battinfo/data/examples/material-spec/npa4-0dnw-evyh-hhdm.json
+++ b/src/battinfo/data/examples/material-spec/npa4-0dnw-evyh-hhdm.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/npa4-0dnw-evyh-hhdm",
     "short_id": "npa40d",
     "name": "NMC811",
+    "kind": "nmc811",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",

--- a/src/battinfo/data/examples/material-spec/qwae-x6cg-c61k-njw7.json
+++ b/src/battinfo/data/examples/material-spec/qwae-x6cg-c61k-njw7.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/qwae-x6cg-c61k-njw7",
     "short_id": "qwaex6",
     "name": "LMFP",
+    "kind": "lmfp",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiMn0.7Fe0.3PO4",

--- a/src/battinfo/data/examples/material-spec/r5xt-4hrh-jm2k-yg4m.json
+++ b/src/battinfo/data/examples/material-spec/r5xt-4hrh-jm2k-yg4m.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/r5xt-4hrh-jm2k-yg4m",
     "short_id": "r5xt4h",
     "name": "Carbon black",
+    "kind": "carbon_black",
     "material_class": "conductive_additive",
     "formula": "C",
     "chemistry_family": "amorphous-carbon",

--- a/src/battinfo/data/examples/material-spec/s2m9-ksma-nb61-8tpa.json
+++ b/src/battinfo/data/examples/material-spec/s2m9-ksma-nb61-8tpa.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/s2m9-ksma-nb61-8tpa",
     "short_id": "s2m9ks",
     "name": "NMC622",
+    "kind": "nmc622",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiNi0.6Mn0.2Co0.2O2",

--- a/src/battinfo/data/examples/material-spec/s9h8-dfbw-zs4k-2qk8.json
+++ b/src/battinfo/data/examples/material-spec/s9h8-dfbw-zs4k-2qk8.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/s9h8-dfbw-zs4k-2qk8",
     "short_id": "s9h8df",
     "name": "KOH",
+    "kind": "koh",
     "material_class": "electrolyte_salt",
     "formula": "KOH",
     "chemistry_family": "alkali-hydroxide",

--- a/src/battinfo/data/examples/material-spec/shzh-t2jt-wwqv-k54m.json
+++ b/src/battinfo/data/examples/material-spec/shzh-t2jt-wwqv-k54m.json
@@ -4,6 +4,7 @@
     "id": "https://w3id.org/battinfo/spec/shzh-t2jt-wwqv-k54m",
     "short_id": "shzht2",
     "name": "LCO",
+    "kind": "lco",
     "material_class": "active_material",
     "electrode_polarity": "positive",
     "formula": "LiCoO2",

--- a/src/battinfo/data/schemas/material-spec.schema.json
+++ b/src/battinfo/data/schemas/material-spec.schema.json
@@ -35,6 +35,15 @@
           "minLength": 1,
           "description": "Human-readable material name / grade (e.g. 'LFP', 'Graphite', 'NMC811', 'PVDF')."
         },
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required Level-1 MaterialKind key from the curated material_kinds vocabulary (e.g. 'graphite', 'lfp', 'nmc811'). The aggregation axis of the Battery Genome; resolves to the kind's chemical-substance class IRI. An unknown kind is rejected at save time. See battinfo.materials.material_kind_keys()."
+        },
+        "grade": {
+          "type": "string",
+          "description": "Manufacturer grade / product version (e.g. 'grade X', 'v2'). Part of spec identity together with manufacturer and product."
+        },
         "material_class": {
           "type": "string",
           "enum": [
@@ -172,6 +181,22 @@
       "items": {
         "type": "string"
       }
+    },
+    "funding": {
+      "$ref": "#/$defs/Funding"
+    },
+    "contributor": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Person"
+      },
+      "minItems": 1,
+      "description": "People who contributed this record to the platform (attribution/provenance). Each is a schema:Person; an ORCID may be given in same_as. Stamped by ws.save."
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1,
+      "description": "License under which this record is released, as an SPDX identifier (e.g. \"cc-by-4.0\") or a URL. Stamped from the workspace default (ws.license) and emitted as dcterms:license in JSON-LD."
     }
   },
   "$defs": {
@@ -227,6 +252,99 @@
           "$ref": "#/$defs/Organization"
         }
       ]
+    },
+    "Funding": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Funding project (grant) under which the record was produced. Maps to schema:funding / schema:Grant in JSON-LD.",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "type": {
+          "const": "Grant"
+        },
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "identifier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "acronym": {
+          "type": "string"
+        },
+        "program": {
+          "type": "string"
+        },
+        "funder": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "Organization"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "same_as": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    },
+    "Person": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "const": "Person"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "given_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "same_as": {
+          "type": "string",
+          "format": "uri"
+        },
+        "affiliation": {
+          "$ref": "#/$defs/Organization"
+        }
+      }
     },
     "MaterialRef": {
       "description": "Reference to another material by canonical material-spec IRI and/or a free-text name.",

--- a/src/battinfo/data/schemas/material.schema.json
+++ b/src/battinfo/data/schemas/material.schema.json
@@ -50,8 +50,23 @@
         "received_date": {
           "$ref": "#/$defs/FlexDate"
         },
+        "opened_date": {
+          "$ref": "#/$defs/FlexDate",
+          "description": "Date this lot was first opened / put into use."
+        },
         "expires_at": {
           "$ref": "#/$defs/FlexDate"
+        },
+        "amount": {
+          "$ref": "modules/common/quantity.schema.json",
+          "description": "Quantity of this lot on hand or consumed (e.g. mass in g, volume in mL)."
+        },
+        "storage": {
+          "type": "string",
+          "description": "Storage conditions for this lot (e.g. 'argon glovebox', 'dry room, -40 degC dew point')."
+        },
+        "processing": {
+          "$ref": "#/$defs/Processing"
         },
         "datasets": {
           "type": "array",
@@ -140,9 +155,50 @@
       "items": {
         "type": "string"
       }
+    },
+    "funding": {
+      "$ref": "#/$defs/Funding"
+    },
+    "contributor": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Person"
+      },
+      "minItems": 1,
+      "description": "People who contributed this record to the platform (attribution/provenance). Each is a schema:Person; an ORCID may be given in same_as. Stamped by ws.save."
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1,
+      "description": "License under which this record is released, as an SPDX identifier (e.g. \"cc-by-4.0\") or a URL. Stamped from the workspace default (ws.license) and emitted as dcterms:license in JSON-LD."
     }
   },
   "$defs": {
+    "Processing": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How this lot was processed into an electrode/coating. Processing is a property of the instance/build, NOT of the spec identity (aqueous vs NMP is not a distinct product).",
+      "properties": {
+        "route": {
+          "type": "string",
+          "enum": [
+            "aqueous",
+            "nmp",
+            "dry",
+            "other"
+          ],
+          "description": "Processing route: water-based (aqueous), NMP solvent-based, solvent-free (dry), or other."
+        },
+        "solvent": {
+          "type": "string",
+          "description": "Processing solvent (e.g. 'water', 'NMP')."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Free-text processing detail (mixing, drying, calendering, ...)."
+        }
+      }
+    },
     "UnixTime": {
       "type": "integer",
       "minimum": 0,
@@ -234,6 +290,99 @@
           "$ref": "#/$defs/Organization"
         }
       ]
+    },
+    "Funding": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Funding project (grant) under which the record was produced. Maps to schema:funding / schema:Grant in JSON-LD.",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "type": {
+          "const": "Grant"
+        },
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "identifier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "acronym": {
+          "type": "string"
+        },
+        "program": {
+          "type": "string"
+        },
+        "funder": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "Organization"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "same_as": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    },
+    "Person": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "const": "Person"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "given_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "same_as": {
+          "type": "string",
+          "format": "uri"
+        },
+        "affiliation": {
+          "$ref": "#/$defs/Organization"
+        }
+      }
     }
   }
 }

--- a/src/battinfo/data/vocab/material_kinds.json
+++ b/src/battinfo/data/vocab/material_kinds.json
@@ -1,0 +1,279 @@
+{
+  "version": "0.1.0",
+  "description": "Curated, shipped vocabulary of generic material kinds (Level 1 of the three-level materials model). A kind is the universal reference identity of a material (graphite, LFP, NMC811, ...): the aggregation axis of the Battery Genome. Every material-spec carries a required `kind`; every material instance links a spec. Each kind's canonical semantic identity is its chemical-substance domain-ontology class IRI (`chemsub`); the battinfo `key` is the ergonomic handle. Kinds missing an ontology class omit `chemsub` and go on the ontology-additions backlog (labeled ns# fallback until upstreamed). This is a governance-by-PR vocabulary, NOT a user-authored record type. Curation to the full set (electrolytes, binders, separators, current collectors, further actives) is a follow-up PR; this file bootstraps the contract and seeds it. `chemsub` values use the domain-chemical-substance namespace (https://w3id.org/emmo/domain/chemical-substance#). `emmo` values are the domain-battery class local-name used to type JSON-LD nodes (must resolve in the bundled domain-battery context). `reference_properties` carry curated, citable generic anchors (value/unit/citation) that the genome compares datasheet- and measurement-reported distributions against; present only where a citable source exists.",
+  "families": [
+    "active_anode",
+    "active_cathode",
+    "binder",
+    "conductive_additive",
+    "electrolyte_solvent",
+    "electrolyte_salt",
+    "separator_material",
+    "current_collector_material",
+    "other"
+  ],
+  "kinds": {
+    "graphite": {
+      "label": "Graphite",
+      "family": "active_anode",
+      "formula": "C",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303",
+      "emmo": "Graphite",
+      "aliases": ["graphite", "natural graphite", "synthetic graphite", "mesocarbon microbead", "mcmb", "gr", "c"],
+      "reference_properties": {
+        "specific_capacity": {"value": 372, "unit": "mAh/g", "citation": "https://doi.org/10.1039/D0SE00175A"},
+        "density": {"value": 2.26, "unit": "g/cm3", "citation": "https://doi.org/10.1039/D0SE00175A"}
+      }
+    },
+    "silicon": {
+      "label": "Silicon",
+      "family": "active_anode",
+      "formula": "Si",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733",
+      "emmo": "Silicon",
+      "aliases": ["silicon", "si", "nano-silicon", "silicon nanoparticles"],
+      "reference_properties": {
+        "specific_capacity": {"value": 3579, "unit": "mAh/g", "citation": "https://doi.org/10.1149/1.1652421"}
+      }
+    },
+    "silicon_graphite": {
+      "label": "Silicon-graphite composite",
+      "family": "active_anode",
+      "formula": "Si/C",
+      "aliases": ["silicon graphite", "silicon-graphite", "si/gr", "si-gr", "silicon/graphite", "sigr", "graphite-silicon"]
+    },
+    "lithium_metal": {
+      "label": "Lithium metal",
+      "family": "active_anode",
+      "formula": "Li",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c109ca45_08c7_4436_a818_a9c575785e2f",
+      "aliases": ["lithium metal", "lithium", "li metal", "li", "metallic lithium", "lithium foil"],
+      "reference_properties": {
+        "specific_capacity": {"value": 3862, "unit": "mAh/g", "citation": "https://doi.org/10.1038/nnano.2017.16"}
+      }
+    },
+    "zinc": {
+      "label": "Zinc metal",
+      "family": "active_anode",
+      "formula": "Zn",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc",
+      "emmo": "Zinc",
+      "aliases": ["zinc", "zn", "zinc metal", "zinc foil"]
+    },
+    "lfp": {
+      "label": "Lithium iron phosphate (LFP)",
+      "family": "active_cathode",
+      "formula": "LiFePO4",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90",
+      "emmo": "LithiumIronPhosphate",
+      "aliases": ["lfp", "lifepo4", "lithium iron phosphate", "lithium iron phosphate (lfp)", "olivine lfp"],
+      "reference_properties": {
+        "specific_capacity": {"value": 170, "unit": "mAh/g", "citation": "https://doi.org/10.1149/1.1837571"}
+      }
+    },
+    "lmfp": {
+      "label": "Lithium manganese iron phosphate (LMFP)",
+      "family": "active_cathode",
+      "formula": "LiMnxFe1-xPO4",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_40c605fd_4e47_4e90_a055_185f749d834c",
+      "emmo": "LithiumManganeseIronPhosphate",
+      "aliases": ["lmfp", "lithium manganese iron phosphate", "limnfepo4"]
+    },
+    "lco": {
+      "label": "Lithium cobalt oxide (LCO)",
+      "family": "active_cathode",
+      "formula": "LiCoO2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af",
+      "emmo": "LithiumCobaltOxide",
+      "aliases": ["lco", "licoo2", "lithium cobalt oxide"]
+    },
+    "lnmo": {
+      "label": "Lithium nickel manganese oxide (LNMO)",
+      "family": "active_cathode",
+      "formula": "LiNi0.5Mn1.5O4",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f3e7979a_e3ef_450a_8762_7d8778afe478",
+      "emmo": "LithiumNickelManganeseOxide",
+      "aliases": ["lnmo", "lithium nickel manganese oxide", "high-voltage spinel", "lini0.5mn1.5o4", "spinel lnmo"]
+    },
+    "nmc111": {
+      "label": "NMC111 (LiNi1/3Mn1/3Co1/3O2)",
+      "family": "active_cathode",
+      "formula": "LiNi0.33Mn0.33Co0.33O2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
+      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "aliases": ["nmc111", "nmc 111", "nmc333", "ncm111", "lini0.33mn0.33co0.33o2", "lini1/3mn1/3co1/3o2"]
+    },
+    "nmc532": {
+      "label": "NMC532 (LiNi0.5Mn0.3Co0.2O2)",
+      "family": "active_cathode",
+      "formula": "LiNi0.5Mn0.3Co0.2O2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
+      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "aliases": ["nmc532", "nmc 532", "ncm532", "lini0.5mn0.3co0.2o2"]
+    },
+    "nmc622": {
+      "label": "NMC622 (LiNi0.6Mn0.2Co0.2O2)",
+      "family": "active_cathode",
+      "formula": "LiNi0.6Mn0.2Co0.2O2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
+      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "aliases": ["nmc622", "nmc 622", "ncm622", "lini0.6mn0.2co0.2o2"]
+    },
+    "nmc811": {
+      "label": "NMC811 (LiNi0.8Mn0.1Co0.1O2)",
+      "family": "active_cathode",
+      "formula": "LiNi0.8Mn0.1Co0.1O2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
+      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "aliases": ["nmc811", "nmc 811", "ncm811", "lini0.8mn0.1co0.1o2"]
+    },
+    "nca": {
+      "label": "NCA (lithium nickel cobalt aluminium oxide)",
+      "family": "active_cathode",
+      "formula": "LiNixCoyAlzO2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_cd17ca33_ae3d_4738_8930_547673bf6c1f",
+      "emmo": "LithiumNickelCobaltAluminiumOxide",
+      "aliases": ["nca", "lithium nickel cobalt aluminium oxide", "lithium nickel cobalt aluminum oxide"]
+    },
+    "mno2": {
+      "label": "Manganese dioxide",
+      "family": "active_cathode",
+      "formula": "MnO2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618",
+      "aliases": ["mno2", "manganese dioxide", "manganese(iv) oxide", "emd"]
+    },
+    "pvdf": {
+      "label": "Polyvinylidene fluoride (PVDF)",
+      "family": "binder",
+      "formula": "(C2H2F2)n",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8",
+      "emmo": "PolyvinylideneFluoride",
+      "aliases": ["pvdf", "polyvinylidene fluoride", "polyvinylidene difluoride", "kynar"]
+    },
+    "cmc": {
+      "label": "Carboxymethyl cellulose (CMC)",
+      "family": "binder",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51",
+      "emmo": "CarboxymethylCellulose",
+      "aliases": ["cmc", "carboxymethyl cellulose", "carboxymethylcellulose", "sodium cmc"]
+    },
+    "sbr": {
+      "label": "Styrene-butadiene rubber (SBR)",
+      "family": "binder",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_210edf30_ad63_438c_97db_f817942db49b",
+      "emmo": "StyreneButadiene",
+      "aliases": ["sbr", "styrene butadiene rubber", "styrene-butadiene", "styrene-butadiene rubber"]
+    },
+    "carbon_black": {
+      "label": "Carbon black",
+      "family": "conductive_additive",
+      "formula": "C",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0a5cb747_60cf_4929_a54a_712c54b49f3b",
+      "emmo": "CarbonBlack",
+      "aliases": ["carbon black", "cb", "super p", "super c65", "c65", "c45", "ketjenblack", "acetylene black"]
+    },
+    "lipf6": {
+      "label": "Lithium hexafluorophosphate (LiPF6)",
+      "family": "electrolyte_salt",
+      "formula": "LiPF6",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771",
+      "emmo": "LithiumHexafluorophosphate",
+      "aliases": ["lipf6", "lithium hexafluorophosphate"]
+    },
+    "koh": {
+      "label": "Potassium hydroxide (KOH)",
+      "family": "electrolyte_salt",
+      "formula": "KOH",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_ccdce7d4_b695_4871_84c2_13679807d077",
+      "emmo": "PotassiumHydroxide",
+      "aliases": ["koh", "potassium hydroxide"]
+    },
+    "ec": {
+      "label": "Ethylene carbonate (EC)",
+      "family": "electrolyte_solvent",
+      "formula": "C3H4O3",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_57339d90_0553_4a96_8da9_ff6c3684e226",
+      "emmo": "EthyleneCarbonate",
+      "aliases": ["ec", "ethylene carbonate"]
+    },
+    "emc": {
+      "label": "Ethyl methyl carbonate (EMC)",
+      "family": "electrolyte_solvent",
+      "formula": "C4H8O3",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_bb20bdea_343c_4911_8c45_37fc1077d22f",
+      "emmo": "EthylMethylCarbonate",
+      "aliases": ["emc", "ethyl methyl carbonate", "ethylmethyl carbonate"]
+    },
+    "dmc": {
+      "label": "Dimethyl carbonate (DMC)",
+      "family": "electrolyte_solvent",
+      "formula": "C3H6O3",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c4a7d7bd_497e_457e_b858_ff73254266d0",
+      "emmo": "DimethylCarbonate",
+      "aliases": ["dmc", "dimethyl carbonate", "dimethylcarbonate"]
+    },
+    "pc": {
+      "label": "Propylene carbonate (PC)",
+      "family": "electrolyte_solvent",
+      "formula": "C4H6O3",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156",
+      "emmo": "PropyleneCarbonate",
+      "aliases": ["pc", "propylene carbonate"]
+    },
+    "fec": {
+      "label": "Fluoroethylene carbonate (FEC)",
+      "family": "electrolyte_solvent",
+      "formula": "C3H3FO3",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_20004d19_02cf_4667_a09f_b5c595b44b1f",
+      "emmo": "FluoroethyleneCarbonate",
+      "aliases": ["fec", "fluoroethylene carbonate"]
+    },
+    "vc": {
+      "label": "Vinylene carbonate (VC)",
+      "family": "electrolyte_solvent",
+      "formula": "C3H2O3",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_31d0d139_7b45_4d1e_8603_92cc12da2fad",
+      "emmo": "VinyleneCarbonate",
+      "aliases": ["vc", "vinylene carbonate"]
+    },
+    "polypropylene": {
+      "label": "Polypropylene (PP) separator",
+      "family": "separator_material",
+      "formula": "(C3H6)n",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b",
+      "emmo": "Polypropylene",
+      "aliases": ["polypropylene", "pp", "pp separator"]
+    },
+    "polyethylene": {
+      "label": "Polyethylene (PE) separator",
+      "family": "separator_material",
+      "formula": "(C2H4)n",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_79220ea3_3426_47a0_9b41_33012d565fc2",
+      "emmo": "Polyethylene",
+      "aliases": ["polyethylene", "pe", "pe separator"]
+    },
+    "aluminium": {
+      "label": "Aluminium current collector",
+      "family": "current_collector_material",
+      "formula": "Al",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4",
+      "emmo": "Aluminium",
+      "aliases": ["aluminium", "aluminum", "al", "aluminium foil", "aluminum foil", "al foil"]
+    },
+    "copper": {
+      "label": "Copper current collector",
+      "family": "current_collector_material",
+      "formula": "Cu",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9",
+      "emmo": "Copper",
+      "aliases": ["copper", "cu", "copper foil", "cu foil"]
+    },
+    "alumina": {
+      "label": "Alumina (Al2O3) coating",
+      "family": "other",
+      "formula": "Al2O3",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_a2b46543_4d0f_488a_b51a_7ed3a4149170",
+      "aliases": ["alumina", "aluminium oxide", "aluminum oxide", "al2o3", "al2o3 particles"]
+    }
+  }
+}

--- a/src/battinfo/materials.py
+++ b/src/battinfo/materials.py
@@ -9,10 +9,96 @@ referenced from many cells (dedup), without rewiring the cell-spec fleet.
 
 from __future__ import annotations
 
+import json
 import warnings
+from functools import lru_cache
+from importlib import resources
+from pathlib import Path
 from typing import Any, Mapping
 
 from battinfo._workspace import _stable_uid
+
+# ── Level 1: MaterialKind vocabulary ────────────────────────────────────────────
+#
+# Kinds are a shipped, versioned, curated vocabulary (governed by PR), NOT a
+# user-authored record type — the genome's cross-dataset promise requires every
+# publisher to converge on ONE identifier for "graphite". A material-spec's
+# required ``kind`` resolves through here (aliases included); an unresolvable kind
+# is a save-time error listing the valid keys, the same UX as any controlled field.
+
+
+def _load_material_kinds_file() -> dict[str, Any]:
+    packaged_path = resources.files("battinfo").joinpath("data", "vocab", "material_kinds.json")
+    if packaged_path.is_file():
+        with packaged_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    repo_root = Path(__file__).resolve().parents[2]
+    asset_path = repo_root.joinpath("src", "battinfo", "data", "vocab", "material_kinds.json")
+    if asset_path.is_file():
+        with asset_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    return {"version": "0", "families": [], "kinds": {}}
+
+
+@lru_cache(maxsize=1)
+def _material_kinds_data() -> dict[str, Any]:
+    return _load_material_kinds_file()
+
+
+@lru_cache(maxsize=1)
+def _material_kind_alias_index() -> dict[str, str]:
+    """Map every lowercased key/label/alias to its canonical kind key."""
+    index: dict[str, str] = {}
+    kinds = _material_kinds_data().get("kinds", {})
+    for key, entry in kinds.items():
+        index[key.lower()] = key
+        label = entry.get("label")
+        if isinstance(label, str) and label.strip():
+            index.setdefault(label.strip().lower(), key)
+        for alias in entry.get("aliases", []) or []:
+            if isinstance(alias, str) and alias.strip():
+                index.setdefault(alias.strip().lower(), key)
+    return index
+
+
+def material_kinds() -> dict[str, Any]:
+    """Return the curated MaterialKind vocabulary (Level 1), as a deep copy.
+
+    Shape: ``{"version", "families": [...], "kinds": {"<key>": {"label",
+    "family", "formula"?, "chemsub"?, "emmo"?, "aliases": [...],
+    "reference_properties"?}}}``. ``chemsub`` is the material's canonical
+    semantic identity — its chemical-substance domain-ontology class IRI.
+    """
+    import copy
+
+    return copy.deepcopy(_material_kinds_data())
+
+
+def material_kind_keys() -> list[str]:
+    """Sorted list of canonical MaterialKind keys (the valid ``kind`` values)."""
+    return sorted(_material_kinds_data().get("kinds", {}))
+
+
+def resolve_material_kind(value: Any) -> str | None:
+    """Resolve a kind key / label / alias to its canonical key, or ``None``.
+
+    Case-insensitive; tolerant of the aliases in the vocabulary ("NMC 811",
+    "LiNi0.8Mn0.1Co0.1O2", "Si/Gr"). Returns ``None`` for an unknown value so
+    callers can raise a helpful save-time error.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return _material_kind_alias_index().get(value.strip().lower())
+
+
+def material_kind(value: Any) -> dict[str, Any] | None:
+    """Return the vocabulary entry for a kind key/alias (with its canonical key), or ``None``."""
+    key = resolve_material_kind(value)
+    if key is None:
+        return None
+    entry = dict(_material_kinds_data()["kinds"][key])
+    entry["key"] = key
+    return entry
 
 # Cell-cell-specific composition fractions are not intrinsic material properties,
 # so they are dropped when lifting an embedded holder to a standalone spec.

--- a/src/battinfo/transform/json_to_jsonld.py
+++ b/src/battinfo/transform/json_to_jsonld.py
@@ -1868,13 +1868,36 @@ _MATERIAL_PROPERTY_TERMS: dict[str, str] = {
 
 
 def _material_node(body: dict[str, Any]) -> dict[str, Any]:
-    """Build a domain-battery JSON-LD node for a material spec/instance body."""
+    """Build a domain-battery JSON-LD node for a material spec/instance body.
+
+    A material-spec's ``kind`` is the authoritative semantic anchor: it types the
+    node from the curated vocabulary (kind -> EMMO class) and links the kind's
+    chemical-substance class IRI via ``schema:sameAs``. Where the kind carries no
+    EMMO class (an ontology-additions gap), fall back to a labeled
+    ``schema:ChemicalSubstance`` node still carrying the chemsub link. When no
+    kind is present (e.g. an embedded/imported material), fall back to resolving
+    the name through the alias table, preserving prior behaviour.
+    """
     node: dict[str, Any] = {}
     if isinstance(body.get("id"), str):
         node["@id"] = body["id"]
     name = body.get("name")
-    emmo_class = _material_emmo_class(name) if isinstance(name, str) and name else None
+    kind_entry = None
+    kind = body.get("kind")
+    if isinstance(kind, str) and kind:
+        from battinfo.materials import material_kind
+
+        kind_entry = material_kind(kind)
+    emmo_class = None
+    same_as = None
+    if kind_entry is not None:
+        emmo_class = kind_entry.get("emmo")
+        same_as = kind_entry.get("chemsub")
+    if emmo_class is None and isinstance(name, str) and name:
+        emmo_class = _material_emmo_class(name)
     node["@type"] = emmo_class or "schema:ChemicalSubstance"
+    if same_as:
+        node["schema:sameAs"] = {"@id": same_as}
     if isinstance(name, str) and name:
         node["schema:name"] = name
     if isinstance(body.get("formula"), str) and body["formula"]:

--- a/src/battinfo/validate/semantic.py
+++ b/src/battinfo/validate/semantic.py
@@ -337,6 +337,59 @@ def _validate_controlled_values(
             )
 
 
+def _validate_material_kind(
+    doc: dict[str, Any],
+    issues: list[ValidationIssue],
+    resource_type: str | None,
+    issue_severity: str,
+) -> None:
+    """A material-spec's ``kind`` must resolve to the curated vocabulary.
+
+    The kind is the Battery Genome's aggregation axis, so an authored spec is
+    required to carry one. It is enforced here rather than as a JSON-schema
+    required field so tolerant flows (lifting embedded materials, interop import)
+    still structurally validate while the strict authoring gate rejects a spec
+    with no kind:
+
+    - kind present but unknown -> hard error listing the valid keys (the
+      save-time rejection); create_material_spec also raises on an explicit
+      unknown kind, so this is the backstop for hand-built records;
+    - kind missing -> the policy's hard severity (error under strict / ws.save,
+      warning under default) so blessed authoring requires it.
+    """
+    spec = doc.get("material_spec")
+    if not isinstance(spec, Mapping):
+        return
+    from battinfo.materials import material_kind_keys, resolve_material_kind
+
+    kind = spec.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        _append_issue(
+            issues,
+            code="semantic.material_kind_missing",
+            severity=issue_severity,
+            path="material_spec.kind",
+            message=(
+                "material spec has no kind. Set a Level-1 kind from the curated "
+                f"vocabulary. Valid kinds: {', '.join(material_kind_keys())}."
+            ),
+            resource_type=resource_type,
+        )
+        return
+    if resolve_material_kind(kind) is None:
+        _append_issue(
+            issues,
+            code="semantic.material_kind_unknown",
+            severity="error",
+            path="material_spec.kind",
+            message=(
+                f"unknown material kind '{kind}'. Valid kinds: "
+                f"{', '.join(material_kind_keys())}."
+            ),
+            resource_type=resource_type,
+        )
+
+
 def _validate_size_code(
     doc: dict[str, Any],
     issues: list[ValidationIssue],
@@ -801,6 +854,7 @@ def validate_semantic_report(
 
     _validate_identifier_consistency(doc, issues, resource_type, hard_issue_severity)
     _validate_controlled_values(doc, issues, resource_type)
+    _validate_material_kind(doc, issues, resource_type, hard_issue_severity)
     _validate_size_code(doc, issues, resource_type, hard_issue_severity)
     # Non-finite numerics are invalid anywhere in the record (RFC 8259); walk the
     # whole doc so nested quantities (electrode coating, etc.) are caught, not just

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -999,7 +999,25 @@ _SAVE_DISPLAY: list[tuple[str, str]] = [
     ("test_specs", "test spec"),
     ("tests", "test"),
     ("datasets", "dataset"),
+    ("material_specs", "material spec"),
+    ("materials", "material"),
 ]
+
+
+def _dedupe_records_by_id(records: list[dict], candidate: dict, body_key: str) -> list[dict]:
+    """Append *candidate* unless a record with the same canonical id is present.
+
+    Re-adding an identical (content-derived) material in one session is a no-op —
+    the deterministic id makes the duplicate detectable — while a genuinely
+    edited record with the same id replaces the earlier one so ws.save writes the
+    latest version.
+    """
+    cand_id = candidate.get(body_key, {}).get("id")
+    if cand_id is None:
+        return [*records, candidate]
+    out = [r for r in records if r.get(body_key, {}).get("id") != cand_id]
+    out.append(candidate)
+    return out
 
 # Canonical BDF column names — the targets for convert_csv() hints.  This is a
 # discovery aid for users; the authoritative mapping lives in interop/battdat.py.
@@ -1196,6 +1214,14 @@ class AuthoringWorkspace:
         # paths written by the most recent ws.save() — submit() uses this to
         # avoid re-submitting records from previous sessions in the same directory
         self._session_paths: set[Path] = set()
+        # First-class material queues (Level 2 spec / Level 3 instance). Materials
+        # are not engine model objects, so the AuthoringWorkspace holds their
+        # canonical records and writes them in ws.save() through the SAME stamp
+        # path as every other record. Keyed spec index lets ws.add("material")
+        # resolve spec= by name/short_id/IRI without ws._ws.
+        self._material_specs: builtins.list[dict] = []
+        self._materials: builtins.list[dict] = []
+        self._material_specs_by_ref: dict[str, dict] = {}
         # workspace-level funding project (grant); lazily loaded from
         # .battinfo/workspace.json on first access via _get_project()
         self._project_ref: ProjectRef | None = None
@@ -2507,6 +2533,10 @@ class AuthoringWorkspace:
         rt_key = str(record_type).strip().lower().replace("_", "-")
         if rt_key == "equipment":
             return self._add_equipment(**kwargs)
+        if rt_key == "material-spec":
+            return self._add_material_spec(**kwargs)
+        if rt_key == "material":
+            return self._add_material(**kwargs)
         try:
             rt = _canon_type(record_type)
         except ValueError:
@@ -2516,10 +2546,13 @@ class AuthoringWorkspace:
         if rt == "test":
             return self._add_tests(**kwargs)
         raise ValueError(
-            f"add() supports type 'cell', 'test', and 'equipment' (got {record_type!r}). "
+            f"add() supports type 'cell', 'test', 'equipment', 'material_spec', and "
+            f"'material' (got {record_type!r}). "
             "Author a cell-spec/test-spec with ws.load(<draft file>); attach datasets "
             "via ws.add('test', data=...); register lab equipment via "
-            "ws.add('equipment', spec=..., serial_number=...)."
+            "ws.add('equipment', spec=..., serial_number=...); author materials via "
+            "ws.add('material_spec', name=..., kind=...) and "
+            "ws.add('material', spec=..., lot=...)."
         )
 
     def save(self, validation_policy: str = "strict", mode: str = "upsert") -> dict:
@@ -2542,18 +2575,27 @@ class AuthoringWorkspace:
         # file afterwards — lets an unchanged, already-stamped re-save report
         # [unchanged] and skip the write entirely.
         stamp_fn, stamp_counts = self._record_stamp()
+        # Materials are written first (same stamp path) so the engine's index
+        # rebuild picks them up and a material instance's spec reference resolves
+        # on disk.
+        material_results = self._save_materials(
+            mode=mode, validation_policy=validation_policy, stamp=stamp_fn
+        )
         result = self._ws.save(
             mode=mode,
             resolve_references=False,
             validation_policy=validation_policy,
             stamp=stamp_fn,
         )
+        result["material_specs"] = material_results["material_specs"]
+        result["materials"] = material_results["materials"]
         # How many records the funding block actually reached this save: every
         # candidate is stamped, but only newly-created or genuinely-changed records
         # are written — an unchanged re-save reaches zero, so it prints nothing.
         stamped = 0
         if stamp_counts["funding"]:
-            for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs"):
+            for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs",
+                        "material_specs", "materials"):
                 for item in result.get(key, []):
                     if isinstance(item, dict) and (
                         item.get("status") == "created" or item.get("content_changed")
@@ -2561,7 +2603,8 @@ class AuthoringWorkspace:
                         stamped += 1
         # Track the exact files written so submit() only sends this session's work.
         self._session_paths = set()
-        for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs"):
+        for key in ("cell_specs", "cell_instances", "tests", "datasets", "test_specs",
+                    "material_specs", "materials"):
             for item in result.get(key, []):
                 p = item.get("path") if isinstance(item, dict) else str(item)
                 if p:
@@ -2585,6 +2628,14 @@ class AuthoringWorkspace:
         for ds_obj in self._ws.datasets:
             if ds_obj.id:
                 name_by_id[ds_obj.id] = ds_obj.name or "dataset"
+        for ms in self._material_specs:
+            body = ms.get("material_spec", {})
+            if body.get("id"):
+                name_by_id[body["id"]] = body.get("name") or "material spec"
+        for m in self._materials:
+            body = m.get("material", {})
+            if body.get("id"):
+                name_by_id[body["id"]] = body.get("lot_id") or body.get("name") or "material"
 
         total = sum(len(result.get(key, [])) for key, _ in _SAVE_DISPLAY)
         print(f"Saved {total} record(s) under {self._ws.source_root}:")
@@ -2612,6 +2663,38 @@ class AuthoringWorkspace:
             # as mockery (red-team W1.3).
             print("\n  Next: ws.list(verbose=True) to inspect, or ws.publish() to publish.")
         return result
+
+    def _save_materials(
+        self, *, mode: str, validation_policy: str, stamp: Any = None
+    ) -> dict:
+        """Write queued material specs then instances through the shared stamp path.
+
+        Materials are not engine model objects, so they are persisted here rather
+        than by ``self._ws.save``. They flow through the SAME ``stamp`` callback as
+        every other record (PR #324 pre-compare stamp), so funding / contributor /
+        license reach material records too (fixes readiness H2), and an unchanged
+        already-stamped re-save is reported ``unchanged`` — no compare-before-stamp
+        bug. Specs are written before instances so an instance's spec reference
+        resolves on disk under strict validation.
+        """
+        from battinfo.api import save_material, save_material_spec  # noqa: PLC0415
+
+        source_root = self._ws.source_root
+        spec_results = [
+            save_material_spec(
+                rec, source_root=source_root, mode=mode, resolve_references=False,
+                validation_policy=validation_policy, stamp=stamp,
+            )
+            for rec in self._material_specs
+        ]
+        material_results = [
+            save_material(
+                rec, source_root=source_root, mode=mode, resolve_references=False,
+                validation_policy=validation_policy, stamp=stamp,
+            )
+            for rec in self._materials
+        ]
+        return {"material_specs": spec_results, "materials": material_results}
 
     def _rel_to_root(self, path: str) -> str:
         """Render *path* relative to the workspace root for compact display."""
@@ -5682,6 +5765,23 @@ class AuthoringWorkspace:
             catalog_node["schema:keywords"] = sorted(_kw)
             catalog_node["dcat:keyword"]    = sorted(_kw)   # DCAT mirror of schema:keywords
 
+        # Standalone material records (Level 2 spec / Level 3 instance) become
+        # first-class deposit nodes: the domain-battery emitter types each by its
+        # kind (kind -> EMMO class + chemical-substance sameAs, labeled fallback
+        # where a class is missing), and the consolidated context resolves those
+        # terms. Cells reference these via material_spec_id on their electrode
+        # components; publishing the standalone nodes makes the links resolve.
+        material_nodes: builtins.list[dict] = []
+        for _mkey in ("material-spec", "material"):
+            for _mrec in record_sets.get(_mkey, []):
+                if not isinstance(_mrec, dict):
+                    continue
+                from battinfo.transform.json_to_jsonld import to_jsonld  # noqa: PLC0415
+
+                _mg = (to_jsonld(_mrec, target="domain-battery").get("@graph") or [])
+                if _mg:
+                    material_nodes.append(dict(_mg[0]))
+
         graph = (
             [catalog_node]
             + ([provider_node] if provider_node else [])
@@ -5691,6 +5791,7 @@ class AuthoringWorkspace:
             + test_spec_nodes
             + instance_nodes
             + test_nodes
+            + material_nodes
             # Equipment provenance: the units/channels the tests actually ran on,
             # so hasTestEquipment / prov:used resolve to described nodes.
             + [equipment_nodes[k] for k in sorted(equipment_nodes)]
@@ -6801,6 +6902,85 @@ class AuthoringWorkspace:
             print(f"  channels:       {n_channels} registered  ({unit_label}/CH1 .. {unit_label}/CH{n_channels})")
             print(f"\n  Next: ws.add('test', ..., channel='{unit_label}/CH1') to attach a test.")
         return [equipment_record, *channel_records]
+
+    def _add_material_spec(self, name: str | None = None, **kwargs) -> builtins.list:
+        """Author a first-class material spec (Level 2), queued for ws.save().
+
+        ``ws.add("material_spec", name="Targray NMC811", kind="nmc811",
+        manufacturer="Targray", grade="grade X", property={...})``
+
+        The IRI is content-derived from (manufacturer, product, grade): re-adding
+        the same product is a no-op, never a duplicate. ``kind`` is required and
+        resolved against the curated vocabulary (aliases welcome); an unknown kind
+        raises listing the valid keys. Attribution (contributor/license/funding)
+        is stamped onto the record by ws.save, like every other record type.
+        """
+        from battinfo.api import create_material_spec  # noqa: PLC0415
+
+        if not name and not kwargs.get("id") and not kwargs.get("uid"):
+            raise ValueError(
+                "ws.add('material_spec', ...) needs name=... (and kind=...). "
+                "Example: ws.add('material_spec', name='LFP', kind='lfp')."
+            )
+        record = create_material_spec(validate=False, name=name, **kwargs)
+        self._material_specs = _dedupe_records_by_id(self._material_specs, record, "material_spec")
+        body = record["material_spec"]
+        self._register_material_spec_keys(body)
+        kind = body.get("kind", "")
+        print(f"  material-spec:  {body.get('name', name)}  [{kind}]  {body['id']}")
+        return [record]
+
+    def _register_material_spec_keys(self, spec_body: dict) -> None:
+        """Index a material spec under every reference form ``spec=`` accepts."""
+        spec_id = spec_body.get("id")
+        if not spec_id:
+            return
+        self._material_specs_by_ref[spec_id] = spec_body
+        for key in (spec_body.get("name"), spec_body.get("short_id"), spec_body.get("product_id")):
+            if isinstance(key, str) and key.strip():
+                self._material_specs_by_ref[key.strip().lower()] = spec_body
+
+    def _resolve_material_spec_arg(self, spec: Any) -> str:
+        """Resolve ``spec=`` for ws.add('material', ...) to a material_spec IRI."""
+        if isinstance(spec, dict) and isinstance(spec.get("material_spec"), dict):
+            body = spec["material_spec"]
+            self._register_material_spec_keys(body)
+            return body["id"]
+        if isinstance(spec, str) and spec.strip():
+            text = spec.strip()
+            if text.startswith("https://w3id.org/battinfo/"):
+                return text
+            found = self._material_specs_by_ref.get(text.lower())
+            if found is not None:
+                return found["id"]
+            raise ValueError(
+                f"Unknown material spec {spec!r}. Pass a material_spec IRI, the record "
+                "from ws.add('material_spec', ...), or a name added in this session."
+            )
+        raise ValueError(
+            "ws.add('material', ...) needs spec=<material-spec record, IRI, or name>."
+        )
+
+    def _add_material(self, spec: Any = None, *, lot: str | None = None, **kwargs) -> builtins.list:
+        """Author a first-class material instance (Level 3), queued for ws.save().
+
+        ``ws.add("material", spec=nmc811_spec, lot="LOT-2026-04",
+        processing={"route": "nmp", "solvent": "NMP"}, storage="dry room")``
+
+        Links a material spec (required), carries the lot/batch, dates, amount,
+        storage, an instance-level ``processing`` block (aqueous vs NMP lives
+        here, never on the spec), and an OPEN property block for as-received
+        measurements. The IRI is content-derived from (spec_id, lot).
+        """
+        from battinfo.api import create_material  # noqa: PLC0415
+
+        spec_id = self._resolve_material_spec_arg(spec)
+        record = create_material(validate=False, material_spec_id=spec_id, lot=lot, **kwargs)
+        self._materials = _dedupe_records_by_id(self._materials, record, "material")
+        body = record["material"]
+        label = body.get("lot_id") or body.get("name") or body["id"].rsplit("/", 1)[-1]
+        print(f"  material:       {label}  {body['id']}")
+        return [record]
 
     def _register_channel_keys(self, channel_body: dict, equipment_body: dict) -> None:
         """Index a channel under every reference form ``channel=`` accepts."""

--- a/tests/test_material_contract.py
+++ b/tests/test_material_contract.py
@@ -165,7 +165,7 @@ def test_material_spec_composition_reference_resolves(tmp_path: Path) -> None:
     base = api.create_material_spec(uid="base23456789abcd", name="NMC811", material_class="active_material")
     api.save_material_spec(base, source_root=tmp_path)
     coated = api.create_material_spec(
-        uid="coat23456789abcd", name="Al2O3-coated NMC811", material_class="active_material",
+        uid="coat23456789abcd", name="Al2O3-coated NMC811", kind="nmc811", material_class="active_material",
         composition={"base_material_id": base["material_spec"]["id"]},
     )
     api.save_material_spec(coated, source_root=tmp_path)

--- a/tests/test_materials_first_class.py
+++ b/tests/test_materials_first_class.py
@@ -1,0 +1,156 @@
+"""First-class materials model: identity (H1), attribution (H2), emission (M6), kind.
+
+Regression tests for the three-level materials model. Each maps to a readiness
+finding (battinfo-records#6 READINESS-REPORT.md) the model fixes.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import battinfo
+import battinfo.api as api
+from battinfo.materials import resolve_material_kind
+
+# ── H1: deterministic, content-derived ids (was: random id every call) ──────────
+
+def test_h1_material_spec_is_deterministic_and_dedupes() -> None:
+    ids = [
+        api.create_material_spec(name="Graphite", formula="C", validate=False)["material_spec"]["id"]
+        for _ in range(3)
+    ]
+    assert len(set(ids)) == 1  # identical create calls -> one id (H1 dead)
+    assert ids[0].startswith("https://w3id.org/battinfo/spec/")
+
+
+def test_h1_identity_basis_is_manufacturer_product_grade() -> None:
+    a = api.create_material_spec(name="NMC811", kind="nmc811", manufacturer="Targray", grade="X", validate=False)
+    b = api.create_material_spec(name="NMC811", kind="nmc811", manufacturer="Targray", grade="X", validate=False)
+    c = api.create_material_spec(name="NMC811", kind="nmc811", manufacturer="Targray", grade="Y", validate=False)
+    assert a["material_spec"]["id"] == b["material_spec"]["id"]
+    assert a["material_spec"]["id"] != c["material_spec"]["id"]  # grade is part of identity
+
+
+def test_h1_material_instance_id_from_spec_and_lot() -> None:
+    spec = api.create_material_spec(name="LFP", validate=False)["material_spec"]["id"]
+    m1 = api.create_material(material_spec_id=spec, lot="LOT-1", validate=False)["material"]["id"]
+    m2 = api.create_material(material_spec_id=spec, lot="LOT-1", validate=False)["material"]["id"]
+    m3 = api.create_material(material_spec_id=spec, lot="LOT-2", validate=False)["material"]["id"]
+    assert m1 == m2 and m1 != m3
+
+
+def test_h1_resave_is_unchanged(tmp_path: Path) -> None:
+    ws_root = tmp_path / "proj"
+    ws_root.mkdir()
+
+    def author():
+        ws = battinfo.workspace(str(ws_root))
+        ws.add("material_spec", name="LFP", kind="lfp", manufacturer="Canrud", grade="std",
+               property={"specific_capacity": {"value": 160, "unit": "mAh/g"}})
+        return ws.save()
+
+    first = author()
+    assert first["material_specs"][0]["status"] == "created"
+    second = author()
+    item = second["material_specs"][0]
+    # A same-IRI re-save of identical content is a no-op (content_changed False).
+    assert item.get("content_changed") is False
+
+
+# ── H2: attribution allowed on the schema and stamped by ws.save ────────────────
+
+def test_h2_attribution_stamped_on_both_material_types(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    ws.license("cc-by-4.0")
+    ws.contributor(orcid="0000-0002-1825-0097", name="Josiah Carberry")
+    spec = ws.add("material_spec", name="LFP", kind="lfp")[0]
+    ws.add("material", spec=spec, lot="LOT-9")
+    ws.save()
+
+    for subdir, key in (("material-spec", "material_spec"), ("material", "material")):
+        files = list((tmp_path / ".battinfo" / "records" / subdir).glob("*.json"))
+        assert files, f"no {subdir} record written"
+        doc = json.loads(files[0].read_text(encoding="utf-8"))
+        assert doc.get("license") == "cc-by-4.0", f"{subdir} missing stamped license (H2)"
+        assert doc.get("contributor"), f"{subdir} missing stamped contributor (H2)"
+        assert doc["contributor"][0]["same_as"].endswith("0000-0002-1825-0097")
+
+
+def test_h2_material_spec_schema_permits_attribution() -> None:
+    from battinfo.validate.record import validate_record
+
+    spec = api.create_material_spec(name="LFP", kind="lfp", validate=False)
+    spec["license"] = "cc-by-4.0"
+    spec["contributor"] = [{"type": "Person", "name": "A", "same_as": "https://orcid.org/0000-0002-1825-0097"}]
+    spec["funding"] = {"type": "Grant", "identifier": "101069765"}
+    assert validate_record(spec).ok  # no additionalProperties error (was H2)
+
+
+# ── M6 / M5: JSON-LD emitted for both material types ────────────────────────────
+
+def test_m6_jsonld_emitted_for_spec_and_instance() -> None:
+    from battinfo.jsonld import record_to_jsonld
+
+    spec = api.create_material_spec(name="LFP", kind="lfp", validate=False)
+    ld = record_to_jsonld(spec, "material-spec")
+    assert ld["@type"] == "LithiumIronPhosphate"
+    assert ld["schema:sameAs"]["@id"].startswith(
+        "https://w3id.org/emmo/domain/chemical-substance#"
+    )  # kind -> chemical-substance class node
+
+    inst = api.create_material(material_spec_id=spec["material_spec"]["id"], lot="L1", validate=False)
+    ldm = record_to_jsonld(inst, "material")
+    assert ldm["schema:isVariantOf"]["@id"] == spec["material_spec"]["id"]
+
+
+def test_m6_kind_without_emmo_class_uses_labeled_fallback() -> None:
+    from battinfo.jsonld import record_to_jsonld
+
+    # silicon_graphite is a genuine ontology gap: no emmo class, no chemsub.
+    spec = api.create_material_spec(name="Anode blend", kind="si/gr", validate=False)
+    ld = record_to_jsonld(spec, "material-spec")
+    assert ld["@type"] == "schema:ChemicalSubstance"  # labeled fallback, not invented term
+
+
+# ── kind vocabulary + validation ────────────────────────────────────────────────
+
+def test_kind_alias_resolution() -> None:
+    assert resolve_material_kind("NMC 811") == "nmc811"
+    assert resolve_material_kind("LiNi0.8Mn0.1Co0.1O2") == "nmc811"
+    assert resolve_material_kind("Si/Gr") == "silicon_graphite"
+    assert resolve_material_kind("nonsense") is None
+
+
+def test_unknown_kind_rejected_with_helpful_message() -> None:
+    with pytest.raises(ValueError) as exc:
+        api.create_material_spec(name="X", kind="unobtanium", validate=False)
+    msg = str(exc.value)
+    assert "Unknown material kind" in msg and "unobtanium" in msg
+    assert "graphite" in msg  # lists valid keys
+
+
+def test_missing_kind_blocks_strict_save_only(tmp_path: Path) -> None:
+    from battinfo.validate.record import validate_record
+
+    spec = api.create_material_spec(uid="abcd23456789abcd", name="Mystery Powder", validate=False)
+    assert "kind" not in spec["material_spec"]
+    # default policy: warning (tolerant flows validate)
+    assert validate_record(spec).ok
+    # strict policy (ws.save): missing kind is an error
+    assert not validate_record(spec, policy="strict").ok
+
+
+def test_kinds_carry_chemsub_or_are_flagged_gaps() -> None:
+    kinds = battinfo.material_kinds()["kinds"]
+    # the 12 seed kinds required by the model are present
+    required = {"graphite", "silicon", "silicon_graphite", "lnmo", "lfp", "nmc111",
+                "nmc532", "nmc811", "lithium_metal", "pvdf", "carbon_black", "lipf6"}
+    assert required.issubset(kinds)
+    # mapped kinds anchor to the chemical-substance ontology
+    assert kinds["graphite"]["chemsub"].startswith(
+        "https://w3id.org/emmo/domain/chemical-substance#"
+    )
+    # a genuine gap omits chemsub (ontology-additions backlog), does not invent one
+    assert "chemsub" not in kinds["silicon_graphite"]

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -5270,7 +5270,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
             "kind": {
               "type": "string",
               "minLength": 1,
-              "description": "Required Level-1 MaterialKind key from the curated material_kinds vocabulary (e.g. 'graphite', 'lfp', 'nmc811'). The aggregation axis of the Battery Genome; resolves to the kind's chemical-substance class IRI. An unknown kind is rejected at save time. See battinfo.material_kind_keys()."
+              "description": "Required Level-1 MaterialKind key from the curated material_kinds vocabulary (e.g. 'graphite', 'lfp', 'nmc811'). The aggregation axis of the Battery Genome; resolves to the kind's chemical-substance class IRI. An unknown kind is rejected at save time. See battinfo.materials.material_kind_keys()."
             },
             "grade": {
               "type": "string",

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -5267,6 +5267,15 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
               "minLength": 1,
               "description": "Human-readable material name / grade (e.g. 'LFP', 'Graphite', 'NMC811', 'PVDF')."
             },
+            "kind": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Required Level-1 MaterialKind key from the curated material_kinds vocabulary (e.g. 'graphite', 'lfp', 'nmc811'). The aggregation axis of the Battery Genome; resolves to the kind's chemical-substance class IRI. An unknown kind is rejected at save time. See battinfo.material_kind_keys()."
+            },
+            "grade": {
+              "type": "string",
+              "description": "Manufacturer grade / product version (e.g. 'grade X', 'v2'). Part of spec identity together with manufacturer and product."
+            },
             "material_class": {
               "type": "string",
               "enum": [
@@ -5404,6 +5413,22 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
           "items": {
             "type": "string"
           }
+        },
+        "funding": {
+          "$ref": "#/$defs/Funding"
+        },
+        "contributor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Person"
+          },
+          "minItems": 1,
+          "description": "People who contributed this record to the platform (attribution/provenance). Each is a schema:Person; an ORCID may be given in same_as. Stamped by ws.save."
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "description": "License under which this record is released, as an SPDX identifier (e.g. \"cc-by-4.0\") or a URL. Stamped from the workspace default (ws.license) and emitted as dcterms:license in JSON-LD."
         }
       },
       "$defs": {
@@ -5459,6 +5484,99 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
               "$ref": "#/$defs/Organization"
             }
           ]
+        },
+        "Funding": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Funding project (grant) under which the record was produced. Maps to schema:funding / schema:Grant in JSON-LD.",
+          "required": [
+            "identifier"
+          ],
+          "properties": {
+            "type": {
+              "const": "Grant"
+            },
+            "id": {
+              "type": "string",
+              "format": "uri"
+            },
+            "identifier": {
+              "type": "string",
+              "minLength": 1
+            },
+            "name": {
+              "type": "string"
+            },
+            "acronym": {
+              "type": "string"
+            },
+            "program": {
+              "type": "string"
+            },
+            "funder": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "type": {
+                  "const": "Organization"
+                },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "same_as": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        },
+        "Person": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "Person"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "given_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "family_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "email": {
+              "type": "string",
+              "format": "email"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "same_as": {
+              "type": "string",
+              "format": "uri"
+            },
+            "affiliation": {
+              "$ref": "#/$defs/Organization"
+            }
+          }
         },
         "MaterialRef": {
           "description": "Reference to another material by canonical material-spec IRI and/or a free-text name.",
@@ -5590,8 +5708,23 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
             "received_date": {
               "$ref": "#/$defs/FlexDate"
             },
+            "opened_date": {
+              "$ref": "#/$defs/FlexDate",
+              "description": "Date this lot was first opened / put into use."
+            },
             "expires_at": {
               "$ref": "#/$defs/FlexDate"
+            },
+            "amount": {
+              "$ref": "modules/common/quantity.schema.json",
+              "description": "Quantity of this lot on hand or consumed (e.g. mass in g, volume in mL)."
+            },
+            "storage": {
+              "type": "string",
+              "description": "Storage conditions for this lot (e.g. 'argon glovebox', 'dry room, -40 degC dew point')."
+            },
+            "processing": {
+              "$ref": "#/$defs/Processing"
             },
             "datasets": {
               "type": "array",
@@ -5680,9 +5813,50 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
           "items": {
             "type": "string"
           }
+        },
+        "funding": {
+          "$ref": "#/$defs/Funding"
+        },
+        "contributor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Person"
+          },
+          "minItems": 1,
+          "description": "People who contributed this record to the platform (attribution/provenance). Each is a schema:Person; an ORCID may be given in same_as. Stamped by ws.save."
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "description": "License under which this record is released, as an SPDX identifier (e.g. \"cc-by-4.0\") or a URL. Stamped from the workspace default (ws.license) and emitted as dcterms:license in JSON-LD."
         }
       },
       "$defs": {
+        "Processing": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "How this lot was processed into an electrode/coating. Processing is a property of the instance/build, NOT of the spec identity (aqueous vs NMP is not a distinct product).",
+          "properties": {
+            "route": {
+              "type": "string",
+              "enum": [
+                "aqueous",
+                "nmp",
+                "dry",
+                "other"
+              ],
+              "description": "Processing route: water-based (aqueous), NMP solvent-based, solvent-free (dry), or other."
+            },
+            "solvent": {
+              "type": "string",
+              "description": "Processing solvent (e.g. 'water', 'NMP')."
+            },
+            "detail": {
+              "type": "string",
+              "description": "Free-text processing detail (mixing, drying, calendering, ...)."
+            }
+          }
+        },
         "UnixTime": {
           "type": "integer",
           "minimum": 0,
@@ -5774,6 +5948,99 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
               "$ref": "#/$defs/Organization"
             }
           ]
+        },
+        "Funding": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Funding project (grant) under which the record was produced. Maps to schema:funding / schema:Grant in JSON-LD.",
+          "required": [
+            "identifier"
+          ],
+          "properties": {
+            "type": {
+              "const": "Grant"
+            },
+            "id": {
+              "type": "string",
+              "format": "uri"
+            },
+            "identifier": {
+              "type": "string",
+              "minLength": 1
+            },
+            "name": {
+              "type": "string"
+            },
+            "acronym": {
+              "type": "string"
+            },
+            "program": {
+              "type": "string"
+            },
+            "funder": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "type": {
+                  "const": "Organization"
+                },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "same_as": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        },
+        "Person": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "Person"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "given_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "family_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "email": {
+              "type": "string",
+              "format": "email"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "same_as": {
+              "type": "string",
+              "format": "uri"
+            },
+            "affiliation": {
+              "$ref": "#/$defs/Organization"
+            }
+          }
         }
       }
     }

--- a/web/lib/showcase.generated.ts
+++ b/web/lib/showcase.generated.ts
@@ -24,6 +24,7 @@ export const showcase: {
         "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
         "short_id": "7d9k2m",
         "name": "NMC811",
+        "kind": "nmc811",
         "material_class": "active_material",
         "formula": "LiNi0.8Mn0.1Co0.1O2"
       },


### PR DESCRIPTION
## What

Makes materials a first-class, three-level model — kind (curated vocabulary),
material-spec (record), material instance (record) — fixing readiness findings
H1, H2, M6 from battinfo-records#6.

- **Level 1 — MaterialKind vocabulary**: new `src/battinfo/data/vocab/material_kinds.json`
  (32 seeded kinds incl. the required 12) + loader (`battinfo.material_kinds()`,
  `battinfo.materials.resolve_material_kind/material_kind/material_kind_keys`) with
  alias resolution. Each kind anchors to its chemical-substance domain-ontology class
  IRI (`chemsub`); genuine ontology gaps omit it and carry a labeled fallback.
- **Level 2 — material-spec**: deterministic content-derived id from
  (manufacturer, product, grade) — the random-id path is gone (H1); required `kind`
  (validated, aliases resolve, unknown = save-time error listing valid keys);
  attribution (contributor/license/funding) on the schema and stamped by `ws.save`
  through the pre-compare stamp path (H2).
- **Level 3 — material instance**: deterministic id from (spec_id, lot); a
  `processing` block (route/solvent/detail) lives here, not on the spec; open
  as-received property block; amount/storage/dates.
- **Blessed API**: `ws.add("material_spec", ...)` / `ws.add("material", spec=..., lot=...)`,
  saved + stamped by `ws.save` — no `ws._ws`.
- **Emission (M6)**: `record_to_jsonld` for both types (kind -> EMMO class + chemsub
  `schema:sameAs`, labeled fallback where unmapped); standalone material nodes added
  to the consolidated deposit graph.
- **Migration**: `scripts/migrate_material_ids.py` re-mints random-id material records
  deterministically, fixes cross-references, and prints the old-id -> new-id map
  (record-file side only; does not touch battinfo-records).
- **Docs**: new reference page `docs/materials-model.md` (three levels, identity,
  processing-at-instance, progressive-fidelity linkage) wired into the nav; field
  reference updated.

## Why

The OCV dataset readiness test showed materials were a half-finished integration:
random ids broke idempotent pipelines (H1), material specs could carry no attribution
or funding (H2), and had no JSON-LD (M6). The kind is the Battery Genome's aggregation
axis, so it must be a converged, curated identifier, not free text.

## How

Deterministic minting mirrors `cell_spec` identity exactly. `kind` is enforced at the
save gate (semantic error under strict / ws.save, warning under default) rather than as
a JSON-schema required field, so tolerant flows (lifting embedded materials, interop
import) still validate while blessed authoring requires it. Kinds source their
semantic identity from `domain-chemical-substance`; no EMMO/chemsub IRIs were invented
(gaps are flagged for the ontology-additions backlog). Schemas are hand-authored JSON
(synced to assets); the web schema bundle was regenerated via `web/scripts/sync-schemas.mjs`.

## Testing

- `uv run pytest`: 1634 passed, 1 skipped. New `tests/test_materials_first_class.py`
  proves H1 dead (identical create calls -> one id; `[unchanged]` resave), attribution
  stamped on both types, JSON-LD emitted for both, unknown-kind rejection message.
- `uv run ruff check src tests scripts` clean; `uv run mypy` clean.
- Web gates green: `sync-schemas --check`, `check:agreement` (#318), `check:create-model`
  (#314), `check:workbench`.
- Migration script verified on the example corpus: re-mints, validates, idempotent.
