### PR TITLE
Top up the kind vocabulary, add cell_configuration, emit test protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Test-protocol JSON-LD (readiness finding M5)**: `record_to_jsonld` now emits
+  test-protocol records — the last record type it could not. The node is a
+  `prov:Plan` / `schema:HowTo` that additionally types itself with the published
+  characterisation-method class where the protocol's kind names one (GITT,
+  pseudo-OCV, EIS, HPPC, cycling, rate capability, capacity check, formation),
+  carries the descriptive method as a `hasTask` chain of typed EMMO process nodes,
+  and stamps contributor/license/funding like every other record. The publication
+  graph builder in `ws.py` had the only implementation; both callers now share one
+  emitter in `battinfo.jsonld`, so a protocol published in a deposit and one
+  exported standalone are the same graph. `ws.export()` writes protocols too.
+
+- **`cell_spec.cell_configuration`**: optional `full_cell` | `half_cell` |
+  `three_electrode_cell`, with no default. Absent still means unstated, which the
+  emitter reads through the existing `reference_electrode` heuristic; a stated value
+  wins in both directions, so `full_cell` suppresses the heuristic for a
+  three-electrode full cell or a commercial cell under potential monitoring.
+  `half_cell` types as `BatteryHalfCell` + `HalfCellDevice`, `three_electrode_cell`
+  as `ThreeElectrodeCellDevice`. `reference_electrode` — permitted by the schema but
+  previously unmodelled, so unauthorable and dropped on save — joins the model at the
+  same time.
+
+- **Material kind vocabulary top-up (0.2.0)**: six kinds added (`lto`, `lmo`,
+  `hard_carbon`, `litfsi`, `lifsi`, `nmp`), taking the vocabulary to 38, and every
+  kind now anchors to a `domain-chemical-substance` class — `silicon_graphite` and
+  the four NMC ratios repoint onto the stoichiometric classes published in 0.15.0
+  instead of sharing the generic `LithiumNickelManganeseCobaltOxide`.
+
+- **External identity anchors on material kinds**: optional `wikidata_qid`,
+  `inchikey`, `pubchem_cid`, `mp_id` and `cas_rn`. The three with a dereferenceable
+  form emit as `skos:exactMatch` (Wikidata, PubChem, Materials Project), so a
+  material joins those systems without a lookup table. Anchors are populated only
+  where verified — an absent one means unverified, never guessed — and no InChIKeys
+  are populated yet. `mp_id` denotes a representative ordered structure, so the
+  solid-solution families carry none by design.
+
 - **`Test.conditions`**: the `Test` model now carries the open, snake_case
   per-execution conditions map (temperature, voltage window, C-rate, frequency
   range, ...) that the test JSON Schema already defined but the model could not

--- a/assets/mappings/domain-battery/entity_type_map.json
+++ b/assets/mappings/domain-battery/entity_type_map.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "status": "curated",
   "source_ontology": "https://w3id.org/emmo/domain/battery/inferred",
   "notes": [
@@ -7,7 +7,8 @@
     "Keys are normalized to lower-case for deterministic lookup in the JSON-LD renderer.",
     "IRIs verified against EMMO domain-battery 0.20.1, domain-electrochemistry 0.36.0, domain-chemical-substance 0.15.0 and EMMO 1.0.2.",
     "0.3.0: added zn-mno2/alkaline chemistry entries and iec_code section.",
-    "0.4.0: added the cell_configuration section. A battery half-cell types as the DEVICE classes BatteryHalfCell (domain-battery, a BatteryCell) and HalfCellDevice (domain-electrochemistry) - never as ElectrochemicalHalfCell, which upstream annotates with an explicit warning against that conflation (it is one electrode plus one electrolyte, not an experimental setup)."
+    "0.4.0: added the cell_configuration section. A battery half-cell types as the DEVICE classes BatteryHalfCell (domain-battery, a BatteryCell) and HalfCellDevice (domain-electrochemistry) - never as ElectrochemicalHalfCell, which upstream annotates with an explicit warning against that conflation (it is one electrode plus one electrolyte, not an experimental setup).",
+    "0.4.1: cell_configuration gained the three-electrode-cell key, the normalized form of the cell-spec schema's three_electrode_cell enum value; three-electrode stays as the tolerant-import spelling."
   ],
   "mappings": {
     "format": {
@@ -57,6 +58,11 @@
         ]
       },
       "three-electrode": {
+        "battery_types": [
+          "ThreeElectrodeCellDevice"
+        ]
+      },
+      "three-electrode-cell": {
         "battery_types": [
           "ThreeElectrodeCellDevice"
         ]

--- a/assets/schemas/cell-spec.schema.json
+++ b/assets/schemas/cell-spec.schema.json
@@ -219,6 +219,15 @@
         "reference_electrode": {
           "type": "string",
           "description": "Counter/reference electrode for half-cell configurations (e.g. 'lithium', 'NHE')."
+        },
+        "cell_configuration": {
+          "type": "string",
+          "enum": [
+            "full_cell",
+            "half_cell",
+            "three_electrode_cell"
+          ],
+          "description": "Electrode configuration as built. Optional; absent means unstated (read as a full cell unless a reference_electrode is present). Stated explicitly it overrides that heuristic: half_cell types the JSON-LD as BatteryHalfCell + HalfCellDevice, three_electrode_cell as ThreeElectrodeCellDevice, full_cell suppresses both."
         }
       }
     },

--- a/assets/vocab/battinfo-records.ttl
+++ b/assets/vocab/battinfo-records.ttl
@@ -1760,6 +1760,15 @@ ns:category a rdf:Property ;
     rdfs:label "Category"@en ;
     rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .
 
+ns:cell_configuration a rdf:Property ;
+    rdfs:label "Cell configuration"@en ;
+    rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .
+
+ns:cellConfiguration a rdf:Property ;
+    rdfs:label "Cell Configuration"@en ;
+    owl:equivalentProperty ns:cell_configuration ;
+    rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .
+
 ns:cell_format a rdf:Property ;
     rdfs:label "Cell format"@en ;
     rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .

--- a/docs/internal/ontology-additions-needed.md
+++ b/docs/internal/ontology-additions-needed.md
@@ -95,6 +95,14 @@ Also mapped in the same pass, though published earlier: `MaximumPulseChargingCur
 
 ### domain-chemical-substance 0.15.0
 
+The kind vocabulary (`material_kinds.json`) is fully anchored against this release: all
+38 kinds carry a `chemsub` class, with `SiliconGraphite`, `HardCarbon`, `LithiumTitanate`,
+`LithiumManganeseOxide`, `LithiumBistrifluoromethanesulfonylimide`,
+`LithiumBisfluorosulfonylimide` and `NMethyl2Pyrrolidone` newly available, and the four
+NMC ratios moved off the generic `LithiumNickelManganeseCobaltOxide` onto their
+stoichiometric classes. `tests/test_materials_first_class.py` checks every `emmo` class
+resolves in the bundled context and agrees with its `chemsub` anchor.
+
 `LithiumNickelManganeseCobaltOxide111` / `532` / `622` / `811` (altLabels NMC111 …) and
 `SiliconGraphite` are wired in `material_map.json`; a named NMC ratio now resolves to its
 own class and bare "NMC" keeps the generic one. The pre-existing `LiTFSI`, `LiFSI` and
@@ -108,11 +116,32 @@ own class and bare "NMC" keeps the generic one. The pre-existing `LiTFSI`, `LiFS
 **Half-cell semantics (decision).** A battery half-cell types as the DEVICE classes
 `BatteryHalfCell` + `HalfCellDevice`, never as `ElectrochemicalHalfCell`: upstream
 annotates that class with an explicit warning against the conflation (it is one electrode
-plus one electrolyte, not an experimental setup). The cell-spec schema has no explicit
-configuration field, so the emitter reads the existing `reference_electrode` field — the
-schema's own half-cell marker — and an explicit `cell_configuration` value wins when one
-is present. Add `cell_configuration` to `cell-spec.schema.json` if the heuristic ever
-needs overriding (three-electrode full cells being the obvious case).
+plus one electrolyte, not an experimental setup).
+
+`cell_spec.cell_configuration` (`full_cell` | `half_cell` | `three_electrode_cell`,
+optional, no default) now carries the statement. The `reference_electrode` heuristic
+survives as the fallback for records that never state a configuration, but an explicit
+value wins in both directions — `full_cell` suppresses the heuristic, which is what a
+three-electrode full cell or a commercial cell under potential monitoring needs.
+`three_electrode_cell` types as `ThreeElectrodeCellDevice`; `full_cell` adds no device
+class at all. Both spellings (`three-electrode`, `three-electrode-cell`) are keyed in
+`entity_type_map.json` so tolerant import and the schema enum land on the same mapping.
+
+### Test-protocol method classes (chameo, via domain-electrochemistry 0.36.0)
+
+`record_to_jsonld` emits test-protocol records as of the vocabulary top-up, and types the
+plan node with the published characterisation-method class where the protocol's kind names
+one: `GalvanostaticIntermittentTitrationTechnique` (gitt),
+`PseudoOpenCircuitVoltageMethod` (quasi_ocv), `ElectrochemicalImpedanceSpectroscopy`
+(eis/impedance), `HPPC`, `CyclingTest`, `CRateTest`, `CapacityTest`, `FormationCycling`.
+The map is `battinfo.jsonld.TEST_METHOD_CLASS`; the IRIs are read from the bundled
+domain-battery context rather than hard-coded, so the emitter, the hosted records context
+and the validator allowlist cannot drift apart. Kinds with no published class
+(`ici`, `dcir`, `calendar_ageing`, `rpt`, the drive cycles) keep the untyped
+`prov:Plan` / `schema:HowTo` node — those are the open candidates if upstream wants them.
+
+This closes readiness finding **M5** (test protocols were the last record type without
+JSON-LD emission).
 
 ## Already published & in use (no action)
 

--- a/docs/materials-model.md
+++ b/docs/materials-model.md
@@ -31,6 +31,28 @@ carries the node until the class is upstreamed). A kind may also carry curated,
 citable `reference_properties` (e.g. graphite 372 mAh/g) — the generic anchors the
 genome compares datasheet- and measurement-reported values against.
 
+### External identity anchors
+
+`chemsub` is the EMMO identity. Materials science also runs on Wikidata, PubChem,
+the Materials Project, InChIKeys and CAS numbers, so a kind may additionally carry
+`wikidata_qid`, `pubchem_cid`, `mp_id`, `inchikey` and `cas_rn`. The three that have
+a stable dereferenceable form are emitted as `skos:exactMatch` links, which is how a
+consumer joins a BattINFO material to those systems with no lookup table:
+
+| Field | Emitted as |
+| --- | --- |
+| `wikidata_qid` | `http://www.wikidata.org/entity/<QID>` |
+| `pubchem_cid` | `https://pubchem.ncbi.nlm.nih.gov/compound/<CID>` |
+| `mp_id` | `https://next-gen.materialsproject.org/materials/<mp-id>` |
+| `inchikey`, `cas_rn` | carried as literals only — neither has a canonical, freely-dereferenceable IRI |
+
+Two rules govern the anchors. **An absent anchor means unverified, never guessed**:
+a kind carries an identifier only once someone has checked it, so an empty field is
+information, not an oversight. And **`mp_id` denotes a representative ordered
+structure**, so solid-solution families (the NMC ratios, NCA, LMFP) legitimately
+carry none — that absence is correct, not a gap to fill. No InChIKeys are populated
+yet; molecular-species curation is a later pass.
+
 ```python
 import battinfo
 from battinfo.materials import material_kind, material_kind_keys, resolve_material_kind
@@ -41,8 +63,19 @@ resolve_material_kind("NMC 811")          # -> "nmc811" (aliases resolve)
 material_kind("graphite")                 # the full entry (chemsub, emmo, refs)
 ```
 
-The seed vocabulary bootstraps the contract; curation to the full set is a
-follow-up PR.
+The vocabulary covers 38 kinds: the common actives (graphite, hard carbon, LTO,
+silicon and Si/Gr, lithium and zinc metal; LFP, LMFP, LCO, LMO, LNMO, the four NMC
+ratios, NCA, MnO2), binders, conductive additives, the salts (LiPF6, LiTFSI, LiFSI,
+KOH), carbonate solvents and additives, separator and current-collector materials,
+plus alumina and NMP. Every one anchors to a `domain-chemical-substance` class.
+Adding a kind is a PR against `src/battinfo/data/vocab/material_kinds.json`; the
+tests check that each new `emmo` class resolves in the bundled context and names the
+same substance as its `chemsub` anchor.
+
+One placement is worth flagging: NMP is a **processing** solvent (slurry casting),
+not an electrolyte solvent, and the family list has no `processing_solvent` value, so
+it sits under `other` with a `family_note` saying why. Add the family when a second
+processing solvent arrives rather than stretching `electrolyte_solvent` to cover it.
 
 ## Level 2 — material-spec (first-class record)
 

--- a/schema/cell-spec.yaml
+++ b/schema/cell-spec.yaml
@@ -42,6 +42,7 @@ classes:
       - ct_year
       - ct_country_of_origin
       - ct_battery_category
+      - ct_cell_configuration
       - ct_specs
 
   Organization:
@@ -258,6 +259,16 @@ slots:
       (LMT, EV, Industrial, Stationary, Portable, SLI).
     aliases:
       - battery_category
+
+  ct_cell_configuration:
+    slot_uri: battinfo:cellConfiguration
+    range: CellConfiguration
+    description: >-
+      Electrode configuration as built (full_cell, half_cell,
+      three_electrode_cell). Optional; absent means unstated, which the emitter
+      reads as a full cell unless a reference_electrode is present.
+    aliases:
+      - cell_configuration
 
   ct_specs:
     slot_uri: battinfo:specs

--- a/schema/types.yaml
+++ b/schema/types.yaml
@@ -77,6 +77,24 @@ enums:
       research:    { description: "Research / experimental cell." }
       prototype:   { description: "Pre-production prototype." }
 
+  CellConfiguration:
+    description: >-
+      Electrode configuration of the cell as built. Absent means unknown; a
+      full cell is the safe reading of an unstated configuration. Stated
+      explicitly, the value overrides the reference_electrode half-cell
+      heuristic in the JSON-LD emitter.
+    permissible_values:
+      full_cell:
+        description: "Two working electrodes; the ordinary battery cell."
+      half_cell:
+        description: >-
+          One working electrode against a counter/reference electrode
+          (typically lithium metal). Types as BatteryHalfCell + HalfCellDevice.
+      three_electrode_cell:
+        description: >-
+          Working, counter and a separate reference electrode, so each electrode
+          potential is measured independently. Types as ThreeElectrodeCellDevice.
+
   CellGrade:
     description: >-
       Battery grade / reuse status per EU Battery Regulation 2023/1542.

--- a/scripts/gen_context.py
+++ b/scripts/gen_context.py
@@ -24,7 +24,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from battinfo.jsonld import _CONTEXT_INLINE, TEST_METHOD_CONTEXT_TERMS  # noqa: E402
+from battinfo.jsonld import (  # noqa: E402
+    _CONTEXT_INLINE,
+    TEST_METHOD_CONTEXT_TERMS,
+    TEST_PROTOCOL_CONTEXT_TERMS,
+)
 from battinfo.transform.cell_spec_node import label_to_compact  # noqa: E402
 
 OUT = ROOT / "src" / "battinfo" / "data" / "context" / "records.context.v1.json"
@@ -42,6 +46,12 @@ def build() -> dict:
     context: dict = dict(_CONTEXT_INLINE)
     context.update(label_to_compact())
     context.update(TEST_METHOD_CONTEXT_TERMS)
+    # Test-protocol vocabulary. setdefault, not update: where a term is already
+    # present from the class table its full-IRI form wins, so adding protocol
+    # emission to record_to_jsonld introduces new terms without rewriting old ones
+    # (a published version's meaning must never change).
+    for term, value in TEST_PROTOCOL_CONTEXT_TERMS.items():
+        context.setdefault(term, value)
     return {"license": LICENSE, "@context": context}
 
 

--- a/src/battinfo/_workspace.py
+++ b/src/battinfo/_workspace.py
@@ -744,6 +744,8 @@ class Workspace:
         size_code: str | None = None,
         iec_code: str | None = None,
         country_of_origin: str | None = None,
+        cell_configuration: str | None = None,
+        reference_electrode: str | None = None,
         rechargeable: bool | None = None,
         year: int | None = None,
         positive_electrode_basis: str | None = None,
@@ -756,8 +758,9 @@ class Workspace:
         retrieved_at: int | str | None = None,
         comment: list[str] | None = None,
     ) -> CellSpec:
-        from battinfo.bundle import CellProductType
+        from battinfo.bundle import CellConfiguration, CellProductType
         resolved_pt = CellProductType(product_type) if product_type is not None else None
+        resolved_cfg = CellConfiguration(cell_configuration) if cell_configuration is not None else None
         cell_spec = CellSpec(
             manufacturer=manufacturer,
             model=model,
@@ -767,6 +770,8 @@ class Workspace:
             size_code=size_code,
             iec_code=iec_code,
             country_of_origin=country_of_origin,
+            cell_configuration=resolved_cfg,
+            reference_electrode=reference_electrode,
             rechargeable=rechargeable,
             year=year,
             positive_electrode_basis=positive_electrode_basis,

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -66,6 +66,23 @@ class CellProductType(StrEnum):
     PROTOTYPE = "prototype"
 
 
+class CellConfiguration(StrEnum):
+    """Electrode configuration of the cell as built.
+
+    Absent means unstated, which the JSON-LD emitter reads as a full cell unless
+    a ``reference_electrode`` is present. Stated explicitly, the value beats that
+    heuristic in both directions: ``half_cell`` types the node as
+    BatteryHalfCell + HalfCellDevice, ``three_electrode_cell`` as
+    ThreeElectrodeCellDevice, and ``full_cell`` suppresses the heuristic even when
+    a reference electrode is recorded (three-electrode full cells, potential
+    monitoring on a commercial cell).
+    """
+
+    FULL_CELL = "full_cell"
+    HALF_CELL = "half_cell"
+    THREE_ELECTRODE_CELL = "three_electrode_cell"
+
+
 def _short_id(entity_id: str) -> str:
     tail = entity_id.rstrip("/").split("/")[-1].replace("-", "")
     return tail[:6]
@@ -1280,6 +1297,8 @@ class CellSpec(BundleJsonModel):
     size_code: str | None = Field(default=None, description="Standardised size code (e.g. '18650', '21700', 'AA').")
     iec_code: str | None = Field(default=None, description="IEC 60086 or IEC 61960 code string (e.g. 'LR6', 'ICR18650').")
     country_of_origin: str | None = Field(default=None, description="Country where the cell is manufactured.")
+    cell_configuration: CellConfiguration | None = Field(default=None, description="Electrode configuration as built: full_cell, half_cell, or three_electrode_cell. Absent means unstated; when stated it overrides the reference_electrode half-cell heuristic in the JSON-LD emitter.")
+    reference_electrode: str | None = Field(default=None, description="Counter/reference electrode used in a half-cell or three-electrode build (e.g. 'lithium', 'NHE').")
     rechargeable: bool | None = Field(default=None, description="True for secondary (rechargeable) cells; false for primary.")
     year: int | None = Field(default=None, description="Year the product or its datasheet was released.")
     datasheet_revision: str | None = Field(default=None, description="Revision label of the source datasheet this spec was taken from.")
@@ -1456,6 +1475,12 @@ class CellSpec(BundleJsonModel):
             notes = []
         raw_pt = product.get("product_type")
         product_type = CellProductType(raw_pt) if isinstance(raw_pt, str) and raw_pt in CellProductType._value2member_map_ else None
+        raw_cfg = product.get("cell_configuration")
+        cell_configuration = (
+            CellConfiguration(raw_cfg)
+            if isinstance(raw_cfg, str) and raw_cfg in CellConfiguration._value2member_map_
+            else None
+        )
         return cls(
             schema_version=str(record.get("schema_version", "1.0.0")),
             id=str(product["id"]),
@@ -1471,6 +1496,8 @@ class CellSpec(BundleJsonModel):
             size_code=product.get("size_code"),
             iec_code=product.get("iec_code"),
             country_of_origin=product.get("country_of_origin"),
+            cell_configuration=cell_configuration,
+            reference_electrode=product.get("reference_electrode"),
             rechargeable=product.get("rechargeable"),
             year=_year_value(product.get("year")),
             datasheet_revision=product.get("datasheet_revision"),
@@ -1608,6 +1635,10 @@ class CellSpec(BundleJsonModel):
             record["cell_spec"]["iec_code"] = self.iec_code
         if self.country_of_origin is not None:
             record["cell_spec"]["country_of_origin"] = self.country_of_origin
+        if self.cell_configuration is not None:
+            record["cell_spec"]["cell_configuration"] = str(self.cell_configuration)
+        if self.reference_electrode is not None:
+            record["cell_spec"]["reference_electrode"] = self.reference_electrode
         if self.rechargeable is not None:
             record["cell_spec"]["rechargeable"] = self.rechargeable
         if self.year is not None:

--- a/src/battinfo/bundle_generated.py
+++ b/src/battinfo/bundle_generated.py
@@ -219,6 +219,24 @@ class CellProductType(str, Enum):
     """
 
 
+class CellConfiguration(str, Enum):
+    """
+    Electrode configuration of the cell as built. Absent means unknown; a full cell is the safe reading of an unstated configuration. Stated explicitly, the value overrides the reference_electrode half-cell heuristic in the JSON-LD emitter.
+    """
+    full_cell = "full_cell"
+    """
+    Two working electrodes; the ordinary battery cell.
+    """
+    half_cell = "half_cell"
+    """
+    One working electrode against a counter/reference electrode (typically lithium metal). Types as BatteryHalfCell + HalfCellDevice.
+    """
+    three_electrode_cell = "three_electrode_cell"
+    """
+    Working, counter and a separate reference electrode, so each electrode potential is measured independently. Types as ThreeElectrodeCellDevice.
+    """
+
+
 class CellGrade(str, Enum):
     """
     Battery grade / reuse status per EU Battery Regulation 2023/1542.
@@ -398,6 +416,9 @@ class CellSpecification(ConfiguredBaseModel):
     ct_battery_category: Optional[BatteryCategoryEU] = Field(default=None, description="""EU Battery Regulation 2023/1542 battery category (LMT, EV, Industrial, Stationary, Portable, SLI).""", json_schema_extra = { "linkml_meta": {'aliases': ['battery_category'],
          'domain_of': ['CellSpecification'],
          'slot_uri': 'battinfo:batteryCategory'} })
+    ct_cell_configuration: Optional[CellConfiguration] = Field(default=None, description="""Electrode configuration as built (full_cell, half_cell, three_electrode_cell). Optional; absent means unstated, which the emitter reads as a full cell unless a reference_electrode is present.""", json_schema_extra = { "linkml_meta": {'aliases': ['cell_configuration'],
+         'domain_of': ['CellSpecification'],
+         'slot_uri': 'battinfo:cellConfiguration'} })
     ct_specs: Optional[SpecSet] = Field(default=None, description="""Quantitative performance specification for this cell type.""", json_schema_extra = { "linkml_meta": {'aliases': ['properties'], 'domain_of': ['CellSpecification'], 'slot_uri': 'battinfo:specs'} })
 
 

--- a/src/battinfo/canonical_aliases.py
+++ b/src/battinfo/canonical_aliases.py
@@ -16,6 +16,7 @@ _CELL_TYPE_PRODUCT_TO_SNAKE = {
     "manufacturingPlace": "manufacturing_place",
     "batteryCategory": "battery_category",
     "referenceElectrode": "reference_electrode",
+    "cellConfiguration": "cell_configuration",
 }
 
 _DATASET_TO_SNAKE = {

--- a/src/battinfo/data/context/records.context.v1.json
+++ b/src/battinfo/data/context/records.context.v1.json
@@ -487,6 +487,15 @@
     "ElectricCurrent": "https://w3id.org/emmo#EMMO_c995ae70_3b84_4ebb_bcfc_69e6a281bb88",
     "Voltage": "https://w3id.org/emmo#EMMO_17b031fb_4695_49b6_bb69_189ec63df3ee",
     "Power": "https://w3id.org/emmo#EMMO_09b9021b_f97b_43eb_b83d_0a764b472bc2",
-    "Duration": "https://w3id.org/emmo#EMMO_0adabf6f_7404_44cb_9f65_32d83d8101a3"
+    "Duration": "https://w3id.org/emmo#EMMO_0adabf6f_7404_44cb_9f65_32d83d8101a3",
+    "GalvanostaticIntermittentTitrationTechnique": "https://w3id.org/emmo/domain/characterisation-methodology/chameo#GalvanostaticIntermittentTitrationTechnique",
+    "PseudoOpenCircuitVoltageMethod": "https://w3id.org/emmo/domain/characterisation-methodology/chameo#PseudoOpenCircuitVoltageMethod",
+    "HPPC": "https://w3id.org/emmo/domain/characterisation-methodology/chameo#HPPC",
+    "CyclingTest": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_435b22d4_c441_45ea_8c79_0cbec11fd287",
+    "CRateTest": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_99b2b3ad_8efc_48ee_a630_6d805a47efdc",
+    "CapacityTest": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_137dc19f_a3af_49af_971f_743d27e09f43",
+    "FormationCycling": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_cb223440_51bd_4f16_a536_96ec408e7de4",
+    "ControlProperty": "electrochemistry:electrochemistry_33e6986c_b35a_4cae_9a94_acb23248065c",
+    "AmperePerAmpereHour": "electrochemistry:AmperePerAmpereHour"
   }
 }

--- a/src/battinfo/data/mappings/domain-battery/entity_type_map.json
+++ b/src/battinfo/data/mappings/domain-battery/entity_type_map.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "status": "curated",
   "source_ontology": "https://w3id.org/emmo/domain/battery/inferred",
   "notes": [
@@ -7,7 +7,8 @@
     "Keys are normalized to lower-case for deterministic lookup in the JSON-LD renderer.",
     "IRIs verified against EMMO domain-battery 0.20.1, domain-electrochemistry 0.36.0, domain-chemical-substance 0.15.0 and EMMO 1.0.2.",
     "0.3.0: added zn-mno2/alkaline chemistry entries and iec_code section.",
-    "0.4.0: added the cell_configuration section. A battery half-cell types as the DEVICE classes BatteryHalfCell (domain-battery, a BatteryCell) and HalfCellDevice (domain-electrochemistry) - never as ElectrochemicalHalfCell, which upstream annotates with an explicit warning against that conflation (it is one electrode plus one electrolyte, not an experimental setup)."
+    "0.4.0: added the cell_configuration section. A battery half-cell types as the DEVICE classes BatteryHalfCell (domain-battery, a BatteryCell) and HalfCellDevice (domain-electrochemistry) - never as ElectrochemicalHalfCell, which upstream annotates with an explicit warning against that conflation (it is one electrode plus one electrolyte, not an experimental setup).",
+    "0.4.1: cell_configuration gained the three-electrode-cell key, the normalized form of the cell-spec schema's three_electrode_cell enum value; three-electrode stays as the tolerant-import spelling."
   ],
   "mappings": {
     "format": {
@@ -57,6 +58,11 @@
         ]
       },
       "three-electrode": {
+        "battery_types": [
+          "ThreeElectrodeCellDevice"
+        ]
+      },
+      "three-electrode-cell": {
         "battery_types": [
           "ThreeElectrodeCellDevice"
         ]

--- a/src/battinfo/data/schemas/cell-spec.schema.json
+++ b/src/battinfo/data/schemas/cell-spec.schema.json
@@ -219,6 +219,15 @@
         "reference_electrode": {
           "type": "string",
           "description": "Counter/reference electrode for half-cell configurations (e.g. 'lithium', 'NHE')."
+        },
+        "cell_configuration": {
+          "type": "string",
+          "enum": [
+            "full_cell",
+            "half_cell",
+            "three_electrode_cell"
+          ],
+          "description": "Electrode configuration as built. Optional; absent means unstated (read as a full cell unless a reference_electrode is present). Stated explicitly it overrides that heuristic: half_cell types the JSON-LD as BatteryHalfCell + HalfCellDevice, three_electrode_cell as ThreeElectrodeCellDevice, full_cell suppresses both."
         }
       }
     },

--- a/src/battinfo/data/vocab/material_kinds.json
+++ b/src/battinfo/data/vocab/material_kinds.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.0",
-  "description": "Curated, shipped vocabulary of generic material kinds (Level 1 of the three-level materials model). A kind is the universal reference identity of a material (graphite, LFP, NMC811, ...): the aggregation axis of the Battery Genome. Every material-spec carries a required `kind`; every material instance links a spec. Each kind's canonical semantic identity is its chemical-substance domain-ontology class IRI (`chemsub`); the battinfo `key` is the ergonomic handle. Kinds missing an ontology class omit `chemsub` and go on the ontology-additions backlog (labeled ns# fallback until upstreamed). This is a governance-by-PR vocabulary, NOT a user-authored record type. Curation to the full set (electrolytes, binders, separators, current collectors, further actives) is a follow-up PR; this file bootstraps the contract and seeds it. `chemsub` values use the domain-chemical-substance namespace (https://w3id.org/emmo/domain/chemical-substance#). `emmo` values are the domain-battery class local-name used to type JSON-LD nodes (must resolve in the bundled domain-battery context). `reference_properties` carry curated, citable generic anchors (value/unit/citation) that the genome compares datasheet- and measurement-reported distributions against; present only where a citable source exists.",
+  "version": "0.2.0",
+  "description": "Curated, shipped vocabulary of generic material kinds (Level 1 of the three-level materials model). A kind is the universal reference identity of a material (graphite, LFP, NMC811, ...): the aggregation axis of the Battery Genome. Every material-spec carries a required `kind`; every material instance links a spec. Each kind's canonical semantic identity is its chemical-substance domain-ontology class IRI (`chemsub`); the battinfo `key` is the ergonomic handle. Kinds missing an ontology class omit `chemsub` and go on the ontology-additions backlog (labeled ns# fallback until upstreamed). This is a governance-by-PR vocabulary, NOT a user-authored record type. `chemsub` values use the domain-chemical-substance namespace (https://w3id.org/emmo/domain/chemical-substance#), verified against release 0.15.0. `emmo` values are the domain-battery class local-name used to type JSON-LD nodes (must resolve in the bundled domain-battery context). `reference_properties` carry curated, citable generic anchors (value/unit/citation) that the genome compares datasheet- and measurement-reported distributions against; present only where a citable source exists. Optional EXTERNAL IDENTITY ANCHORS (`wikidata_qid`, `inchikey`, `pubchem_cid`, `mp_id`, `cas_rn`) tie a kind to the identifier systems the rest of materials science already uses; each is emitted as a `skos:exactMatch` link. They are populated only where the value has been verified — an absent anchor means unverified, never guessed. `mp_id` denotes a representative ORDERED structure in the Materials Project, so solid-solution families (NMC, NCA, LMFP) legitimately carry none. NMP is a processing solvent, not an electrolyte solvent; the families enum has no processing-solvent value, so it sits under `other` until one is added.",
   "families": [
     "active_anode",
     "active_cathode",
@@ -19,6 +19,9 @@
       "formula": "C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303",
       "emmo": "Graphite",
+      "wikidata_qid": "Q5309",
+      "pubchem_cid": "5462310",
+      "mp_id": "mp-48",
       "aliases": ["graphite", "natural graphite", "synthetic graphite", "mesocarbon microbead", "mcmb", "gr", "c"],
       "reference_properties": {
         "specific_capacity": {"value": 372, "unit": "mAh/g", "citation": "https://doi.org/10.1039/D0SE00175A"},
@@ -31,6 +34,8 @@
       "formula": "Si",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733",
       "emmo": "Silicon",
+      "wikidata_qid": "Q670",
+      "mp_id": "mp-149",
       "aliases": ["silicon", "si", "nano-silicon", "silicon nanoparticles"],
       "reference_properties": {
         "specific_capacity": {"value": 3579, "unit": "mAh/g", "citation": "https://doi.org/10.1149/1.1652421"}
@@ -40,13 +45,32 @@
       "label": "Silicon-graphite composite",
       "family": "active_anode",
       "formula": "Si/C",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3f061928_e90f_4414_9308_d4c843ebb79a",
+      "emmo": "SiliconGraphite",
       "aliases": ["silicon graphite", "silicon-graphite", "si/gr", "si-gr", "silicon/graphite", "sigr", "graphite-silicon"]
+    },
+    "hard_carbon": {
+      "label": "Hard carbon",
+      "family": "active_anode",
+      "formula": "C",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_5cee19d2_f916_4264_a8ed_efed13a808d2",
+      "emmo": "HardCarbon",
+      "aliases": ["hard carbon", "hard-carbon", "hc", "non-graphitizable carbon", "non-graphitising carbon", "disordered carbon"]
+    },
+    "lto": {
+      "label": "Lithium titanate (LTO)",
+      "family": "active_anode",
+      "formula": "Li4Ti5O12",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_acdb232f_8041_4e11_8a11_5db2d2baae4d",
+      "emmo": "LithiumTitanate",
+      "aliases": ["lto", "li4ti5o12", "lithium titanate", "lithium titanium oxide", "lithium titanate oxide", "spinel lto"]
     },
     "lithium_metal": {
       "label": "Lithium metal",
       "family": "active_anode",
       "formula": "Li",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c109ca45_08c7_4436_a818_a9c575785e2f",
+      "mp_id": "mp-135",
       "aliases": ["lithium metal", "lithium", "li metal", "li", "metallic lithium", "lithium foil"],
       "reference_properties": {
         "specific_capacity": {"value": 3862, "unit": "mAh/g", "citation": "https://doi.org/10.1038/nnano.2017.16"}
@@ -66,6 +90,9 @@
       "formula": "LiFePO4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90",
       "emmo": "LithiumIronPhosphate",
+      "wikidata_qid": "Q3042400",
+      "pubchem_cid": "15320824",
+      "mp_id": "mp-19017",
       "aliases": ["lfp", "lifepo4", "lithium iron phosphate", "lithium iron phosphate (lfp)", "olivine lfp"],
       "reference_properties": {
         "specific_capacity": {"value": 170, "unit": "mAh/g", "citation": "https://doi.org/10.1149/1.1837571"}
@@ -85,7 +112,17 @@
       "formula": "LiCoO2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af",
       "emmo": "LithiumCobaltOxide",
+      "mp_id": "mp-22526",
       "aliases": ["lco", "licoo2", "lithium cobalt oxide"]
+    },
+    "lmo": {
+      "label": "Lithium manganese oxide (LMO)",
+      "family": "active_cathode",
+      "formula": "LiMn2O4",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827",
+      "emmo": "LithiumManganeseOxide",
+      "mp_id": "mp-22584",
+      "aliases": ["lmo", "limn2o4", "lithium manganese oxide", "spinel", "spinel lmo", "lithium manganate"]
     },
     "lnmo": {
       "label": "Lithium nickel manganese oxide (LNMO)",
@@ -99,32 +136,35 @@
       "label": "NMC111 (LiNi1/3Mn1/3Co1/3O2)",
       "family": "active_cathode",
       "formula": "LiNi0.33Mn0.33Co0.33O2",
-      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
-      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_a0b57956_8ba1_4021_ade9_44a87d103d90",
+      "emmo": "LithiumNickelManganeseCobaltOxide111",
       "aliases": ["nmc111", "nmc 111", "nmc333", "ncm111", "lini0.33mn0.33co0.33o2", "lini1/3mn1/3co1/3o2"]
     },
     "nmc532": {
       "label": "NMC532 (LiNi0.5Mn0.3Co0.2O2)",
       "family": "active_cathode",
       "formula": "LiNi0.5Mn0.3Co0.2O2",
-      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
-      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_592acd61_23c8_4a1a_b41b_1eeabedc0710",
+      "emmo": "LithiumNickelManganeseCobaltOxide532",
+      "wikidata_qid": "Q121086662",
       "aliases": ["nmc532", "nmc 532", "ncm532", "lini0.5mn0.3co0.2o2"]
     },
     "nmc622": {
       "label": "NMC622 (LiNi0.6Mn0.2Co0.2O2)",
       "family": "active_cathode",
       "formula": "LiNi0.6Mn0.2Co0.2O2",
-      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
-      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_cfcde9c2_3a9c_4add_b27e_0ba0cedf1c70",
+      "emmo": "LithiumNickelManganeseCobaltOxide622",
+      "wikidata_qid": "Q121086348",
       "aliases": ["nmc622", "nmc 622", "ncm622", "lini0.6mn0.2co0.2o2"]
     },
     "nmc811": {
       "label": "NMC811 (LiNi0.8Mn0.1Co0.1O2)",
       "family": "active_cathode",
       "formula": "LiNi0.8Mn0.1Co0.1O2",
-      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d",
-      "emmo": "LithiumNickelManganeseCobaltOxide",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_e877987f_3b08_4e21_8f2e_c280e6bef52f",
+      "emmo": "LithiumNickelManganeseCobaltOxide811",
+      "wikidata_qid": "Q121086674",
       "aliases": ["nmc811", "nmc 811", "ncm811", "lini0.8mn0.1co0.1o2"]
     },
     "nca": {
@@ -178,7 +218,26 @@
       "formula": "LiPF6",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771",
       "emmo": "LithiumHexafluorophosphate",
+      "wikidata_qid": "Q2583808",
+      "pubchem_cid": "23688915",
+      "mp_id": "mp-9143",
       "aliases": ["lipf6", "lithium hexafluorophosphate"]
+    },
+    "litfsi": {
+      "label": "Lithium bis(trifluoromethanesulfonyl)imide (LiTFSI)",
+      "family": "electrolyte_salt",
+      "formula": "LiC2F6NO4S2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_8267551d_7572_42f6_888d_96ff0c78f3aa",
+      "emmo": "LithiumBistrifluoromethanesulfonylimide",
+      "aliases": ["litfsi", "lithium bis(trifluoromethanesulfonyl)imide", "lithium bistrifluoromethanesulfonylimide", "lithium bis(trifluoromethanesulfonyl)amide", "tfsi"]
+    },
+    "lifsi": {
+      "label": "Lithium bis(fluorosulfonyl)imide (LiFSI)",
+      "family": "electrolyte_salt",
+      "formula": "LiF2NO4S2",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731",
+      "emmo": "LithiumBisfluorosulfonylimide",
+      "aliases": ["lifsi", "lithium bis(fluorosulfonyl)imide", "lithium bisfluorosulfonylimide", "lithium bis(fluorosulfonyl)amide", "fsi"]
     },
     "koh": {
       "label": "Potassium hydroxide (KOH)",
@@ -194,6 +253,8 @@
       "formula": "C3H4O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_57339d90_0553_4a96_8da9_ff6c3684e226",
       "emmo": "EthyleneCarbonate",
+      "wikidata_qid": "Q421145",
+      "pubchem_cid": "7303",
       "aliases": ["ec", "ethylene carbonate"]
     },
     "emc": {
@@ -274,6 +335,15 @@
       "formula": "Al2O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_a2b46543_4d0f_488a_b51a_7ed3a4149170",
       "aliases": ["alumina", "aluminium oxide", "aluminum oxide", "al2o3", "al2o3 particles"]
+    },
+    "nmp": {
+      "label": "N-methyl-2-pyrrolidone (NMP)",
+      "family": "other",
+      "family_note": "Processing solvent (slurry casting), not an electrolyte solvent. The families enum has no processing_solvent value yet, so this sits under `other`.",
+      "formula": "C5H9NO",
+      "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c",
+      "emmo": "NMethyl2Pyrrolidone",
+      "aliases": ["nmp", "n-methyl-2-pyrrolidone", "n-methylpyrrolidone", "1-methyl-2-pyrrolidone", "methylpyrrolidone"]
     }
   }
 }

--- a/src/battinfo/jsonld.py
+++ b/src/battinfo/jsonld.py
@@ -1,8 +1,8 @@
 """Serialize BattINFO records as JSON-LD.
 
-Each record type (cell-spec, cell-instance, test, dataset) is transformed into
-valid JSON-LD using the curated property/unit mappings and the BattINFO records
-context at ``data/context/records.context.json``.
+Each record type (cell-spec, cell-instance, test, test-protocol, dataset) is
+transformed into valid JSON-LD using the curated property/unit mappings and the
+BattINFO records context at ``data/context/records.context.json``.
 
 The output is immediately usable by any JSON-LD processor (e.g. ``pyld``,
 ``rdflib`` + ``rdflib-jsonld``) to expand into RDF triples.
@@ -18,9 +18,10 @@ Usage::
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 _DATA = Path(__file__).parent / "data"
 _CONTEXT_PATH = _DATA / "context" / "records.context.json"
@@ -79,11 +80,47 @@ def _load_test_method_context_terms() -> dict:
         "LowerVoltageLimit", "UpperVoltageLimit", "TerminationQuantity",
         "CRate", "ElectricCurrent", "Voltage", "Power", "ElectricalResistance",
         "Duration", "ConventionalProperty",
+        # Characterisation-method classes a test protocol types itself with
+        # (see TEST_METHOD_CLASS). Pulled from the same bundled context, so the
+        # emitter, the hosted context and the validator allowlist cannot drift.
+        *TEST_METHOD_CLASS.values(),
     )
     return {t: db[t] for t in wanted if t in db}
 
 
+# Test-protocol ``kind`` -> characterisation-method class prefLabel. Only kinds whose
+# method has a published class are mapped; anything else keeps the untyped plan node.
+# Every prefLabel below is verified against domain-electrochemistry 0.36.0 (which
+# imports chameo) and resolves in the bundled domain-battery context.
+TEST_METHOD_CLASS: dict[str, str] = {
+    "gitt":            "GalvanostaticIntermittentTitrationTechnique",
+    "quasi_ocv":       "PseudoOpenCircuitVoltageMethod",
+    "eis":             "ElectrochemicalImpedanceSpectroscopy",
+    "impedance":       "ElectrochemicalImpedanceSpectroscopy",
+    "hppc":            "HPPC",
+    "cycling":         "CyclingTest",
+    "rate_capability": "CRateTest",
+    "capacity_check":  "CapacityTest",
+    "formation":       "FormationCycling",
+}
+
+
 TEST_METHOD_CONTEXT_TERMS = _load_test_method_context_terms()
+
+
+def test_method_class(kind: Any) -> str | None:
+    """A protocol/test ``kind`` -> its EMMO characterisation-method class, or ``None``.
+
+    Tolerant of the spellings importers produce ("GITT", "rate-capability",
+    "quasi OCV"); an unmapped kind returns ``None`` and the caller emits an
+    untyped plan node rather than inventing a class.
+    """
+    if not isinstance(kind, str) or not kind.strip():
+        return None
+    key = re.sub(r"[\s\-]+", "_", kind.strip().lower())
+    cls = TEST_METHOD_CLASS.get(key)
+    # Only offer a class the bundled context can actually resolve.
+    return cls if cls in TEST_METHOD_CONTEXT_TERMS else None
 
 
 def step_emmo_class(mode: str, direction: str | None) -> str | None:
@@ -184,6 +221,288 @@ TEST_PROTOCOL_CONTEXT_TERMS: dict[str, Any] = {
     "NumberOfIterations":   "electrochemistry:electrochemistry_88dd2bce_fb17_4705_905d_892681812290",
     "AmperePerAmpereHour":  "electrochemistry:AmperePerAmpereHour",
 }
+
+
+# ── Test-protocol node builder ────────────────────────────────────────────────
+# One implementation, two consumers: ``test_protocol_to_jsonld`` (a standalone
+# record document) and the publication graph builder in ``ws.py`` (the same node
+# as a graph member). Keeping it here is what keeps the two in parity — the
+# publication path had the only implementation, which is why record_to_jsonld
+# had no test-protocol emitter at all (readiness finding M5).
+
+
+def _unit_pref_labels() -> dict[str, tuple[str, str]]:
+    """{unit symbol -> (unit IRI, prefLabel)} from the curated unit map."""
+    path = _DATA / "mappings" / "domain-battery" / "unit_map.curated.json"
+    out: dict[str, tuple[str, str]] = {}
+    if not path.exists():
+        return out
+    for m in json.loads(path.read_text(encoding="utf-8")).get("mappings", []):
+        if m.get("symbol") and m.get("unit_iri") and m.get("unit_pref_label"):
+            out[m["symbol"]] = (m["unit_iri"], m["unit_pref_label"])
+    return out
+
+
+_UNIT_PREF_LABELS = _unit_pref_labels()
+
+
+def resolve_unit_iri(unit_symbol: str) -> str | None:
+    """Unit symbol -> compact unit IRI, across the curated maps, the records
+    context (V, mA, degC, ...) and the test-condition extras (A/Ah for C-rate)."""
+    if not unit_symbol:
+        return None
+    labelled = _UNIT_PREF_LABELS.get(unit_symbol)
+    if labelled:
+        return _compact_iri(labelled[0])
+    if unit_symbol in _UNIT_MAP:
+        return _compact_iri(_UNIT_MAP[unit_symbol])
+    ctx_val = _CONTEXT_INLINE.get(unit_symbol)
+    if isinstance(ctx_val, str) and (":" in ctx_val or ctx_val.startswith("http")):
+        return ctx_val
+    return TEST_CONDITION_UNIT_IRI.get(unit_symbol)
+
+
+def condition_quantity_node(key: str, value: Any, unit_symbol: str) -> dict | None:
+    """A test condition -> EMMO quantity node (the ``@type`` comes from the
+    controlled vocabulary), or ``None`` if the key is unmapped — the caller then
+    falls back to ``schema:PropertyValue``."""
+    cls = TEST_CONDITION_CLASS.get(str(key).lower())
+    if not cls:
+        return None
+    node: dict = {"@type": cls, "hasNumericalPart": {"hasNumberValue": value}}
+    # A generic class (e.g. ConventionalProperty for temperature) needs a human
+    # label to say *which* property it is.
+    if cls in TEST_CONDITION_GENERIC_CLASSES:
+        node["rdfs:label"] = str(key).replace("_", " ")
+    unit_iri = resolve_unit_iri(unit_symbol) if unit_symbol else (
+        # C-rate is dimensionless-by-symbol; default to AmperePerAmpereHour.
+        TEST_CONDITION_UNIT_IRI["A/Ah"] if cls == "CRate" else None
+    )
+    if unit_iri:
+        node["hasMeasurementUnit"] = {"@id": unit_iri}
+    return node
+
+
+def typed_quantity_node(emmo_class: str, value: Any, unit_symbol: str) -> dict:
+    """An EMMO quantity node with an explicit ``@type`` (used for method steps)."""
+    node: dict = {"@type": emmo_class, "hasNumericalPart": {"hasNumberValue": value}}
+    unit_iri = resolve_unit_iri(unit_symbol) if unit_symbol else None
+    if unit_iri:
+        node["hasMeasurementUnit"] = {"@id": unit_iri}
+    return node
+
+
+def method_step_node(step: Mapping[str, Any]) -> dict:
+    """A descriptive method step -> EMMO process node.
+
+    Groups become an ``IterativeWorkflow`` with ``NumberOfIterations`` + nested
+    ``hasTask``; leaf steps carry ``hasControlParameter`` /
+    ``hasTerminationParameter`` / ``hasProperty``.
+    """
+    mode = step.get("mode")
+    if mode == "group":
+        gnode: dict = {"@type": step_emmo_class("group", None) or "IterativeWorkflow"}
+        count = step.get("count")
+        if isinstance(count, int):
+            gnode["NumberOfIterations"] = {"hasNumericalPart": {"hasNumberValue": count}}
+        gnode["hasTask"] = [method_step_node(s) for s in (step.get("steps") or []) if isinstance(s, Mapping)]
+        return gnode
+
+    node: dict = {"@type": step_emmo_class(str(mode or ""), step.get("direction")) or "ElectrochemicalProcess"}
+    if step.get("description"):
+        node["rdfs:label"] = step["description"]
+    controls: list = []
+    for key, qty in (step.get("setpoints") or {}).items():
+        qcls = setpoint_emmo_class(key) or TEST_CONDITION_CLASS.get(str(key).lower())
+        if qcls and isinstance(qty, Mapping) and qty.get("value") is not None:
+            controls.append(typed_quantity_node(qcls, qty["value"], qty.get("unit", "")))
+    if controls:
+        node["hasControlParameter"] = controls
+    terminations: list = []
+    for term in (step.get("termination") or []):
+        if not isinstance(term, Mapping):
+            continue
+        tcls = termination_emmo_class(str(term.get("quantity") or ""), term.get("direction"))
+        if tcls and term.get("value") is not None:
+            terminations.append(typed_quantity_node(tcls, term["value"], term.get("unit", "")))
+    duration = step.get("duration")
+    if isinstance(duration, Mapping) and duration.get("value") is not None:
+        dcls = termination_emmo_class("duration", "elapsed") or "Duration"
+        terminations.append(typed_quantity_node(dcls, duration["value"], duration.get("unit", "")))
+    if terminations:
+        node["hasTerminationParameter"] = terminations
+    temperature = step.get("temperature")
+    if isinstance(temperature, Mapping) and temperature.get("value") is not None:
+        tnode = condition_quantity_node("temperature", temperature["value"], temperature.get("unit", ""))
+        if tnode is not None:
+            node["hasProperty"] = [tnode]
+    return node
+
+
+def protocol_property_value(name: str, value: Any, group: str = "") -> dict:
+    """Labelled ``schema:PropertyValue`` fallback for anything outside the
+    controlled condition vocabulary. ``group`` rides ``schema:propertyID`` so a
+    consumer can still tell a safety limit from an ambient condition."""
+    node: dict = {"@type": "schema:PropertyValue", "schema:name": name}
+    if group:
+        node["schema:propertyID"] = group
+    if isinstance(value, Mapping):
+        if value.get("value") is not None:
+            node["schema:value"] = value["value"]
+            if value.get("unit"):
+                node["schema:unitText"] = value["unit"]
+        else:
+            node["schema:value"] = json.dumps(dict(value), ensure_ascii=False, sort_keys=True)
+    else:
+        node["schema:value"] = value
+    return node
+
+
+def artifact_distribution_node(art: Mapping[str, Any], *, locator_url: Callable[[str], Any] | None = None) -> dict:
+    """An actionable artifact link -> a ``dcat:Distribution`` node, so the runnable
+    protocol file is machine-discoverable alongside the descriptive method.
+
+    *locator_url* resolves a workspace-relative locator to its hosted URL; the
+    publication path injects one (files being uploaded resolve to the deposit),
+    and the standalone record path leaves the locator as authored.
+    """
+    node: dict = {"@type": "dcat:Distribution"}
+    role = art.get("role")
+    fmt = art.get("format")
+    title = (role or "").replace("_", " ")
+    if fmt:
+        title = f"{title} ({fmt})".strip()
+    if title:
+        node["dcterms:title"] = title
+    loc = art.get("locator")
+    if loc:
+        if locator_url is not None:
+            node["dcat:downloadURL"] = locator_url(str(loc))
+        else:
+            node["dcat:downloadURL"] = (
+                {"@id": str(loc)} if str(loc).startswith(("http://", "https://")) else str(loc)
+            )
+    if art.get("media_type"):
+        node["dcat:mediaType"] = art["media_type"]
+    ct = art.get("conforms_to")
+    if ct:
+        node["dcterms:conformsTo"] = (
+            {"@id": ct} if str(ct).startswith(("http://", "https://")) else ct
+        )
+    if isinstance(art.get("byte_size"), int):
+        node["dcat:byteSize"] = art["byte_size"]
+    # Standard vocabulary (no custom battinfo: terms): the artifact role is a
+    # dcterms:type, the format token a dcterms:format, the checksum an spdx:Checksum.
+    if role:
+        node["dcterms:type"] = role
+    if fmt:
+        node["dcterms:format"] = fmt
+    if art.get("sha256"):
+        node["spdx:checksum"] = {
+            "@type": "spdx:Checksum",
+            "spdx:algorithm": "spdx:checksumAlgorithm_sha256",
+            "spdx:checksumValue": art["sha256"],
+        }
+    return node
+
+
+def test_protocol_node(
+    record: Mapping[str, Any],
+    *,
+    locator_url: Callable[[str], Any] | None = None,
+) -> dict | None:
+    """A test-protocol record -> its publication-graph node (no ``@context``).
+
+    PROV-O: the thing a ``prov:used`` plan-link targets is a ``prov:Plan``;
+    ``schema:HowTo`` is the schema.org analog for a procedure. Where the
+    protocol's kind names a published characterisation method (GITT, pseudo-OCV,
+    EIS, ...), that class joins the ``@type`` so the plan is queryable as the
+    method it is. Returns ``None`` when the record carries no protocol IRI.
+    """
+    raw_spec = record.get("test_spec")
+    spec: Mapping[str, Any] = raw_spec if isinstance(raw_spec, Mapping) else {}
+    iri = spec.get("id")
+    if not isinstance(iri, str) or not iri:
+        return None
+
+    types: list = ["prov:Plan", "schema:HowTo"]
+    method_class = test_method_class(spec.get("kind"))
+    if method_class:
+        types.append(method_class)
+    node: dict = {"@type": types, "@id": iri}
+    if spec.get("name"):
+        node["schema:name"] = spec["name"]
+    if spec.get("kind"):
+        node["schema:additionalType"] = spec["kind"]
+    if spec.get("description"):
+        node["schema:description"] = spec["description"]
+
+    # ── Descriptive method -> EMMO process graph (queryable) ──────────────────
+    # The ordered method becomes a hasTask chain of typed step nodes, each
+    # carrying hasControlParameter / hasTerminationParameter / hasProperty.
+    method = record.get("method") or []
+    if isinstance(method, list) and method:
+        node["hasTask"] = [method_step_node(s) for s in method if isinstance(s, Mapping)]
+
+    props: list = []
+    fallback: list = []
+    conditions = record.get("conditions")
+    if isinstance(conditions, Mapping):
+        for name, raw_value in conditions.items():
+            value = raw_value.get("value") if isinstance(raw_value, Mapping) else raw_value
+            unit = raw_value.get("unit", "") if isinstance(raw_value, Mapping) else ""
+            qnode = condition_quantity_node(name, value, unit) if value is not None else None
+            if qnode is not None:
+                props.append(qnode)
+            else:
+                fallback.append(protocol_property_value(name, raw_value, "conditions"))
+    if props:
+        node["hasProperty"] = props
+    # Global safety limits (max_voltage_V, max_temperature_degC, ...) are part of
+    # the protocol; emit each as a labelled PropertyValue so none is dropped.
+    safety = record.get("safety")
+    if isinstance(safety, Mapping):
+        for key, value in safety.items():
+            if value is not None:
+                fallback.append(protocol_property_value(str(key), value, "safety"))
+    if fallback:
+        node["schema:additionalProperty"] = fallback
+
+    # Actionable layer: link runnable protocol files as distributions.
+    artifacts = record.get("artifacts")
+    if isinstance(artifacts, list) and artifacts:
+        node["dcat:distribution"] = [
+            artifact_distribution_node(a, locator_url=locator_url) for a in artifacts if isinstance(a, Mapping)
+        ]
+    return node
+
+
+def test_protocol_context() -> dict:
+    """The ``@context`` a standalone test-protocol document needs.
+
+    The records context plus the prefLabel -> compact-IRI class table and the
+    method/protocol vocabulary — the same layering the publication graph uses, so
+    a protocol resolves identically standalone and inside a deposit.
+    """
+    from battinfo.transform.cell_spec_node import label_to_compact  # noqa: PLC0415
+
+    context: dict = dict(_CONTEXT_INLINE)
+    context.update(label_to_compact())
+    for term, value in TEST_PROTOCOL_CONTEXT_TERMS.items():
+        context.setdefault(term, value)
+    for term, value in TEST_METHOD_CONTEXT_TERMS.items():
+        context.setdefault(term, value)
+    return context
+
+
+def test_protocol_to_jsonld(record: dict) -> dict:
+    """Transform a test-protocol (test-spec) record dict to JSON-LD."""
+    node = test_protocol_node(record) or {"@type": ["prov:Plan", "schema:HowTo"], "@id": ""}
+    prov = record.get("provenance") or {}
+    if prov:
+        node["dcterms:source"] = _provenance(prov)
+    return {"@context": test_protocol_context(), **node}
+
 
 # EMMO battery-type IRIs (from domain-battery.context.json)
 _BATTERY_TYPE_IRIS: dict[str, str] = {
@@ -534,6 +853,10 @@ _TRANSFORMERS = {
     "cell-instance":  cell_instance_to_jsonld,
     "cell_instance":  cell_instance_to_jsonld,
     "test":           test_to_jsonld,
+    "test-protocol":  test_protocol_to_jsonld,
+    "test_protocol":  test_protocol_to_jsonld,
+    "test-spec":      test_protocol_to_jsonld,
+    "test_spec":      test_protocol_to_jsonld,
     "dataset":        dataset_to_jsonld,
     "material-spec":  _material_to_jsonld,
     "material_spec":  _material_to_jsonld,
@@ -581,7 +904,9 @@ def record_to_jsonld(record: dict, record_type: str, *, context: str = "url") ->
     record:
         The plain-JSON record dict (as loaded from ``.battinfo/records/``).
     record_type:
-        One of ``"cell-spec"``, ``"cell-instance"``, ``"test"``, ``"dataset"``.
+        One of ``"cell-spec"``, ``"cell-instance"``, ``"test"``,
+        ``"test-protocol"``, ``"dataset"``, ``"material-spec"``/``"material"``,
+        or a component spec/instance type.
     context:
         ``"url"`` (default) references the hosted context (``_CONTEXT_URL``)
         with a one-line ``@context`` — the hosted document carries the full

--- a/src/battinfo/materials.py
+++ b/src/battinfo/materials.py
@@ -100,6 +100,40 @@ def material_kind(value: Any) -> dict[str, Any] | None:
     entry["key"] = key
     return entry
 
+
+# ── External identity anchors ──────────────────────────────────────────────────
+#
+# A kind's ``chemsub`` class is its EMMO identity; these are the identifiers the
+# rest of materials science already uses for the same substance. Resolving them to
+# dereferenceable IRIs lets a consumer join a BattINFO material to Wikidata,
+# PubChem or the Materials Project without a lookup table.
+#
+# ``inchikey`` and ``cas_rn`` are carried as literals only: neither has a canonical,
+# freely-dereferenceable IRI form, so neither is emitted as ``skos:exactMatch``.
+# InChIKeys are also NOT guessed — molecular-species curation is a later pass.
+EXTERNAL_ID_IRI_TEMPLATES: dict[str, str] = {
+    "wikidata_qid": "http://www.wikidata.org/entity/{}",
+    "pubchem_cid": "https://pubchem.ncbi.nlm.nih.gov/compound/{}",
+    "mp_id": "https://next-gen.materialsproject.org/materials/{}",
+}
+EXTERNAL_ID_FIELDS: tuple[str, ...] = ("wikidata_qid", "inchikey", "pubchem_cid", "mp_id", "cas_rn")
+
+
+def material_kind_exact_match_iris(entry: Mapping[str, Any] | None) -> list[str]:
+    """Dereferenceable IRIs for a kind entry's external identity anchors.
+
+    Ordered by :data:`EXTERNAL_ID_IRI_TEMPLATES` so emission is deterministic.
+    Absent anchors yield nothing — an anchor is only ever present when verified.
+    """
+    if not isinstance(entry, Mapping):
+        return []
+    iris: list[str] = []
+    for field, template in EXTERNAL_ID_IRI_TEMPLATES.items():
+        value = entry.get(field)
+        if isinstance(value, str) and value.strip():
+            iris.append(template.format(value.strip()))
+    return iris
+
 # Cell-cell-specific composition fractions are not intrinsic material properties,
 # so they are dropped when lifting an embedded holder to a standalone spec.
 _CELL_LOCAL_PROPERTY_KEYS = {"mass_fraction", "volume_fraction", "weight_fraction"}

--- a/src/battinfo/transform/json_to_jsonld.py
+++ b/src/battinfo/transform/json_to_jsonld.py
@@ -1877,6 +1877,10 @@ def _material_node(body: dict[str, Any]) -> dict[str, Any]:
     ``schema:ChemicalSubstance`` node still carrying the chemsub link. When no
     kind is present (e.g. an embedded/imported material), fall back to resolving
     the name through the alias table, preserving prior behaviour.
+
+    The kind's verified external identity anchors (Wikidata, PubChem, Materials
+    Project) ride ``skos:exactMatch``, so a consumer can join the node to the
+    identifier systems the rest of materials science already uses.
     """
     node: dict[str, Any] = {}
     if isinstance(body.get("id"), str):
@@ -1890,14 +1894,20 @@ def _material_node(body: dict[str, Any]) -> dict[str, Any]:
         kind_entry = material_kind(kind)
     emmo_class = None
     same_as = None
+    exact_matches: list[str] = []
     if kind_entry is not None:
+        from battinfo.materials import material_kind_exact_match_iris
+
         emmo_class = kind_entry.get("emmo")
         same_as = kind_entry.get("chemsub")
+        exact_matches = material_kind_exact_match_iris(kind_entry)
     if emmo_class is None and isinstance(name, str) and name:
         emmo_class = _material_emmo_class(name)
     node["@type"] = emmo_class or "schema:ChemicalSubstance"
     if same_as:
         node["schema:sameAs"] = {"@id": same_as}
+    if exact_matches:
+        node["skos:exactMatch"] = [{"@id": iri} for iri in exact_matches]
     if isinstance(name, str) and name:
         node["schema:name"] = name
     if isinstance(body.get("formula"), str) and body["formula"]:

--- a/src/battinfo/validate/jsonld.py
+++ b/src/battinfo/validate/jsonld.py
@@ -273,6 +273,16 @@ def _allowed_type_terms() -> set[str]:
         if isinstance(emmo_class, str) and emmo_class:
             allowed.add(emmo_class)
 
+    # A material-spec types itself from its kind's curated ``emmo`` class, so the
+    # kind vocabulary is a term source in its own right — reading it here means
+    # adding a kind cannot produce a document the validator then rejects.
+    from battinfo.materials import material_kinds  # noqa: PLC0415
+
+    for entry in material_kinds().get("kinds", {}).values():
+        emmo_class = entry.get("emmo")
+        if isinstance(emmo_class, str) and emmo_class:
+            allowed.add(emmo_class)
+
     return allowed
 
 

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -789,28 +789,6 @@ def _resolve_project_openaire(identifier: str, *, timeout: float = 15.0) -> dict
         return {}
 
 
-def _property_value(name: str, value: Any, group: str = "") -> dict:
-    """Build a schema:PropertyValue for a structured test condition/setpoint.
-
-    Handles scalars, ``{value, unit}`` quantity dicts, and other mappings (stringified).
-    ``group`` (conditions/setpoints/termination_criteria) is recorded as schema:propertyID
-    so consumers can tell a setpoint from a termination criterion.
-    """
-    node: dict = {"@type": "schema:PropertyValue", "schema:name": name}
-    if group:
-        node["schema:propertyID"] = group
-    if isinstance(value, dict):
-        if value.get("value") is not None:
-            node["schema:value"] = value["value"]
-            if value.get("unit"):
-                node["schema:unitText"] = value["unit"]
-        else:
-            node["schema:value"] = json.dumps(value, ensure_ascii=False, sort_keys=True)
-    else:
-        node["schema:value"] = value
-    return node
-
-
 def _provider(creators: list[dict] | None, contributors: list[dict] | None) -> tuple[str, str]:
     """Best-effort publishing organisation: the first affiliation (name, ror) among agents."""
     for c in (creators or []) + (contributors or []):
@@ -2352,6 +2330,11 @@ class AuthoringWorkspace:
             "size_code": kwargs.get("size_code", None),
             "iec_code": kwargs.get("iec_code", None),
             "country_of_origin": kwargs.get("country_of_origin", None),
+            # Electrode configuration: full_cell | half_cell | three_electrode_cell.
+            # Leave null unless you know it; null is read as a full cell unless a
+            # reference_electrode is present.
+            "cell_configuration": kwargs.get("cell_configuration", None),
+            "reference_electrode": kwargs.get("reference_electrode", None),
             "rechargeable": kwargs.get("rechargeable", None),
             "year": kwargs.get("year", None),
             "source_file": kwargs.get("source_file", None),
@@ -4890,14 +4873,8 @@ class AuthoringWorkspace:
         any JSON-LD tool that resolves the embedded context.
         """
         from battinfo.jsonld import (
-            _UNIT_MAP,
-            TEST_CONDITION_CLASS,
-            TEST_CONDITION_GENERIC_CLASSES,
-            TEST_CONDITION_UNIT_IRI,
             funding_to_jsonld,
-            setpoint_emmo_class,
-            step_emmo_class,
-            termination_emmo_class,
+            test_protocol_node,
         )
 
         # Workspace funding project (grant) → schema:funding/Grant. The grant is
@@ -4937,8 +4914,6 @@ class AuthoringWorkspace:
                     _contrib_present.add(_key)
                     contributors.append(_agent)
 
-        _DATA_DIR = Path(__file__).parent / "data"
-
         # Shared canonical builders (also used by the resolver artifact path, so
         # both emitters produce byte-identical cell-spec nodes) plus the
         # prefLabel → compact-IRI table used for inline context terms.
@@ -4946,103 +4921,6 @@ class AuthoringWorkspace:
             build_cell_spec_node,
             label_to_compact,
         )
-        from battinfo.transform.cell_spec_node import (
-            compact_iri as _compact_iri,
-        )
-
-        # {unit_symbol → (unit_iri, prefLabel)} for test-condition / method-step units.
-        _unit_json = _DATA_DIR / "mappings" / "domain-battery" / "unit_map.curated.json"
-        _unit_label: dict[str, tuple[str, str]] = {}
-        if _unit_json.exists():
-            for m in json.loads(_unit_json.read_text(encoding="utf-8")).get("mappings", []):
-                if m.get("symbol") and m.get("unit_iri") and m.get("unit_pref_label"):
-                    _unit_label[m["symbol"]] = (m["unit_iri"], m["unit_pref_label"])
-
-        def _resolve_unit_iri(unit_symbol: str) -> str | None:
-            """Symbol → compact unit IRI, across curated maps, the records context
-            (V, mA, degC, …) and the test-condition extras (A/Ah for C-rate)."""
-            if not unit_symbol:
-                return None
-            ul = _unit_label.get(unit_symbol)
-            if ul:
-                return _compact_iri(ul[0])
-            if unit_symbol in _UNIT_MAP:
-                return _compact_iri(_UNIT_MAP[unit_symbol])
-            ctx_val = _RECORDS_CONTEXT.get(unit_symbol)
-            if isinstance(ctx_val, str) and (":" in ctx_val or ctx_val.startswith("http")):
-                return ctx_val
-            return TEST_CONDITION_UNIT_IRI.get(unit_symbol)
-
-        def _condition_quantity_node(key: str, value: Any, unit_symbol: str) -> dict | None:
-            """A test condition → EMMO quantity node (the @type comes from the
-            controlled vocabulary), or None if the key is unmapped (caller falls
-            back to schema:PropertyValue and emits a warning)."""
-            cls = TEST_CONDITION_CLASS.get(str(key).lower())
-            if not cls:
-                return None
-            node: dict = {"@type": cls, "hasNumericalPart": {"hasNumberValue": value}}
-            # A generic class (e.g. ConventionalProperty for temperature) needs a
-            # human label to say *which* property it is.
-            if cls in TEST_CONDITION_GENERIC_CLASSES:
-                node["rdfs:label"] = str(key).replace("_", " ")
-            unit_iri = _resolve_unit_iri(unit_symbol) if unit_symbol else (
-                # C-rate is dimensionless-by-symbol; default to AmperePerAmpereHour.
-                TEST_CONDITION_UNIT_IRI["A/Ah"] if cls == "CRate" else None
-            )
-            if unit_iri:
-                node["hasMeasurementUnit"] = {"@id": unit_iri}
-            return node
-
-        def _typed_quantity_node(emmo_class: str, value: Any, unit_symbol: str) -> dict:
-            """An EMMO quantity node with an explicit @type (used for method steps)."""
-            node: dict = {"@type": emmo_class, "hasNumericalPart": {"hasNumberValue": value}}
-            unit_iri = _resolve_unit_iri(unit_symbol) if unit_symbol else None
-            if unit_iri:
-                node["hasMeasurementUnit"] = {"@id": unit_iri}
-            return node
-
-        def _method_step_node(step: dict) -> dict:
-            """A descriptive method step → EMMO process node. Groups become an
-            IterativeWorkflow with NumberOfIterations + nested hasTask; leaf steps
-            carry hasControlParameter / hasTerminationParameter / hasProperty."""
-            mode = step.get("mode")
-            if mode == "group":
-                gnode: dict = {"@type": step_emmo_class("group", None) or "IterativeWorkflow"}
-                count = step.get("count")
-                if isinstance(count, int):
-                    gnode["NumberOfIterations"] = {"hasNumericalPart": {"hasNumberValue": count}}
-                gnode["hasTask"] = [_method_step_node(s) for s in (step.get("steps") or [])]
-                return gnode
-
-            node: dict = {"@type": step_emmo_class(str(mode or ""), step.get("direction")) or "ElectrochemicalProcess"}
-            if step.get("description"):
-                node["rdfs:label"] = step["description"]
-            controls: list = []
-            for key, qty in (step.get("setpoints") or {}).items():
-                qcls = setpoint_emmo_class(key) or TEST_CONDITION_CLASS.get(str(key).lower())
-                if qcls and isinstance(qty, dict) and qty.get("value") is not None:
-                    controls.append(_typed_quantity_node(qcls, qty["value"], qty.get("unit", "")))
-            if controls:
-                node["hasControlParameter"] = controls
-            terminations: list = []
-            for term in (step.get("termination") or []):
-                if not isinstance(term, dict):
-                    continue
-                tcls = termination_emmo_class(str(term.get("quantity") or ""), term.get("direction"))
-                if tcls and term.get("value") is not None:
-                    terminations.append(_typed_quantity_node(tcls, term["value"], term.get("unit", "")))
-            duration = step.get("duration")
-            if isinstance(duration, dict) and duration.get("value") is not None:
-                dcls = termination_emmo_class("duration", "elapsed") or "Duration"
-                terminations.append(_typed_quantity_node(dcls, duration["value"], duration.get("unit", "")))
-            if terminations:
-                node["hasTerminationParameter"] = terminations
-            temperature = step.get("temperature")
-            if isinstance(temperature, dict) and temperature.get("value") is not None:
-                tnode = _condition_quantity_node("temperature", temperature["value"], temperature.get("unit", ""))
-                if tnode is not None:
-                    node["hasProperty"] = [tnode]
-            return node
 
         def _artifact_download_url(loc: str) -> Any:
             """Resolve an artifact locator to its download URL. An http(s) locator is
@@ -5060,41 +4938,11 @@ class AuthoringWorkspace:
             return text
 
         def _artifact_distribution(art: dict) -> dict:
-            """An actionable artifact link → a dcat:Distribution node, so the runnable
-            protocol file is machine-discoverable alongside the descriptive method."""
-            node: dict = {"@type": "dcat:Distribution"}
-            role = art.get("role")
-            fmt = art.get("format")
-            title = (role or "").replace("_", " ")
-            if fmt:
-                title = f"{title} ({fmt})".strip()
-            if title:
-                node["dcterms:title"] = title
-            loc = art.get("locator")
-            if loc:
-                node["dcat:downloadURL"] = _artifact_download_url(loc)
-            if art.get("media_type"):
-                node["dcat:mediaType"] = art["media_type"]
-            ct = art.get("conforms_to")
-            if ct:
-                node["dcterms:conformsTo"] = (
-                    {"@id": ct} if str(ct).startswith(("http://", "https://")) else ct
-                )
-            if isinstance(art.get("byte_size"), int):
-                node["dcat:byteSize"] = art["byte_size"]
-            # Standard vocabulary (no custom battinfo: terms): the artifact role is a
-            # dcterms:type, the format token a dcterms:format, the checksum an spdx:Checksum.
-            if role:
-                node["dcterms:type"] = role
-            if fmt:
-                node["dcterms:format"] = fmt
-            if art.get("sha256"):
-                node["spdx:checksum"] = {
-                    "@type": "spdx:Checksum",
-                    "spdx:algorithm": "spdx:checksumAlgorithm_sha256",
-                    "spdx:checksumValue": art["sha256"],
-                }
-            return node
+            """An actionable artifact link → a dcat:Distribution node, resolving the
+            locator against the files being uploaded with this deposit."""
+            from battinfo.jsonld import artifact_distribution_node  # noqa: PLC0415
+
+            return artifact_distribution_node(art, locator_url=_artifact_download_url)
 
         # ── Load cell specs ────────────────────────────────────────────────────
         # One canonical builder (shared with the resolver path): the physical
@@ -5329,66 +5177,21 @@ class AuthoringWorkspace:
         # Each test activity's ``prov:used`` points at the spec it followed. Emit a
         # described node for that spec so the link resolves to a real node in the
         # graph instead of a dangling IRI — mirroring how cell specs and datasets
-        # are inlined above. PROV-O: the thing a ``prov:used`` plan-link targets is a
-        # ``prov:Plan``; ``schema:HowTo`` is the schema.org analog for a procedure.
+        # are inlined above. The node itself is built by the shared emitter in
+        # battinfo.jsonld, so a protocol published in a deposit and one emitted
+        # standalone by record_to_jsonld are the same graph.
         # The importer keys off ``BatteryTest``/``BatteryCellSpecification`` types
         # (see import_), so these nodes are ignored on round-trip — safe to add.
         test_spec_nodes: list[dict] = []
-        _tspec_recs = record_sets.get("test-protocol", [])
-        if _tspec_recs:
-            for raw in _tspec_recs:
-                try:
-                    spec = raw.get("test_spec", {})
-                    iri  = spec.get("id", "")
-                    if not iri:
-                        continue
-                    snode: dict = {
-                        "@type": ["prov:Plan", "schema:HowTo"],
-                        "@id":   iri,
-                    }
-                    if spec.get("name"):
-                        snode["schema:name"] = spec["name"]
-                    if spec.get("kind"):
-                        snode["schema:additionalType"] = spec["kind"]
-                    if spec.get("description"):
-                        snode["schema:description"] = spec["description"]
-                    # ── Descriptive method → EMMO process graph (queryable) ───────
-                    # The ordered method becomes a hasTask chain of typed step nodes,
-                    # each carrying hasControlParameter / hasTerminationParameter /
-                    # hasProperty quantities. Protocol-level ambient conditions attach
-                    # as hasProperty; names outside the controlled vocabulary fall back
-                    # to schema:PropertyValue (and trigger a publication warning).
-                    method = raw.get("method") or []
-                    if method:
-                        snode["hasTask"] = [_method_step_node(s) for s in method]
-                    _props: list = []
-                    _fallback: list = []
-                    for _name, _val in (raw.get("conditions") or {}).items():
-                        _v = _val.get("value") if isinstance(_val, dict) else _val
-                        _u = _val.get("unit", "") if isinstance(_val, dict) else ""
-                        qnode = _condition_quantity_node(_name, _v, _u) if _v is not None else None
-                        if qnode is not None:
-                            _props.append(qnode)
-                        else:
-                            _fallback.append(_property_value(_name, _val, "conditions"))
-                    if _props:
-                        snode["hasProperty"] = _props
-                    # Global safety limits (max_voltage_V, max_temperature_degC, ...)
-                    # are part of the protocol; emit each as a labelled PropertyValue
-                    # so they are not dropped from the publication graph.
-                    for _sk, _sv in (raw.get("safety") or {}).items():
-                        if _sv is not None:
-                            _fallback.append(_property_value(str(_sk), _sv, "safety"))
-                    if _fallback:
-                        snode["schema:additionalProperty"] = _fallback
-                    # Actionable layer: link runnable protocol files as distributions.
-                    if raw.get("artifacts"):
-                        snode["dcat:distribution"] = [
-                            _artifact_distribution(a) for a in raw["artifacts"] if isinstance(a, dict)
-                        ]
-                    test_spec_nodes.append(snode)
-                except Exception:
-                    continue
+        for raw in record_sets.get("test-protocol", []):
+            if not isinstance(raw, dict):
+                continue
+            try:
+                snode = test_protocol_node(raw, locator_url=_artifact_download_url)
+            except Exception:
+                continue
+            if snode is not None:
+                test_spec_nodes.append(snode)
 
         # ── Build dataset metadata ─────────────────────────────────────────────
         # A dataset may carry several distributions (files) — e.g. a normalised
@@ -6226,6 +6029,7 @@ class AuthoringWorkspace:
             "cell-spec":     "cell-spec",
             "cell-instance": "cell-instance",
             "test":          "test",
+            "test-protocol": "test-protocol",
             "dataset":       "dataset",
         }
 
@@ -6429,6 +6233,8 @@ class AuthoringWorkspace:
             size_code=raw.get("size_code"),
             iec_code=raw.get("iec_code"),
             country_of_origin=raw.get("country_of_origin"),
+            cell_configuration=raw.get("cell_configuration"),
+            reference_electrode=raw.get("reference_electrode"),
             rechargeable=raw.get("rechargeable"),
             year=raw.get("year"),
             specs=specs or None,

--- a/tests/test_cell_configuration.py
+++ b/tests/test_cell_configuration.py
@@ -1,0 +1,130 @@
+"""Explicit cell_configuration: authoring, save gate, and JSON-LD typing.
+
+The emitter has typed half-cells from the ``reference_electrode`` marker since the
+domain-battery 0.20.1 import. That heuristic is a guess; ``cell_configuration`` is
+the statement. These tests pin both, and the precedence between them.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import battinfo
+from battinfo.bundle import CellConfiguration, CellSpec
+from battinfo.jsonld import record_to_jsonld
+from battinfo.transform.cell_spec_node import physical_type_stack
+
+_BASE = {"cell_format": "coin", "chemistry": "li-ion", "positive_electrode_basis": "lfp"}
+
+
+@pytest.mark.parametrize(
+    ("configuration", "expected"),
+    [
+        ("half_cell", ("BatteryHalfCell", "HalfCellDevice")),
+        ("three_electrode_cell", ("ThreeElectrodeCellDevice",)),
+        ("full_cell", ()),
+    ],
+)
+def test_each_configuration_value_types_the_cell(configuration: str, expected: tuple[str, ...]) -> None:
+    types = physical_type_stack({**_BASE, "cell_configuration": configuration})
+    for cls in expected:
+        assert cls in types, f"{configuration}: expected {cls} in {types}"
+    # A device class is never invented for a configuration that does not name one.
+    if not expected:
+        assert not {"BatteryHalfCell", "HalfCellDevice", "ThreeElectrodeCellDevice"} & set(types)
+    # Never the electrode-plus-electrolyte class, whatever the configuration.
+    assert "ElectrochemicalHalfCell" not in types
+
+
+def test_reference_electrode_heuristic_still_applies_when_unstated() -> None:
+    types = physical_type_stack({**_BASE, "reference_electrode": "lithium"})
+    assert "BatteryHalfCell" in types and "HalfCellDevice" in types, types
+
+
+def test_explicit_full_cell_beats_the_reference_electrode_heuristic() -> None:
+    """A three-electrode full cell records a reference electrode and is still a
+    full cell — the stated configuration wins over the marker."""
+    types = physical_type_stack(
+        {**_BASE, "reference_electrode": "lithium", "cell_configuration": "full_cell"}
+    )
+    assert "BatteryHalfCell" not in types and "HalfCellDevice" not in types, types
+
+
+def test_explicit_three_electrode_beats_the_heuristic() -> None:
+    types = physical_type_stack(
+        {**_BASE, "reference_electrode": "lithium", "cell_configuration": "three_electrode_cell"}
+    )
+    assert "ThreeElectrodeCellDevice" in types, types
+    assert "BatteryHalfCell" not in types
+
+
+def test_descriptor_path_agrees_with_the_canonical_path() -> None:
+    from battinfo.transform.json_to_jsonld import _descriptor_specification_to_jsonld
+
+    node = _descriptor_specification_to_jsonld(
+        {"format": "coin", "chemistry": "li-ion", "cell_configuration": "three_electrode_cell"}
+    )
+    assert "ThreeElectrodeCellDevice" in node["isDescriptionFor"]["@type"]
+
+
+# ── authoring + persistence ────────────────────────────────────────────────────
+
+def test_authoring_round_trips_through_save_and_emission(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    draft = ws.template(
+        "cell-spec", manufacturer="Lab", model="HC-1", format="coin", chemistry="li-ion",
+        cell_configuration="half_cell", reference_electrode="lithium",
+    )
+    ws.load(draft)
+    ws.save()   # strict validation: the save gate must accept the enum value
+
+    written = next((tmp_path / ".battinfo" / "records" / "cell-spec").glob("*.json"))
+    record = json.loads(written.read_text(encoding="utf-8"))
+    assert record["cell_spec"]["cell_configuration"] == "half_cell"
+    assert record["cell_spec"]["reference_electrode"] == "lithium"
+
+    back = CellSpec.from_record(record)
+    assert back.cell_configuration is CellConfiguration.HALF_CELL
+    assert back.reference_electrode == "lithium"
+
+    types = record_to_jsonld(record, "cell-spec")["isDescriptionFor"]["@type"]
+    assert "BatteryHalfCell" in types and "HalfCellDevice" in types
+
+
+def test_save_gate_rejects_a_value_outside_the_enum(tmp_path: Path) -> None:
+    from battinfo.validate.record import validate_record
+
+    ws = battinfo.workspace(str(tmp_path))
+    ws.load(ws.template("cell-spec", manufacturer="Lab", model="X", format="coin", chemistry="li-ion"))
+    ws.save()
+    written = next((tmp_path / ".battinfo" / "records" / "cell-spec").glob("*.json"))
+    record = json.loads(written.read_text(encoding="utf-8"))
+
+    record["cell_spec"]["cell_configuration"] = "quarter_cell"
+    report = validate_record(record, policy="strict")
+    assert not report.ok
+    assert any("cell_configuration" in issue.path for issue in report.issues)
+
+
+def test_configuration_is_optional_and_absent_by_default(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    ws.load(ws.template("cell-spec", manufacturer="Lab", model="X", format="coin", chemistry="li-ion"))
+    ws.save()
+    written = next((tmp_path / ".battinfo" / "records" / "cell-spec").glob("*.json"))
+    record = json.loads(written.read_text(encoding="utf-8"))
+    assert "cell_configuration" not in record["cell_spec"]
+
+
+def test_model_and_json_schema_agree_on_the_enum() -> None:
+    from importlib import resources
+
+    schema_file = resources.files("battinfo").joinpath("data", "schemas", "cell-spec.schema.json")
+    with schema_file.open("r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    values = schema["properties"]["cell_spec"]["properties"]["cell_configuration"]["enum"]
+    assert set(values) == {c.value for c in CellConfiguration}
+    from battinfo.bundle_generated import CellConfiguration as GeneratedCellConfiguration
+
+    assert {c.value for c in GeneratedCellConfiguration} == set(values)

--- a/tests/test_materials_first_class.py
+++ b/tests/test_materials_first_class.py
@@ -108,10 +108,15 @@ def test_m6_jsonld_emitted_for_spec_and_instance() -> None:
 def test_m6_kind_without_emmo_class_uses_labeled_fallback() -> None:
     from battinfo.jsonld import record_to_jsonld
 
-    # silicon_graphite is a genuine ontology gap: no emmo class, no chemsub.
-    spec = api.create_material_spec(name="Anode blend", kind="si/gr", validate=False)
+    # mno2 is anchored in chemical-substance but has no domain-battery class the
+    # bundled context resolves, so the node falls back to a labeled
+    # schema:ChemicalSubstance that still carries the chemsub link.
+    spec = api.create_material_spec(name="EMD cathode powder", kind="mno2", validate=False)
     ld = record_to_jsonld(spec, "material-spec")
     assert ld["@type"] == "schema:ChemicalSubstance"  # labeled fallback, not invented term
+    assert ld["schema:sameAs"]["@id"].startswith(
+        "https://w3id.org/emmo/domain/chemical-substance#"
+    )
 
 
 # ── kind vocabulary + validation ────────────────────────────────────────────────
@@ -144,13 +149,70 @@ def test_missing_kind_blocks_strict_save_only(tmp_path: Path) -> None:
 
 def test_kinds_carry_chemsub_or_are_flagged_gaps() -> None:
     kinds = battinfo.material_kinds()["kinds"]
-    # the 12 seed kinds required by the model are present
-    required = {"graphite", "silicon", "silicon_graphite", "lnmo", "lfp", "nmc111",
-                "nmc532", "nmc811", "lithium_metal", "pvdf", "carbon_black", "lipf6"}
+    # the full seed set the model requires is present
+    required = {"graphite", "silicon", "silicon_graphite", "hard_carbon", "lto",
+                "lnmo", "lfp", "lmo", "nmc111", "nmc532", "nmc622", "nmc811",
+                "lithium_metal", "pvdf", "carbon_black", "lipf6", "litfsi",
+                "lifsi", "nmp"}
     assert required.issubset(kinds)
-    # mapped kinds anchor to the chemical-substance ontology
-    assert kinds["graphite"]["chemsub"].startswith(
-        "https://w3id.org/emmo/domain/chemical-substance#"
-    )
-    # a genuine gap omits chemsub (ontology-additions backlog), does not invent one
-    assert "chemsub" not in kinds["silicon_graphite"]
+    # every chemsub anchor is a chemical-substance class IRI; none is invented
+    for key, entry in kinds.items():
+        chemsub = entry.get("chemsub")
+        assert chemsub is None or chemsub.startswith(
+            "https://w3id.org/emmo/domain/chemical-substance#substance_"
+        ), f"{key} carries a non-chemical-substance anchor"
+    # silicon_graphite was the seed's ontology gap; chemical-substance 0.15.0
+    # published SiliconGraphite, so it now anchors like the rest
+    assert kinds["silicon_graphite"]["emmo"] == "SiliconGraphite"
+
+
+def test_every_kind_emmo_class_resolves_in_the_bundled_context() -> None:
+    """A kind's ``emmo`` class must be a term the domain-battery context resolves,
+    and must name the same substance as its ``chemsub`` anchor."""
+    import json
+    from importlib import resources
+
+    ctx_file = resources.files("battinfo").joinpath("data", "context", "domain-battery.context.json")
+    with ctx_file.open("r", encoding="utf-8") as handle:
+        context = json.load(handle)["@context"]
+    for key, entry in battinfo.material_kinds()["kinds"].items():
+        emmo_class = entry.get("emmo")
+        if emmo_class is None:
+            continue
+        assert emmo_class in context, f"{key}: {emmo_class} does not resolve in the bundled context"
+        if entry.get("chemsub"):
+            assert context[emmo_class] == entry["chemsub"], f"{key}: emmo/chemsub disagree"
+
+
+def test_external_identity_anchors_emit_as_exact_match() -> None:
+    from battinfo.jsonld import record_to_jsonld
+
+    spec = api.create_material_spec(name="SLP30", kind="graphite", validate=False)
+    matches = {m["@id"] for m in record_to_jsonld(spec, "material-spec")["skos:exactMatch"]}
+    assert matches == {
+        "http://www.wikidata.org/entity/Q5309",
+        "https://pubchem.ncbi.nlm.nih.gov/compound/5462310",
+        "https://next-gen.materialsproject.org/materials/mp-48",
+    }
+    # a kind with no verified anchors emits none, rather than a guessed one
+    plain = api.create_material_spec(name="PVDF binder", kind="pvdf", validate=False)
+    assert "skos:exactMatch" not in record_to_jsonld(plain, "material-spec")
+
+
+def test_no_inchikeys_are_guessed() -> None:
+    """The field exists on the schema; molecular-species curation follows later.
+    Populating it with anything unverified is the failure mode this guards."""
+    kinds = battinfo.material_kinds()["kinds"]
+    assert not [k for k, e in kinds.items() if e.get("inchikey")]
+
+
+def test_anchor_fields_stay_inside_the_declared_set() -> None:
+    """A typo'd anchor key would silently emit nothing; pin the field names."""
+    from battinfo.materials import EXTERNAL_ID_FIELDS, EXTERNAL_ID_IRI_TEMPLATES
+
+    known = {"label", "family", "family_note", "formula", "chemsub", "emmo",
+             "aliases", "reference_properties", *EXTERNAL_ID_FIELDS}
+    for key, entry in battinfo.material_kinds()["kinds"].items():
+        unexpected = set(entry) - known
+        assert not unexpected, f"{key} carries unrecognised fields {unexpected}"
+    assert set(EXTERNAL_ID_IRI_TEMPLATES).issubset(EXTERNAL_ID_FIELDS)

--- a/tests/test_test_protocol_jsonld.py
+++ b/tests/test_test_protocol_jsonld.py
@@ -1,0 +1,159 @@
+"""Test-protocol JSON-LD emission (readiness finding M5).
+
+Protocols were the last record type ``record_to_jsonld`` could not emit: the only
+implementation lived inside the publication graph builder. It now lives in
+``battinfo.jsonld`` and both callers share it, so a protocol published in a deposit
+and one exported standalone are the same graph.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from rdflib import Graph
+
+import battinfo
+
+# Imported as a module, not by name: the protocol helpers follow the existing
+# ``test_to_jsonld`` naming, so importing them here would have pytest try to
+# collect them as test functions.
+from battinfo import jsonld as bi_jsonld
+from battinfo.jsonld import record_to_jsonld
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "src" / "battinfo" / "data" / "examples" / "test-protocol"
+
+
+def _example(uid: str) -> dict:
+    return json.loads((EXAMPLES / f"test-protocol-{uid}.json").read_text(encoding="utf-8"))
+
+
+def test_record_to_jsonld_accepts_test_protocol() -> None:
+    doc = record_to_jsonld(_example("3p7k-2m9r-6t4n-1v8x"), "test-protocol", context="inline")
+    assert doc["@id"] == "https://w3id.org/battinfo/spec/3p7k-2m9r-6t4n-1v8x"
+    assert "prov:Plan" in doc["@type"] and "schema:HowTo" in doc["@type"]
+
+
+@pytest.mark.parametrize("alias", ["test-protocol", "test_protocol", "test-spec", "test_spec"])
+def test_every_record_type_alias_routes_to_the_protocol_emitter(alias: str) -> None:
+    assert record_to_jsonld(_example("3p7k-2m9r-6t4n-1v8x"), alias)["@id"]
+
+
+def test_protocol_types_itself_with_its_method_class() -> None:
+    gitt = record_to_jsonld(_example("3p7k-2m9r-6t4n-1v8x"), "test-protocol")
+    assert "GalvanostaticIntermittentTitrationTechnique" in gitt["@type"]
+    pocv = record_to_jsonld(_example("t163-7ba5-r0kn-h9my"), "test-protocol")
+    assert "PseudoOpenCircuitVoltageMethod" in pocv["@type"]
+
+
+def test_unmapped_kind_keeps_the_plan_node_untyped() -> None:
+    assert bi_jsonld.test_method_class("some-bespoke-procedure") is None
+    node = bi_jsonld.test_protocol_node({"test_spec": {"id": "https://example.org/p", "kind": "other"}})
+    assert node["@type"] == ["prov:Plan", "schema:HowTo"]
+
+
+def test_method_kind_spellings_importers_produce_all_resolve() -> None:
+    for spelling in ("GITT", "gitt", "quasi ocv", "quasi-ocv", "rate-capability"):
+        assert bi_jsonld.test_method_class(spelling) is not None, spelling
+
+
+def test_a_record_without_a_protocol_iri_yields_no_node() -> None:
+    assert bi_jsonld.test_protocol_node({"test_spec": {"name": "draft"}}) is None
+
+
+def test_every_shipped_protocol_example_parses_as_rdf() -> None:
+    """A typed method node is worth nothing if the document does not expand."""
+    seen_method_class = 0
+    for path in sorted(EXAMPLES.glob("*.json")):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        doc = record_to_jsonld(record, "test-protocol", context="inline")
+        graph = Graph()
+        graph.parse(data=json.dumps(doc), format="json-ld")
+        assert len(graph) > 0, f"{path.name} expanded to no triples"
+        if len(doc["@type"]) > 2:
+            seen_method_class += 1
+    assert seen_method_class >= 5, "expected the shipped examples to exercise several method classes"
+
+
+def test_method_steps_become_a_typed_task_chain() -> None:
+    doc = record_to_jsonld(_example("j19t-9cm0-f219-zh4y"), "test-protocol", context="inline")
+    tasks = doc["hasTask"]
+    assert tasks, "a protocol with a descriptive method must emit hasTask"
+    # Every step node carries a bare EMMO process class, never a raw literal.
+    for task in tasks:
+        assert isinstance(task["@type"], str) and ":" not in task["@type"]
+
+
+def test_hosted_context_resolves_everything_the_protocol_emitter_uses() -> None:
+    """``context="url"`` is only safe if the hosted document is a superset."""
+    from importlib import resources
+
+    ctx_file = resources.files("battinfo").joinpath("data", "context", "records.context.v1.json")
+    with ctx_file.open("r", encoding="utf-8") as handle:
+        hosted = json.load(handle)["@context"]
+    for path in sorted(EXAMPLES.glob("*.json")):
+        doc = record_to_jsonld(json.loads(path.read_text(encoding="utf-8")), "test-protocol", context="inline")
+        for term in _bare_terms(doc):
+            assert term in hosted, f"{path.name}: {term} missing from the hosted context"
+
+
+def _bare_terms(node: object, out: set[str] | None = None) -> set[str]:
+    """Every key and bare @type token a document uses (skipping the context)."""
+    out = set() if out is None else out
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "@context":
+                continue
+            if not key.startswith("@") and ":" not in key:
+                out.add(key)
+            if key == "@type":
+                for token in (value if isinstance(value, list) else [value]):
+                    if isinstance(token, str) and ":" not in token:
+                        out.add(token)
+            else:
+                _bare_terms(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _bare_terms(item, out)
+    return out
+
+
+def test_publication_graph_and_standalone_document_agree(tmp_path: Path) -> None:
+    """The two consumers of the shared builder must produce the same node."""
+    record = _example("j19t-9cm0-f219-zh4y")
+    ws = battinfo.workspace(str(tmp_path))
+    graph_doc = ws._assemble_zenodo_jsonld(
+        {"test-protocol": [record]},
+        zenodo_record_id=1, prereserved_doi="10.5281/zenodo.1",
+        record_url="https://zenodo.org/records/1", data_filenames=[],
+        title="t", description="d", license="CC-BY-4.0",
+    )
+    graph_node = next(n for n in graph_doc["@graph"] if n.get("@id") == record["test_spec"]["id"])
+    standalone = {k: v for k, v in record_to_jsonld(record, "test-protocol").items()
+                  if k not in ("@context", "dcterms:source")}
+    for key, value in standalone.items():
+        assert graph_node.get(key) == value, f"{key} differs between the two emitters"
+
+
+def test_attribution_is_stamped_like_every_other_record_type() -> None:
+    record = dict(_example("3p7k-2m9r-6t4n-1v8x"))
+    record["license"] = "https://creativecommons.org/licenses/by/4.0/"
+    record["contributor"] = [{"name": "Josiah Carberry",
+                              "same_as": "https://orcid.org/0000-0002-1825-0097"}]
+    record["funding"] = {"identifier": "101103997", "name": "A grant"}
+    doc = record_to_jsonld(record, "test-protocol")
+    assert doc["dcterms:license"]["@id"] == record["license"]
+    assert doc["schema:contributor"][0]["@id"].endswith("0000-0002-1825-0097")
+    assert doc["schema:funding"]["schema:identifier"] == "101103997"
+
+
+def test_export_writes_a_protocol_document(tmp_path: Path) -> None:
+    ws = battinfo.workspace(str(tmp_path))
+    records = tmp_path / ".battinfo" / "records" / "test-protocol"
+    records.mkdir(parents=True)
+    record = _example("3p7k-2m9r-6t4n-1v8x")
+    (records / "test-protocol-3p7k-2m9r-6t4n-1v8x.json").write_text(
+        json.dumps(record), encoding="utf-8"
+    )
+    written = ws.export()
+    assert any(p.name.endswith(".jsonld") and "test-protocol" in p.parent.name for p in written)

--- a/web/lib/records-context.generated.ts
+++ b/web/lib/records-context.generated.ts
@@ -493,6 +493,15 @@ export const recordsContext: Record<string, unknown> = {
     "ElectricCurrent": "https://w3id.org/emmo#EMMO_c995ae70_3b84_4ebb_bcfc_69e6a281bb88",
     "Voltage": "https://w3id.org/emmo#EMMO_17b031fb_4695_49b6_bb69_189ec63df3ee",
     "Power": "https://w3id.org/emmo#EMMO_09b9021b_f97b_43eb_b83d_0a764b472bc2",
-    "Duration": "https://w3id.org/emmo#EMMO_0adabf6f_7404_44cb_9f65_32d83d8101a3"
+    "Duration": "https://w3id.org/emmo#EMMO_0adabf6f_7404_44cb_9f65_32d83d8101a3",
+    "GalvanostaticIntermittentTitrationTechnique": "https://w3id.org/emmo/domain/characterisation-methodology/chameo#GalvanostaticIntermittentTitrationTechnique",
+    "PseudoOpenCircuitVoltageMethod": "https://w3id.org/emmo/domain/characterisation-methodology/chameo#PseudoOpenCircuitVoltageMethod",
+    "HPPC": "https://w3id.org/emmo/domain/characterisation-methodology/chameo#HPPC",
+    "CyclingTest": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_435b22d4_c441_45ea_8c79_0cbec11fd287",
+    "CRateTest": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_99b2b3ad_8efc_48ee_a630_6d805a47efdc",
+    "CapacityTest": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_137dc19f_a3af_49af_971f_743d27e09f43",
+    "FormationCycling": "https://w3id.org/emmo/domain/electrochemistry#electrochemistry_cb223440_51bd_4f16_a536_96ec408e7de4",
+    "ControlProperty": "electrochemistry:electrochemistry_33e6986c_b35a_4cae_9a94_acb23248065c",
+    "AmperePerAmpereHour": "electrochemistry:AmperePerAmpereHour"
   }
 };

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -1439,6 +1439,15 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
             "reference_electrode": {
               "type": "string",
               "description": "Counter/reference electrode for half-cell configurations (e.g. 'lithium', 'NHE')."
+            },
+            "cell_configuration": {
+              "type": "string",
+              "enum": [
+                "full_cell",
+                "half_cell",
+                "three_electrode_cell"
+              ],
+              "description": "Electrode configuration as built. Optional; absent means unstated (read as a full cell unless a reference_electrode is present). Stated explicitly it overrides that heuristic: half_cell types the JSON-LD as BatteryHalfCell + HalfCellDevice, three_electrode_cell as ThreeElectrodeCellDevice, full_cell suppresses both."
             }
           }
         },


### PR DESCRIPTION
## What

Four related pieces of the materials/half-cell work, on top of #330 and #331.

1. **Kind vocabulary top-up (0.1.0 -> 0.2.0).** Six kinds added (`lto`, `lmo`, `hard_carbon`, `litfsi`, `lifsi`, `nmp`), taking it to 38. `silicon_graphite` and the four NMC ratios repoint onto the stoichiometric classes chemical-substance 0.15.0 published, instead of sharing the generic `LithiumNickelManganeseCobaltOxide`. Every kind now carries a `chemsub` anchor.
2. **External identity anchors.** Optional `wikidata_qid`, `inchikey`, `pubchem_cid`, `mp_id`, `cas_rn` per kind. The three with a dereferenceable form emit as `skos:exactMatch`.
3. **`cell_spec.cell_configuration`.** Optional `full_cell` | `half_cell` | `three_electrode_cell`, no default.
4. **Test-protocol JSON-LD emission** — closes readiness finding M5.

## Why

The seed vocabulary was written before chemical-substance 0.15.0 shipped, so five kinds pointed at a generic class or nothing at all. NMC532 and NMC811 resolving to the same IRI defeats the aggregation the genome exists for.

`chemsub` is the EMMO identity, but nobody outside the EMMO ecosystem starts there. A Wikidata QID, a PubChem CID or an mp-id is how a consumer joins a BattINFO material to the rest of materials science, and hardcoding those joins downstream is exactly the lookup table the vocabulary is supposed to remove.

The half-cell typing added in #331 reads `reference_electrode` because there was nothing better to read. That is a guess: a three-electrode full cell records a reference electrode and is not a half-cell, and the heuristic has no way to be told so.

`record_to_jsonld` handled every record type except test protocols. The publication graph builder had a perfectly good protocol emitter, but it lived inside a nested closure in `ws.py`, so nothing else could reach it. Protocols were the last record type a user could not export.

## How

**Vocabulary.** Every IRI verified against the `0.15.0` tag before writing. Anchors are populated only where verified; an absent one means unverified, never guessed. No InChIKeys are populated — molecular-species curation is a later pass, and the field exists so that pass has somewhere to land. `mp_id` denotes a representative ordered structure, so the solid-solution families (NMC, NCA, LMFP) carry none by design.

NMP is a processing solvent, not an electrolyte solvent. The families enum has no `processing_solvent` value, so it sits under `other` with a `family_note` saying why, rather than stretching `electrolyte_solvent`.

`validate/jsonld.py` now reads the kind vocabulary as a term source, so adding a kind cannot produce a document the validator then rejects.

**cell_configuration.** Through the LinkML pipeline: enum in `schema/types.yaml`, `ct_cell_configuration` slot in `schema/cell-spec.yaml`, then the two `gen-pydantic` hunks patched into `bundle_generated.py` (the #331 pattern — a full regen still produces unrelated churn). Save gate gains the enum in `cell-spec.schema.json`; `assets/` and the packaged copy stay byte-identical.

Explicit wins over the heuristic in both directions, which is the point: `full_cell` suppresses it even with a reference electrode present. `reference_electrode` joins the model at the same time — the schema permitted it but nothing modelled it, so it was unauthorable and dropped on save.

`entity_type_map.json` gains `three-electrode-cell` alongside the existing `three-electrode`, since the enum value normalizes to the former and tolerant import produces the latter.

**Protocol emission.** The nested helpers in `_assemble_zenodo_jsonld` move to `battinfo.jsonld` as module-level functions and `ws.py` calls them, so there is one implementation rather than two that can drift. `record_to_jsonld` gains `test-protocol` (plus `test_protocol`/`test-spec`/`test_spec` aliases) and `ws.export()` writes protocol documents.

The plan node additionally types itself with the published characterisation-method class where the protocol's kind names one — GITT, pseudo-OCV, EIS, HPPC, cycling, rate capability, capacity check, formation. Kinds with no published class keep the untyped `prov:Plan` / `schema:HowTo` node rather than inventing one. The IRIs come from the bundled domain-battery context, not from literals here, so the emitter, the hosted records context and the validator allowlist share one source.

`scripts/gen_context.py` folds the protocol terms into `records.context.v1.json` with `setdefault`, so the hosted context stays a true superset for `context="url"` without rewriting any published term. Purely additive: 10 new terms, no value changes. `records.context.json` is untouched (`assemble_context.py --check` is stale on main for unrelated keys).

## Testing

`uv run pytest` 1684 passed, 1 skipped. `ruff check src tests scripts` clean. `mypy` clean over 69 files. `.tools/quality/run_verification.py` exit 0. `gen_context.py --check` and `sync_examples.py --check` in sync; `npm run sync:schemas -- --check` and `sync:context -- --check` in sync.

New: `tests/test_cell_configuration.py` (11) covers each enum value's type stack, the heuristic fallback, explicit-beats-heuristic both ways, authoring round-trip through save, save-gate rejection of an out-of-enum value, and model/schema/generated-enum agreement. `tests/test_test_protocol_jsonld.py` (15) covers the dispatcher aliases, method-class typing, the untyped fallback, rdflib parsing of all 20 shipped protocol examples, hosted-context completeness, attribution parity, and that the publication graph and the standalone document produce the same node.

Existing material tests updated where 0.15.0 changed the facts: `silicon_graphite` is no longer an ontology gap, so the labeled-fallback test moves to `mno2` (anchored, no domain-battery class). Added checks that every kind's `emmo` class resolves in the bundled context and agrees with its `chemsub`, that anchors emit as `skos:exactMatch`, that no InChIKeys are populated, and that no kind carries an unrecognised field.
