### PR TITLE
Clear the five open dependabot alerts (postcss, undici, fast-uri)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "autoprefixer": "10.4.19",
-        "postcss": "8.5.18",
+        "postcss": "8.5.25",
         "tailwindcss": "3.4.6",
         "tsx": "^4.23.0",
         "typescript": "5.5.3"
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2016,9 +2016,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -2183,9 +2183,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2202,7 +2202,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2812,9 +2812,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,7 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.19",
-    "postcss": "8.5.18",
+    "postcss": "8.5.25",
     "tailwindcss": "3.4.6",
     "tsx": "^4.23.0",
     "typescript": "5.5.3"


### PR DESCRIPTION
## What

Clears all five open dependabot alerts. Lockfile and manifest only, no source changes.

| Package | Severity | Advisory | From | To | Ecosystem |
|---|---|---|---|---|---|
| fast-uri | high | GHSA-7p8r-x3mc-p8w7 | 3.1.4 | 3.1.5 | npm (`web/package-lock.json`) |
| postcss | moderate | GHSA-fxqj-rqcc-2cmp | 8.5.18 | 8.5.25 | npm (`web/package.json` + lock) |
| undici | moderate x3 | GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm, GHSA-8xcm-r25x-g524 | 6.27.0 | 6.28.0 | npm (`web/package-lock.json`) |

Nothing left open. No Python alerts existed; `uv.lock` is untouched.

## Why

Five advisories on the default branch: a `fast-uri` host-confusion parse bug reachable through `ajv`, three `undici` request/response-integrity issues (CRLF injection, cookie attribute injection, response desync via the retry interceptor), and the incomplete-fix follow-up to the `postcss` `sourceMappingURL` arbitrary-`.map`-read advisory.

## How

Every fix landed inside the existing semver range, so no manifest range had to widen and no major bump was needed.

`postcss` is a direct devDependency, so it moved in `package.json` (8.5.18 to 8.5.25, keeping the exact-pin style used for the other devDeps). The existing `"postcss": "$postcss"` override means that single bump pulls every transitive copy along with it: `next`, `tailwindcss`, `autoprefixer`, `postcss-import`, `postcss-js`, `postcss-nested`, `postcss-load-config`.

`undici` and `fast-uri` are transitive only, via `@digitalbazaar/http-client` (`^6.23.0`) and `ajv` (`^3.0.1`) respectively. Both patched versions already satisfy those ranges, so `npm update --package-lock-only undici fast-uri` was enough. No override or forced resolution needed.

`nanoid` 3.3.12 to 3.3.17 rides along as postcss 8.5.25's required `^3.3.16`. That is the whole diff: four version bumps, 28 lock lines.

## Testing

- `npm audit` after a clean `npm ci`: 0 vulnerabilities.
- Full website CI job reproduced locally from `.github/workflows/ci.yml` after a clean `npm ci`: examples sync, schemas sync (37 files), records-context sync, validator agreement (110 canonical records valid, 5 broken fixtures correctly rejected), workbench checks, create-model emitter drift check (67 `@type` tokens), and `npm run build` (17 static routes). All pass.
- Security workflow's Python gate reproduced: `uv export --no-emit-project --no-emit-package batterydf --all-extras` then `uvx pip-audit -r` returns "No known vulnerabilities found".
- `uv run pytest -q`: 1654 passed, 1 skipped. (First run showed one failure in `tests/test_ingest.py::test_publish_ingest_workspace_submits_bundle_and_returns_cell_url`; it passes alone and did not reproduce on a clean re-run, and the Python side has no changes in this PR.)
