### PR TITLE
Publish the checksum algorithm a record states, stop collapsing cells on their label

### DIFF
--- a/src/battinfo/api/_resolver.py
+++ b/src/battinfo/api/_resolver.py
@@ -26,6 +26,7 @@ from battinfo.api._shared import (
     _validate_canonical_record,
     _validate_publication_artifact,
 )
+from battinfo.jsonld import schema_checksum_terms
 from battinfo.transform.cell_spec_node import build_cell_spec_node
 from battinfo.validate.core import DEFAULT_POLICY, ValidationPolicy
 
@@ -152,13 +153,6 @@ def _schema_distribution_value(value: Any, *, part_of_id: str) -> dict[str, Any]
         and not isinstance(checksum, Mapping)
     ):
         return None
-    if not (
-        isinstance(checksum, Mapping)
-        and isinstance(checksum.get("algorithm"), str)
-        and checksum["algorithm"].lower() == "sha256"
-        and isinstance(checksum.get("value"), str)
-    ):
-        return None
     out: dict[str, Any] = {"@type": "schema:DataDownload"}
     if isinstance(value.get("name"), str):
         out["schema:name"] = value["name"]
@@ -173,7 +167,10 @@ def _schema_distribution_value(value: Any, *, part_of_id: str) -> dict[str, Any]
     if isinstance(value.get("accessLevel"), str):
         out["schema:accessLevel"] = value["accessLevel"]
     out["schema:isPartOf"] = {"@id": part_of_id}
-    out["schema:sha256"] = checksum["value"]
+    # schema:sha256 for a genuine sha256, a named PropertyValue for anything else.
+    # Previously a non-sha256 (or absent) checksum dropped the WHOLE distribution
+    # from the resolved document — URL, format and size with it.
+    out.update(schema_checksum_terms(checksum))
     return out
 
 

--- a/src/battinfo/jsonld.py
+++ b/src/battinfo/jsonld.py
@@ -358,6 +358,80 @@ def protocol_property_value(name: str, value: Any, group: str = "") -> dict:
     return node
 
 
+# ── File checksums ────────────────────────────────────────────────────────────
+#
+# A published digest is an assertion about a file, and a deposit is permanent, so
+# the algorithm is always taken from the record and never assumed. SPDX 2.x names
+# its hash-algorithm individuals ``spdx:checksumAlgorithm_<name>``; only the
+# algorithms SPDX actually defines get an IRI. Anything else (the dataset
+# schema's "other" escape hatch) keeps its name as a plain literal rather than
+# inventing an SPDX term that does not exist.
+_SPDX_CHECKSUM_ALGORITHMS: frozenset[str] = frozenset({
+    "adler32", "blake2b256", "blake2b384", "blake2b512", "blake3",
+    "md2", "md4", "md5", "md6",
+    "sha1", "sha224", "sha256", "sha384", "sha512",
+    "sha3_256", "sha3_384", "sha3_512",
+})
+
+
+def _checksum_parts(checksum: Any) -> tuple[str, str] | None:
+    """``(algorithm, value)`` from a record checksum block, or None if unusable."""
+    if not isinstance(checksum, Mapping):
+        return None
+    algorithm = checksum.get("algorithm")
+    value = checksum.get("value")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    if not isinstance(algorithm, str) or not algorithm.strip():
+        return None
+    return algorithm.strip().lower(), value.strip()
+
+
+def checksum_node(checksum: Any) -> dict | None:
+    """A record ``checksum`` block -> an ``spdx:Checksum`` node, or None.
+
+    The node carries the algorithm the record ACTUALLY states. Emitting an md5
+    digest under the sha256 term would publish a false claim about the file, so
+    the algorithm is never defaulted; where SPDX defines the algorithm the term
+    is an IRI reference, so it links to the SPDX individual rather than being a
+    look-alike string.
+    """
+    parts = _checksum_parts(checksum)
+    if parts is None:
+        return None
+    algorithm, value = parts
+    node: dict = {"@type": "spdx:Checksum"}
+    if algorithm in _SPDX_CHECKSUM_ALGORITHMS:
+        node["spdx:checksumAlgorithm"] = {"@id": f"spdx:checksumAlgorithm_{algorithm}"}
+    else:
+        node["spdx:checksumAlgorithm"] = algorithm
+    node["spdx:checksumValue"] = value
+    return node
+
+
+def schema_checksum_terms(checksum: Any) -> dict:
+    """A record ``checksum`` block -> its schema.org terms (``{}`` when unusable).
+
+    schema.org names exactly one algorithm (``schema:sha256``), so that term is
+    reserved for a genuine sha256; every other algorithm rides a named
+    ``schema:PropertyValue`` instead of being relabeled as one.
+    """
+    parts = _checksum_parts(checksum)
+    if parts is None:
+        return {}
+    algorithm, value = parts
+    if algorithm == "sha256":
+        return {"schema:sha256": value}
+    return {
+        "schema:checksum": {
+            "@type": "schema:PropertyValue",
+            "schema:propertyID": algorithm,
+            "schema:name": algorithm,
+            "schema:value": value,
+        }
+    }
+
+
 def artifact_distribution_node(art: Mapping[str, Any], *, locator_url: Callable[[str], Any] | None = None) -> dict:
     """An actionable artifact link -> a ``dcat:Distribution`` node, so the runnable
     protocol file is machine-discoverable alongside the descriptive method.
@@ -398,11 +472,10 @@ def artifact_distribution_node(art: Mapping[str, Any], *, locator_url: Callable[
     if fmt:
         node["dcterms:format"] = fmt
     if art.get("sha256"):
-        node["spdx:checksum"] = {
-            "@type": "spdx:Checksum",
-            "spdx:algorithm": "spdx:checksumAlgorithm_sha256",
-            "spdx:checksumValue": art["sha256"],
-        }
+        # The artifact model names this field sha256, so the algorithm is known;
+        # it still goes through the shared builder so every checksum in every
+        # document has one shape and one predicate.
+        node["spdx:checksum"] = checksum_node({"algorithm": "sha256", "value": art["sha256"]})
     return node
 
 
@@ -711,8 +784,73 @@ def test_to_jsonld(record: dict) -> dict:
     return {k: v for k, v in node.items() if v is not None and v != [] and v != {}}
 
 
+def _schema_variable_measured(values: Any) -> list[dict]:
+    """``variable_measured`` entries -> ``schema:PropertyValue`` nodes.
+
+    Same shape the publication path emits, so a dataset described once reads the
+    same whether it is fetched as a record or out of a deposit.
+    """
+    out: list[dict] = []
+    if not isinstance(values, list):
+        return out
+    for value in values:
+        if not isinstance(value, Mapping):
+            continue
+        name = value.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        node: dict = {"@type": "schema:PropertyValue", "schema:name": name}
+        if isinstance(value.get("description"), str):
+            node["schema:description"] = value["description"]
+        if isinstance(value.get("unit_text"), str):
+            node["schema:unitText"] = value["unit_text"]
+        same_as = value.get("same_as") or value.get("sameAs")
+        if isinstance(same_as, str):
+            node["schema:sameAs"] = same_as
+            node["schema:propertyID"] = same_as
+        out.append(node)
+    return out
+
+
+def _schema_citations(values: Any) -> list:
+    """``citations`` entries -> ``schema:CreativeWork`` nodes (or plain strings)."""
+    out: list = []
+    if not isinstance(values, list):
+        return out
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            out.append(value)
+            continue
+        if not isinstance(value, Mapping):
+            continue
+        node: dict = {"@type": "schema:CreativeWork"}
+        url = value.get("url")
+        if isinstance(url, str):
+            node["@id"] = url
+            node["schema:url"] = url
+        if isinstance(value.get("name"), str):
+            node["schema:name"] = value["name"]
+        if isinstance(value.get("kind"), str):
+            node["schema:additionalType"] = value["kind"]
+        if isinstance(value.get("doi"), str):
+            node["bibo:doi"] = value["doi"]
+        if isinstance(value.get("citation_key"), str):
+            node["schema:identifier"] = value["citation_key"]
+        if len(node) > 1:
+            out.append(node)
+    return out
+
+
 def dataset_to_jsonld(record: dict) -> dict:
-    """Transform a dataset record dict to JSON-LD."""
+    """Transform a dataset record dict to JSON-LD.
+
+    DCAT carries the catalog skeleton (title, access, subject, distributions);
+    schema.org carries the discovery layer (description, keywords, measured
+    variables, techniques, citations), because DCAT has no term for most of it
+    and schema.org is what dataset search engines read. Where both vocabularies
+    name a field, both are emitted — the same twinning the publication graph
+    already does — so neither kind of consumer has to guess.
+    """
     ds   = record.get("dataset") or {}
     prov = record.get("provenance") or {}
 
@@ -722,14 +860,36 @@ def dataset_to_jsonld(record: dict) -> dict:
         "@id":      ds.get("id", ""),
         "dcterms:title": ds.get("name"),
     }
+    if ds.get("description"):
+        node["dcterms:description"] = ds["description"]
+        node["schema:description"] = ds["description"]
     if ds.get("license"):
         node["dcterms:license"] = {"@id": ds["license"]}
     if ds.get("access_url"):
         node["dcat:accessURL"] = {"@id": ds["access_url"]}
+    keywords = [k for k in (ds.get("keywords") or []) if isinstance(k, str) and k.strip()]
+    if keywords:
+        node["dcat:keyword"] = keywords
+        node["schema:keywords"] = keywords
     if ds.get("created_at"):
         node["dcterms:created"] = _epoch_to_iso(ds["created_at"])
     if ds.get("modified_at"):
         node["dcterms:modified"] = _epoch_to_iso(ds["modified_at"])
+    if ds.get("published_at"):
+        node["dcterms:issued"] = _epoch_to_iso(ds["published_at"])
+        node["schema:datePublished"] = _epoch_to_iso(ds["published_at"])
+    techniques = [t for t in (ds.get("measurement_techniques") or []) if isinstance(t, str) and t.strip()]
+    if techniques:
+        node["schema:measurementTechnique"] = techniques
+    methods = [m for m in (ds.get("measurement_methods") or []) if isinstance(m, str) and m.strip()]
+    if methods:
+        node["schema:measurementMethod"] = methods
+    variables = _schema_variable_measured(ds.get("variable_measured"))
+    if variables:
+        node["schema:variableMeasured"] = variables
+    citations = _schema_citations(ds.get("citations"))
+    if citations:
+        node["schema:citation"] = citations
     about = ds.get("about")
     if about:
         # Tolerate a single IRI string (wrap it) instead of iterating it
@@ -745,17 +905,23 @@ def dataset_to_jsonld(record: dict) -> dict:
         ld_dists = []
         for d in dists:
             dist: dict = {"@type": "dcat:Distribution"}
+            if d.get("name"):
+                dist["schema:name"] = d["name"]
+            if d.get("description"):
+                dist["schema:description"] = d["description"]
             if d.get("content_url"):
                 dist["dcat:downloadURL"] = {"@id": d["content_url"]}
             if d.get("encoding_format"):
                 dist["dcat:mediaType"] = d["encoding_format"]
-            cs = d.get("checksum")
-            if isinstance(cs, Mapping):
-                dist["spdx:checksum"] = {
-                    "@type": "spdx:Checksum",
-                    "spdx:checksumAlgorithm": f"spdx:checksumAlgorithm_{cs.get('algorithm', '')}",
-                    "spdx:checksumValue":     cs.get("value", ""),
-                }
+            # File size: dcat:byteSize is an integer, schema:contentSize is text;
+            # the record stores the string form, so only a digit string casts.
+            size = str(d.get("content_size") or "")
+            if size.isdigit():
+                dist["dcat:byteSize"] = int(size)
+                dist["schema:contentSize"] = size
+            checksum = checksum_node(d.get("checksum"))
+            if checksum is not None:
+                dist["spdx:checksum"] = checksum
             ld_dists.append(dist)
         node["dcat:distribution"] = ld_dists
 

--- a/src/battinfo/publication.py
+++ b/src/battinfo/publication.py
@@ -27,6 +27,7 @@ from battinfo.bundle import (
     Test,
     ZenodoCellRecord,
 )
+from battinfo.jsonld import schema_checksum_terms
 from battinfo.validate.core import PUBLISHER_POLICY, ValidationPolicy
 from battinfo.validate.publication import validate_publication_report
 from battinfo.validate.pydantic import validate_json
@@ -397,15 +398,7 @@ def _schema_distribution_node(value: Mapping[str, Any], *, part_of_id: str) -> d
     if isinstance(access_level, str):
         node["schema:accessLevel"] = access_level
     node["schema:isPartOf"] = {"@id": part_of_id}
-    if isinstance(checksum, Mapping) and isinstance(checksum.get("algorithm"), str) and isinstance(checksum.get("value"), str):
-        if checksum["algorithm"].lower() == "sha256":
-            node["schema:sha256"] = checksum["value"]
-        else:
-            node["schema:checksum"] = {
-                "@type": "schema:PropertyValue",
-                "schema:propertyID": checksum["algorithm"],
-                "schema:value": checksum["value"],
-            }
+    node.update(schema_checksum_terms(checksum))
     return node
 
 

--- a/src/battinfo/transform/json_to_jsonld.py
+++ b/src/battinfo/transform/json_to_jsonld.py
@@ -1867,6 +1867,92 @@ _MATERIAL_PROPERTY_TERMS: dict[str, str] = {
 }
 
 
+# Processing-route token -> human label. The tokens are the `route` enum of
+# material.schema.json; the label rides the emitted DefinedTerm so a reader need
+# not fetch the schema to know what "nmp" means.
+_PROCESSING_ROUTE_LABELS: dict[str, str] = {
+    "aqueous": "Water-based (aqueous) processing",
+    "nmp": "NMP solvent-based processing",
+    "dry": "Solvent-free (dry) processing",
+    "other": "Other processing route",
+}
+
+
+def _solvent_node(solvent: str) -> dict[str, Any] | None:
+    """A solvent name -> a typed chemical-substance node, or a labeled one.
+
+    Resolves through the curated material-kind vocabulary, so a solvent that is
+    also a known kind (NMP) carries its chemical-substance class IRI and EMMO
+    type. An unknown solvent (water has no chemical-substance anchor in the
+    bundled ontology) still emits, carrying its name — a labeled node beats a
+    dropped one.
+    """
+    if not isinstance(solvent, str) or not solvent.strip():
+        return None
+    from battinfo.materials import material_kind
+
+    entry = material_kind(solvent)
+    node: dict[str, Any] = {}
+    if entry is not None:
+        chemsub = entry.get("chemsub")
+        emmo = entry.get("emmo")
+        if isinstance(chemsub, str) and chemsub:
+            node["@id"] = chemsub
+        if isinstance(emmo, str) and emmo:
+            node["@type"] = emmo
+    node.setdefault("@type", "schema:ChemicalSubstance")
+    node["schema:name"] = solvent.strip()
+    return node
+
+
+def _processing_node(processing: Any) -> dict[str, Any] | None:
+    """A material instance's ``processing`` block -> a typed EMMO process node.
+
+    Processing is the reason material instances exist as a level (aqueous vs NMP
+    is a build property, not a distinct product), so it has to survive into the
+    semantic view. The block becomes the EMMO ``Manufacturing`` process that
+    produced this lot, hung off the material with ``prov:wasGeneratedBy``:
+
+    * ``route``   -> a ``schema:DefinedTerm`` carrying the controlled token and
+      its label, hung on ``dcterms:type`` (the same standard predicate the
+      artifact-role token already uses; no ``battinfo:`` term is minted, and no
+      term-set IRI either, since that vocabulary is not hosted yet).
+    * ``solvent`` -> ``hasSolvent`` pointing at the substance, typed by its
+      chemical-substance class where the vocabulary knows it. When the record
+      states no solvent but the route names one (``nmp``), the route resolves it,
+      since the enum defines that route AS the solvent.
+    * ``detail``  -> ``schema:description``.
+    """
+    if not isinstance(processing, dict) or not processing:
+        return None
+    route = processing.get("route")
+    solvent = processing.get("solvent")
+    detail = processing.get("detail")
+
+    node: dict[str, Any] = {"@type": "Manufacturing", "skos:prefLabel": "Manufacturing"}
+    if isinstance(route, str) and route.strip():
+        token = route.strip()
+        term: dict[str, Any] = {"@type": "schema:DefinedTerm", "schema:termCode": token}
+        label = _PROCESSING_ROUTE_LABELS.get(token.lower())
+        if label:
+            term["schema:name"] = label
+        node["dcterms:type"] = term
+    if not (isinstance(solvent, str) and solvent.strip()) and isinstance(route, str):
+        # The route names its own solvent for the solvent-based routes; an
+        # unknown route simply resolves to nothing and is left alone.
+        from battinfo.materials import material_kind
+
+        if material_kind(route) is not None:
+            solvent = route
+    solvent_node = _solvent_node(solvent) if isinstance(solvent, str) else None
+    if solvent_node:
+        node["hasSolvent"] = solvent_node
+    if isinstance(detail, str) and detail.strip():
+        node["schema:description"] = detail.strip()
+    # Nothing beyond the bare process type is not worth a node.
+    return node if len(node) > 2 else None
+
+
 def _material_node(body: dict[str, Any]) -> dict[str, Any]:
     """Build a domain-battery JSON-LD node for a material spec/instance body.
 
@@ -1914,9 +2000,22 @@ def _material_node(body: dict[str, Any]) -> dict[str, Any]:
         node["schema:molecularFormula"] = body["formula"]
     if isinstance(body.get("material_spec_id"), str):
         node["schema:isVariantOf"] = {"@id": body["material_spec_id"]}
+    # Lot / batch identity: the strings that tie this record to the physical
+    # container on the shelf. schema:identifier carries them as named
+    # PropertyValues so each keeps the name of the system that issued it.
+    identifiers = [
+        {"@type": "schema:PropertyValue", "schema:name": key, "schema:value": body[key]}
+        for key in ("lot_id", "batch_id")
+        if isinstance(body.get(key), str) and body[key].strip()
+    ]
+    if identifiers:
+        node["schema:identifier"] = identifiers[0] if len(identifiers) == 1 else identifiers
     prop_nodes = _descriptor_property_nodes(body.get("property"), term_overrides=_MATERIAL_PROPERTY_TERMS)
     if prop_nodes:
         node["hasProperty"] = prop_nodes[0] if len(prop_nodes) == 1 else prop_nodes
+    processing = _processing_node(body.get("processing"))
+    if processing:
+        node["prov:wasGeneratedBy"] = processing
     return node
 
 
@@ -1926,6 +2025,12 @@ def _to_domain_battery_jsonld_material(data: dict[str, Any]) -> dict[str, Any]:
     citation = _citation_to_jsonld(data.get("provenance"))
     if citation is not None:
         node["schema:citation"] = citation
+    # Envelope notes are authored free text about this lot; the publication graph
+    # already carries them as schema:comment, so the record emitter matches it
+    # rather than dropping them.
+    notes = [n for n in (data.get("notes") or []) if isinstance(n, str) and n.strip()]
+    if notes:
+        node["schema:comment"] = notes[0] if len(notes) == 1 else notes
     return {
         "@context": _base_context(
             include_battinfo=True,

--- a/src/battinfo/validate/jsonld.py
+++ b/src/battinfo/validate/jsonld.py
@@ -146,6 +146,8 @@ _EXPLICIT_ALLOWED_TYPE_TERMS = {
     "ElectrolyticConductivity",
     "Mass",
     "MassLoading",
+    # The EMMO process a material lot's `processing` block emits as.
+    "Manufacturing",
     "NPRatio",
     "TheoreticalCapacity",
     "Tortuosity",

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -22,7 +22,7 @@ import json
 import os
 import re
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -302,6 +302,25 @@ _CONFORMANCE_IRI = {
     "non-conformant": "earl:failed",
     "unknown":        "earl:cantTell",
 }
+
+
+def _spdx_algorithm_name(checksum: Any) -> str | None:
+    """Read the algorithm back out of an emitted ``spdx:Checksum`` node.
+
+    The term may be an IRI reference (``{"@id": "spdx:checksumAlgorithm_md5"}``),
+    the same CURIE as a bare string, or a plain algorithm name for something SPDX
+    does not define — all three are accepted, so a deposit round-trips whichever
+    emitter wrote it.
+    """
+    if not isinstance(checksum, Mapping):
+        return None
+    term = checksum.get("spdx:checksumAlgorithm") or checksum.get("spdx:algorithm")
+    if isinstance(term, Mapping):
+        term = term.get("@id")
+    if not isinstance(term, str) or not term.strip():
+        return None
+    return term.rsplit("checksumAlgorithm_", 1)[-1].strip() or None
+
 
 _UNIX_EPOCH = "1970-01-01T00:00:00Z"
 
@@ -1176,6 +1195,11 @@ class AuthoringWorkspace:
         self._session_credentials: dict[str, str] = {}
         # name -> Cell, keyed by short_id for test matching
         self._cells_by_short_id: dict[str, Any] = {}
+        # Lookup keys that two or more DIFFERENT cells answer to. A display name
+        # is not an identifier: a batch may legitimately share one public label
+        # across many serials. Such a key cannot pick a cell, so resolving it
+        # raises instead of silently returning whichever cell was indexed last.
+        self._ambiguous_cell_keys: set[str] = set()
         # True once cell instances saved in a previous session have been lazily
         # loaded from .battinfo/records/cell-instance/ into the index above, so a
         # fresh process can still resolve a cell by serial (day-2 rehydration).
@@ -2910,6 +2934,25 @@ class AuthoringWorkspace:
         print(f"  Loaded {count} cell instance(s) into matching index.")
         return count
 
+    def _index_cell(self, cell: Any, *keys: str | None) -> None:
+        """Index ``cell`` under every lookup key it answers to (and each key's short id).
+
+        A cell's IDENTITY is its serial number; its name is display text, so a
+        batch may share one public label across many serials. When a key already
+        points at a *different* cell it is recorded as ambiguous rather than
+        overwritten, and :meth:`_resolve_cell` then refuses to guess.
+        """
+        for key in keys:
+            if not key:
+                continue
+            for k in (key, _short_id(key)):
+                if not k:
+                    continue
+                existing = self._cells_by_short_id.get(k)
+                if existing is not None and existing is not cell:
+                    self._ambiguous_cell_keys.add(k)
+                self._cells_by_short_id[k] = cell
+
     def _index_saved_cells(self) -> int:
         """Load cell instances saved on disk into the serial → cell index (quiet).
 
@@ -2937,15 +2980,8 @@ class AuthoringWorkspace:
                     serial_number=ci.get("serial_number"),
                     batch_id=ci.get("batch_id"),
                 )
-                for label in (ci.get("name"), ci.get("serial_number")):
-                    if label:
-                        self._cells_by_short_id[label] = cell
-                        sid = _short_id(label)
-                        if sid:
-                            self._cells_by_short_id[sid] = cell
-                stored_sid = ci.get("short_id", "")
-                if stored_sid:
-                    self._cells_by_short_id[stored_sid] = cell
+                self._index_cell(cell, ci.get("serial_number"), ci.get("name"),
+                                 ci.get("short_id") or None)
                 count += 1
             except Exception as exc:
                 print(f"  WARNING: could not load {src.name} -- {exc}")
@@ -3260,11 +3296,7 @@ class AuthoringWorkspace:
             )
             cell.id = iri
             sn = node.get("schema:serialNumber", "")
-            if sn:
-                self._cells_by_short_id[sn] = cell
-            sid = _short_id(sn)
-            if sid:
-                self._cells_by_short_id[sid] = cell
+            self._index_cell(cell, sn)
             print(f"  instance: {sn or iri}")
 
         # ── 7. Import tests + datasets ─────────────────────────────────────────
@@ -3328,7 +3360,7 @@ class AuthoringWorkspace:
                     status="completed",
                     access_url=dl_url,
                     format=fmt,
-                    checksum_algorithm=cs.get("spdx:checksumAlgorithm", "").split("_")[-1] or None,
+                    checksum_algorithm=_spdx_algorithm_name(cs),
                     checksum_value=cs.get("spdx:checksumValue") or None,
                 )
                 # Preserve the test IRI and the dataset IRI from the JSON-LD
@@ -3363,6 +3395,7 @@ class AuthoringWorkspace:
         """
         self._ws = self._make_engine()
         self._cells_by_short_id = {}
+        self._ambiguous_cell_keys = set()
         self._session_paths = set()
         print("Workspace cleared.")
 
@@ -4873,7 +4906,9 @@ class AuthoringWorkspace:
         any JSON-LD tool that resolves the embedded context.
         """
         from battinfo.jsonld import (
+            checksum_node,
             funding_to_jsonld,
+            schema_checksum_terms,
             test_protocol_node,
         )
 
@@ -5209,12 +5244,14 @@ class AuthoringWorkspace:
                     for dist in (ds.get("distributions") or []):
                         url   = dist.get("content_url") or ""
                         fname = _file_uri_to_path(url).name
-                        cs    = dist.get("checksum", {})
                         dists.append({
                             "filename":     fname,
                             "content_url":  url,
                             "format":       dist.get("encoding_format", ""),
-                            "checksum":     cs.get("value", ""),
+                            # The whole checksum block, algorithm included. Carrying
+                            # only the value here is what let an md5 digest be
+                            # published under the sha256 term downstream.
+                            "checksum":     dist.get("checksum") or {},
                             "role":         dist.get("role", ""),
                             "description":  dist.get("description", ""),
                             "content_size": dist.get("content_size", ""),
@@ -5308,13 +5345,12 @@ class AuthoringWorkspace:
                 if meta.get("test_iri") and not is_raw:
                     dnode["prov:wasGeneratedBy"] = {"@id": meta["test_iri"]}
 
-                if dist["checksum"]:
-                    dnode["spdx:checksum"] = {
-                        "@type":                  "spdx:Checksum",
-                        # IRI reference to the SPDX algorithm individual, not a literal.
-                        "spdx:checksumAlgorithm": {"@id": "spdx:checksumAlgorithm_sha256"},
-                        "spdx:checksumValue":     dist["checksum"],
-                    }
+                # The algorithm is the record's, never assumed: a deposit is
+                # permanent, and an md5 digest published as a sha256 is a false
+                # statement about the file rather than a missing one.
+                _checksum = checksum_node(dist["checksum"])
+                if _checksum is not None:
+                    dnode["spdx:checksum"] = _checksum
                 # File size: dcat:byteSize is an integer; schema:contentSize is text.
                 _size = str(dist.get("content_size") or "")
                 if _size.isdigit():
@@ -5331,8 +5367,9 @@ class AuthoringWorkspace:
                     "schema:name":          fname,
                     "schema:isPartOf":      {"@id": ds_id},
                 }
-                if dist["checksum"]:
-                    sdl["schema:sha256"] = dist["checksum"]
+                # schema:sha256 names one algorithm, so it is reserved for a real
+                # sha256; anything else rides a named PropertyValue.
+                sdl.update(schema_checksum_terms(dist["checksum"]))
                 if dist.get("description"):
                     sdl["schema:description"] = dist["description"]
                 if _size.isdigit():
@@ -6264,12 +6301,7 @@ class AuthoringWorkspace:
             serial_number=result.get("serial_number"),
             batch_id=result.get("batch_id"),
         )
-        for label in (result.get("name"), result.get("serial_number")):
-            if label:
-                self._cells_by_short_id[label] = cell
-                sid = _short_id(label)
-                if sid:
-                    self._cells_by_short_id[sid] = cell
+        self._index_cell(cell, result.get("serial_number"), result.get("name"))
         return cell
 
     def _reference_spec(self, result: dict) -> Any:
@@ -6357,9 +6389,11 @@ class AuthoringWorkspace:
     ) -> builtins.list:
         """Create cell instances.
 
-        * ``names`` — human labels (e.g. lab batch IDs); the primary identifier.
+        * ``names`` — human labels (e.g. lab batch IDs); display text, which
+          several cells of one batch may share.
         * ``serial_numbers`` — manufacturer serials (optional); parallel to ``names``
-          when both are given.
+          when both are given. The serial is the cell's identity: it de-duplicates
+          the batch and must be unique within it.
         * ``iris`` — pre-allocated IRIs to reuse instead of minting (parallel, equal length).
         * ``from_file`` — JSON file mapping ``{name: pre-allocated-IRI}``.
         """
@@ -6403,19 +6437,50 @@ class AuthoringWorkspace:
             else:
                 entries = [(n, s, None) for (n, s) in pairs]
 
-            # Drop duplicates and cells already in this session (by their label).
-            seen: set[str] = set()
+            # Drop cells already in this session, keyed on IDENTITY.
+            #
+            # A cell instance is identified by its serial number. The name is
+            # display text: a batch may legitimately share one public label
+            # across many physical cells (95 cells under 12 labels is a real
+            # shape), so keying the de-duplication on the label collapsed such a
+            # batch to one cell per label and lost the rest without failing.
+            # Prefer the serial; fall back to the name only when no serial is
+            # supplied, which is the single-label case the old key served.
+            seen: dict[str, str | None] = {}
             already: list[str] = []
+            repeated_serials: list[str] = []
+            repeated_names: list[str] = []
             deduped: list[tuple[str | None, str | None, str | None]] = []
             for n, s, iri in entries:
-                label = n or s or ""
-                if label in seen:
+                key = s or n or ""
+                if key and key in seen:
+                    # Two entries claiming one identity. A repeated serial is a
+                    # contradiction in the input (loud); a repeated bare name is
+                    # merely indistinguishable (warn and keep the first).
+                    (repeated_serials if s else repeated_names).append(key)
                     continue
-                if label and label in self._cells_by_short_id:
-                    already.append(label)
+                if key and key in self._cells_by_short_id:
+                    already.append(key)
                     continue
-                seen.add(label)
+                if key:
+                    seen[key] = n
                 deduped.append((n, s, iri))
+            if repeated_serials:
+                dupes = sorted(set(repeated_serials))
+                raise ValueError(
+                    f"serial_numbers contains {len(repeated_serials)} repeated serial(s): "
+                    f"{dupes[:5]}" + (" ..." if len(dupes) > 5 else "") + ". "
+                    "A serial number identifies one physical cell, so it cannot appear "
+                    "twice in one batch. Names may repeat; serials may not."
+                )
+            if repeated_names:
+                dupes = sorted(set(repeated_names))
+                print(
+                    f"  WARNING: {len(repeated_names)} repeated name(s) with no serial "
+                    f"-- keeping the first of each: {dupes[:5]}"
+                    + (" ..." if len(dupes) > 5 else "")
+                    + "\n           Pass serial_numbers=[...] to author them as distinct cells."
+                )
             if already:
                 print(f"  WARNING: {len(already)} already in workspace -- skipping: {already[:5]}"
                       + (" ..." if len(already) > 5 else ""))
@@ -6457,13 +6522,10 @@ class AuthoringWorkspace:
             )
             if iri is not None:
                 cell.id = iri
-            # Index by both the name and the serial (and their short IDs) for matching.
-            for cell_key in (name, serial):
-                if cell_key:
-                    self._cells_by_short_id[cell_key] = cell
-                    sid = _short_id(cell_key)
-                    if sid:
-                        self._cells_by_short_id[sid] = cell
+            # Index by both the serial and the name (and their short IDs) for
+            # matching. The serial goes first so it wins the identity slot; a
+            # name shared by several cells is flagged ambiguous, not overwritten.
+            self._index_cell(cell, serial, name)
             cells.append(cell)
             print(f"  cell: {name or serial}  {iri or '(IRI auto-assigned)'}")
         return cells
@@ -7122,10 +7184,19 @@ class AuthoringWorkspace:
             sid = _short_id(s)
 
             def _lookup() -> Any:
-                hit = self._cells_by_short_id.get(s)
-                if hit is None and sid:
-                    hit = self._cells_by_short_id.get(sid)
-                return hit
+                for key in (s, sid):
+                    if not key:
+                        continue
+                    if key in self._ambiguous_cell_keys:
+                        raise ValueError(
+                            f"{key!r} matches more than one cell in this workspace, so it "
+                            "cannot identify one. It is a display name shared by several "
+                            "cells; reference the cell by its serial number or IRI instead."
+                        )
+                    hit = self._cells_by_short_id.get(key)
+                    if hit is not None:
+                        return hit
+                return None
 
             hit = _lookup()
             if hit is None:
@@ -7188,6 +7259,16 @@ class AuthoringWorkspace:
         tests = []
         for f in matched_files:
             sid = _short_id(f.stem)
+            ambiguous = next(
+                (k for k in (sid, f.stem) if k and k in self._ambiguous_cell_keys), None
+            )
+            if ambiguous is not None:
+                # Matching this file to "a" cell would attach the measurement to
+                # an arbitrary one of several. Skip it and say why.
+                unmatched.append(f)
+                print(f"  AMBIGUOUS {f.name} -- {ambiguous!r} matches more than one cell; "
+                      "name the file after the serial number")
+                continue
             if sid and sid in self._cells_by_short_id:
                 cell, how = self._cells_by_short_id[sid], f'short id "{sid}"'
             elif f.stem in self._cells_by_short_id:

--- a/tests/test_prepublish_gaps.py
+++ b/tests/test_prepublish_gaps.py
@@ -1,0 +1,364 @@
+"""Regression tests for the three defects found authoring a real corpus for deposit.
+
+Gap IDs are the ones in the Flores half-cell OCV readiness report:
+
+* **G6** - a file digest was published under the sha256 term whatever algorithm
+  the record actually stated, so Zenodo's md5 went out as a sha256. A digest is
+  an assertion about a file and a deposit is permanent, so this was a wrong
+  statement rather than a missing one.
+* **G9** - ``ws.add("cell", names=..., serial_numbers=...)`` de-duplicated on the
+  display label, so a batch sharing public labels silently collapsed to one cell
+  per label.
+* **G3** - ``record_to_jsonld`` dropped authored content: a material lot's whole
+  ``processing`` block (aqueous vs NMP, the reason instances exist as a level)
+  and most of the dataset discovery fields.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.jsonld import record_to_jsonld  # noqa: E402
+from battinfo.ws import AuthoringWorkspace  # noqa: E402
+
+MD5 = "7e779f63372291ad56b2e01de6639cc7"          # 32 hex chars, a real md5
+SHA256 = "b" * 64
+
+
+# ── G6: the emitted checksum states the algorithm the record carries ───────────
+
+def _dataset_record(algorithm: str, value: str) -> dict:
+    return {
+        "dataset": {
+            "id": "https://w3id.org/battinfo/dataset/d1",
+            "name": "DS",
+            "distributions": [{
+                "name": "cell.parquet",
+                "content_url": "https://zenodo.org/api/records/1/files/cell.parquet/content",
+                "encoding_format": "application/vnd.apache.parquet",
+                "checksum": {"algorithm": algorithm, "value": value},
+            }],
+        }
+    }
+
+
+def test_record_md5_checksum_is_typed_md5_not_sha256() -> None:
+    out = record_to_jsonld(_dataset_record("md5", MD5), "dataset")
+    checksum = out["dcat:distribution"][0]["spdx:checksum"]
+
+    assert checksum["spdx:checksumAlgorithm"] == {"@id": "spdx:checksumAlgorithm_md5"}
+    assert checksum["spdx:checksumValue"] == MD5
+    # The whole document must not claim sha256 anywhere.
+    assert "sha256" not in json.dumps(out)
+
+
+def test_record_sha256_checksum_is_still_typed_sha256() -> None:
+    out = record_to_jsonld(_dataset_record("sha256", SHA256), "dataset")
+    checksum = out["dcat:distribution"][0]["spdx:checksum"]
+
+    assert checksum["spdx:checksumAlgorithm"] == {"@id": "spdx:checksumAlgorithm_sha256"}
+    assert checksum["spdx:checksumValue"] == SHA256
+
+
+def test_algorithm_term_is_an_iri_reference_not_a_look_alike_string() -> None:
+    """The SPDX individual must be a node reference, so it links rather than
+    merely resembling the term."""
+    out = record_to_jsonld(_dataset_record("md5", MD5), "dataset")
+    algorithm = out["dcat:distribution"][0]["spdx:checksum"]["spdx:checksumAlgorithm"]
+    assert isinstance(algorithm, dict) and "@id" in algorithm
+
+
+def test_algorithm_outside_spdx_keeps_its_name_instead_of_inventing_a_term() -> None:
+    out = record_to_jsonld(_dataset_record("other", "abc"), "dataset")
+    checksum = out["dcat:distribution"][0]["spdx:checksum"]
+    assert checksum["spdx:checksumAlgorithm"] == "other"
+    assert checksum["spdx:checksumValue"] == "abc"
+
+
+def _deposit_graph(algorithm: str, value: str) -> dict:
+    record_sets = {
+        "cell-spec": [{"cell_spec": {
+            "id": "https://w3id.org/battinfo/spec/cs1", "name": "Half cell",
+            "manufacturer": "M", "model": "HC", "format": "coin", "chemistry": "li-metal"}}],
+        "cell-instance": [{"cell": {
+            "id": "https://w3id.org/battinfo/cell/c1", "serial_number": "SN-001",
+            "cell_spec_id": "https://w3id.org/battinfo/spec/cs1"}}],
+        "test": [{"test": {
+            "id": "https://w3id.org/battinfo/test/t1", "kind": "ocv",
+            "cell_id": "https://w3id.org/battinfo/cell/c1",
+            "dataset_ids": ["https://w3id.org/battinfo/dataset/d1"]}}],
+        "dataset": [{"dataset": {
+            "id": "https://w3id.org/battinfo/dataset/d1", "name": "DS",
+            "about": ["https://w3id.org/battinfo/cell/c1"],
+            "distributions": [{
+                "name": "cell.parquet",
+                "content_url": "https://zenodo.org/api/records/1/files/cell.parquet/content",
+                "encoding_format": "application/vnd.apache.parquet",
+                "role": "processed",
+                "checksum": {"algorithm": algorithm, "value": value},
+            }]}}],
+    }
+    return AuthoringWorkspace._assemble_zenodo_jsonld(
+        record_sets,
+        zenodo_record_id=1,
+        prereserved_doi="10.5281/zenodo.1",
+        record_url="https://zenodo.org/records/1",
+        data_filenames=["cell.parquet"],
+        title="T",
+    )
+
+
+def test_deposit_graph_never_publishes_an_md5_digest_as_a_sha256() -> None:
+    doc = _deposit_graph("md5", MD5)
+    blob = json.dumps(doc)
+
+    # This is the exact defect: the digest went out under the sha256 term.
+    assert "sha256" not in blob
+    assert "spdx:checksumAlgorithm_md5" in blob
+
+    for node in doc["@graph"]:
+        for dist in node.get("dcat:distribution") or []:
+            checksum = dist.get("spdx:checksum")
+            if checksum:
+                assert checksum["spdx:checksumAlgorithm"] == {"@id": "spdx:checksumAlgorithm_md5"}
+                assert checksum["spdx:checksumValue"] == MD5
+        for download in node.get("schema:distribution") or []:
+            # schema:sha256 names one algorithm, so an md5 rides a PropertyValue.
+            assert "schema:sha256" not in download
+            assert download["schema:checksum"]["schema:propertyID"] == "md5"
+            assert download["schema:checksum"]["schema:value"] == MD5
+
+
+def test_deposit_graph_still_uses_the_schema_sha256_term_for_a_real_sha256() -> None:
+    doc = _deposit_graph("sha256", SHA256)
+    downloads = [d for node in doc["@graph"] for d in (node.get("schema:distribution") or [])]
+
+    assert downloads
+    for download in downloads:
+        assert download["schema:sha256"] == SHA256
+        assert "schema:checksum" not in download
+
+
+def test_deposit_algorithm_round_trips_back_out_of_the_graph() -> None:
+    from battinfo.ws import _spdx_algorithm_name
+
+    doc = _deposit_graph("md5", MD5)
+    checksum = next(
+        dist["spdx:checksum"]
+        for node in doc["@graph"]
+        for dist in (node.get("dcat:distribution") or [])
+        if dist.get("spdx:checksum")
+    )
+    assert _spdx_algorithm_name(checksum) == "md5"
+    # Tolerates the bare-CURIE form an older document may carry.
+    assert _spdx_algorithm_name({"spdx:checksumAlgorithm": "spdx:checksumAlgorithm_sha512"}) == "sha512"
+
+
+def test_resolver_keeps_a_distribution_whose_checksum_is_not_sha256() -> None:
+    """A non-sha256 checksum used to drop the WHOLE distribution - URL, format
+    and size with it - from the resolved document."""
+    from battinfo.api._resolver import _schema_distribution_value
+
+    node = _schema_distribution_value(
+        {"content_url": "https://x/f.parquet", "encoding_format": "application/vnd.apache.parquet",
+         "checksum": {"algorithm": "md5", "value": MD5}},
+        part_of_id="https://w3id.org/battinfo/dataset/d1",
+    )
+    assert node is not None
+    assert node["schema:contentUrl"] == "https://x/f.parquet"
+    assert "schema:sha256" not in node
+    assert node["schema:checksum"]["schema:value"] == MD5
+
+
+def test_resolver_keeps_a_distribution_with_no_checksum_at_all() -> None:
+    from battinfo.api._resolver import _schema_distribution_value
+
+    node = _schema_distribution_value(
+        {"content_url": "https://x/f.parquet", "encoding_format": "text/csv"},
+        part_of_id="https://w3id.org/battinfo/dataset/d1",
+    )
+    assert node is not None
+    assert node["schema:contentUrl"] == "https://x/f.parquet"
+
+
+# ── G9: a cell instance is identified by its serial, not its display label ─────
+
+def _ws_with_spec(tmp_path: Path) -> tuple[AuthoringWorkspace, object]:
+    ws = AuthoringWorkspace(root=tmp_path, registry_url=None)
+    (tmp_path / "d.cell-spec.json").write_text(
+        '{"manufacturer":"X","model":"Y","format":"coin","chemistry":"nmc"}', encoding="utf-8"
+    )
+    return ws, ws.load(tmp_path / "d.cell-spec.json")
+
+
+def test_batch_sharing_display_labels_creates_one_cell_per_serial(tmp_path: Path) -> None:
+    """The corpus shape: 95 physical cells behind 12 public labels."""
+    ws, spec = _ws_with_spec(tmp_path)
+
+    cells = ws.add(
+        "cell", spec=spec,
+        names=[f"L{i % 12}" for i in range(95)],
+        serial_numbers=[f"SN-{i:03d}" for i in range(95)],
+    )
+
+    assert len(cells) == 95
+    assert len({c.serial_number for c in cells}) == 95
+    assert len({c.name for c in cells}) == 12
+
+
+def test_two_cells_may_share_a_name_when_their_serials_differ(tmp_path: Path) -> None:
+    ws, spec = _ws_with_spec(tmp_path)
+    cells = ws.add("cell", spec=spec, names=["A", "A"], serial_numbers=["x1", "x2"])
+
+    assert [c.serial_number for c in cells] == ["x1", "x2"]
+    assert [c.name for c in cells] == ["A", "A"]
+
+
+def test_re_adding_the_same_serial_and_name_is_a_no_op(tmp_path: Path) -> None:
+    ws, spec = _ws_with_spec(tmp_path)
+    first = ws.add("cell", spec=spec, names=["A", "A"], serial_numbers=["x1", "x2"])
+    again = ws.add("cell", spec=spec, names=["A", "A"], serial_numbers=["x1", "x2"])
+
+    assert len(first) == 2
+    assert again == []
+
+
+def test_a_repeated_serial_in_one_batch_fails_loudly(tmp_path: Path) -> None:
+    ws, spec = _ws_with_spec(tmp_path)
+
+    with pytest.raises(ValueError, match="repeated serial"):
+        ws.add("cell", spec=spec, names=["A", "B"], serial_numbers=["x1", "x1"])
+
+
+def test_serial_only_batches_are_unaffected(tmp_path: Path) -> None:
+    ws, spec = _ws_with_spec(tmp_path)
+    cells = ws.add("cell", spec=spec, serial_numbers=["s1", "s2", "s3"])
+    assert len(cells) == 3
+
+
+def test_a_shared_label_cannot_silently_resolve_to_one_of_its_cells(tmp_path: Path) -> None:
+    """Now that a label may name several cells, using it as a reference must
+    fail rather than attach a measurement to an arbitrary one."""
+    ws, spec = _ws_with_spec(tmp_path)
+    ws.add("cell", spec=spec, names=["A", "A"], serial_numbers=["x1", "x2"])
+
+    with pytest.raises(ValueError, match="more than one cell"):
+        ws._resolve_cell("A")
+
+    # The serial is unambiguous and still resolves.
+    assert ws._resolve_cell("x2").serial_number == "x2"
+
+
+# ── G3: emission keeps the content the record was authored with ───────────────
+
+NMP_IRI = "https://w3id.org/emmo/domain/chemical-substance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c"
+
+
+def _material_record(processing: dict) -> dict:
+    return {
+        "material": {
+            "id": "https://w3id.org/battinfo/material/m1",
+            "name": "NMC811 coating lot 7",
+            "lot_id": "LOT-7",
+            "material_spec_id": "https://w3id.org/battinfo/material-spec/s1",
+            "processing": processing,
+        },
+        "notes": ["kept in the dry room"],
+    }
+
+
+def test_nmp_processing_route_emits_the_chemical_substance_iri() -> None:
+    out = record_to_jsonld(
+        _material_record({"route": "nmp", "detail": "cast at 40 um wet thickness"}), "material"
+    )
+    process = out["prov:wasGeneratedBy"]
+
+    assert process["@type"] == "Manufacturing"
+    assert process["dcterms:type"]["schema:termCode"] == "nmp"
+    assert process["hasSolvent"]["@id"] == NMP_IRI
+    assert process["schema:description"] == "cast at 40 um wet thickness"
+
+
+def test_aqueous_and_nmp_lots_are_distinguishable_in_the_semantic_view() -> None:
+    """The distinction the whole material-instance level exists to record."""
+    aqueous = record_to_jsonld(_material_record({"route": "aqueous", "solvent": "water"}), "material")
+    nmp = record_to_jsonld(_material_record({"route": "nmp", "solvent": "NMP"}), "material")
+
+    assert aqueous["prov:wasGeneratedBy"]["dcterms:type"]["schema:termCode"] == "aqueous"
+    assert nmp["prov:wasGeneratedBy"]["dcterms:type"]["schema:termCode"] == "nmp"
+    # Water has no chemical-substance anchor in the bundled ontology, so it emits
+    # as a labeled node - present and readable, rather than dropped.
+    assert aqueous["prov:wasGeneratedBy"]["hasSolvent"]["schema:name"] == "water"
+
+
+def test_material_lot_id_and_notes_survive_emission() -> None:
+    out = record_to_jsonld(_material_record({"route": "dry"}), "material")
+
+    assert out["schema:identifier"]["schema:value"] == "LOT-7"
+    assert out["schema:comment"] == "kept in the dry room"
+
+
+def test_a_material_without_processing_emits_no_process_node() -> None:
+    record = _material_record({})
+    record["material"].pop("processing")
+    assert "prov:wasGeneratedBy" not in record_to_jsonld(record, "material")
+
+
+def test_dataset_discovery_fields_survive_emission() -> None:
+    record = {
+        "dataset": {
+            "id": "https://w3id.org/battinfo/dataset/d1",
+            "name": "Cell A pseudo-OCV",
+            "description": "Pseudo-OCV of a graphite half cell at C/20.",
+            "keywords": ["ocv", "graphite"],
+            "published_at": 1750000000,
+            "measurement_techniques": ["pseudo-OCV"],
+            "measurement_methods": ["GITT"],
+            "variable_measured": [{"name": "voltage", "unit_text": "V", "description": "cell voltage"}],
+            "citations": [{"name": "Flores et al.", "doi": "10.1000/xyz", "url": "https://doi.org/10.1000/xyz"}],
+            "distributions": [{
+                "name": "cellA.parquet",
+                "content_url": "https://x/cellA.parquet",
+                "encoding_format": "application/vnd.apache.parquet",
+                "content_size": "10485760",
+                "description": "processed BDF table",
+            }],
+        }
+    }
+    out = record_to_jsonld(record, "dataset")
+
+    assert out["schema:description"].startswith("Pseudo-OCV")
+    assert out["dcterms:description"].startswith("Pseudo-OCV")
+    assert out["schema:keywords"] == ["ocv", "graphite"]
+    assert out["dcat:keyword"] == ["ocv", "graphite"]
+    assert out["schema:datePublished"].startswith("2025-")
+    assert out["dcterms:issued"].startswith("2025-")
+    assert out["schema:measurementTechnique"] == ["pseudo-OCV"]
+    assert out["schema:measurementMethod"] == ["GITT"]
+    assert out["schema:variableMeasured"][0]["schema:name"] == "voltage"
+    assert out["schema:variableMeasured"][0]["schema:unitText"] == "V"
+    assert out["schema:citation"][0]["bibo:doi"] == "10.1000/xyz"
+
+    dist = out["dcat:distribution"][0]
+    assert dist["schema:name"] == "cellA.parquet"
+    assert dist["schema:description"] == "processed BDF table"
+    assert dist["dcat:byteSize"] == 10485760
+    assert dist["schema:contentSize"] == "10485760"
+
+
+def test_dataset_emission_tolerates_a_non_numeric_content_size() -> None:
+    out = record_to_jsonld(
+        {"dataset": {"id": "d1", "name": "DS", "distributions": [
+            {"content_url": "https://x/f", "content_size": "10 MB"}]}},
+        "dataset",
+    )
+    dist = out["dcat:distribution"][0]
+    assert "dcat:byteSize" not in dist
+    assert "schema:contentSize" not in dist

--- a/web/lib/jsonld.generated.ts
+++ b/web/lib/jsonld.generated.ts
@@ -592,14 +592,61 @@ export const jsonldGallery: {
       "@type": "http://www.w3.org/ns/dcat#Dataset",
       "@id": "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x",
       "dcterms:title": "Cell cycling run for BattINFO cell 3m6k9t",
+      "dcterms:description": "Raw cycling and metadata export for one physical cell.",
+      "schema:description": "Raw cycling and metadata export for one physical cell.",
       "dcterms:license": {
         "@id": "https://creativecommons.org/licenses/by/4.0/"
       },
       "dcat:accessURL": {
         "@id": "https://example.org/lab-data/dataset-1f8r-6v2k-9p4m-3t7x"
       },
+      "dcat:keyword": [
+        "battery cycling",
+        "time series",
+        "lithium-ion"
+      ],
+      "schema:keywords": [
+        "battery cycling",
+        "time series",
+        "lithium-ion"
+      ],
       "dcterms:created": "2026-02-22T00:00:00Z",
       "dcterms:modified": "2026-02-22T00:00:00Z",
+      "dcterms:issued": "2026-02-22T00:00:00Z",
+      "schema:datePublished": "2026-02-22T00:00:00Z",
+      "schema:measurementTechnique": [
+        "cycling"
+      ],
+      "schema:measurementMethod": [
+        "galvanostatic cycling"
+      ],
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "voltage",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "current",
+          "schema:unitText": "A"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "capacity",
+          "schema:unitText": "Ah"
+        }
+      ],
+      "schema:citation": [
+        {
+          "@type": "schema:CreativeWork",
+          "@id": "https://doi.org/10.5281/zenodo.1234567",
+          "schema:url": "https://doi.org/10.5281/zenodo.1234567",
+          "schema:additionalType": "dataset",
+          "bibo:doi": "10.5281/zenodo.1234567",
+          "schema:identifier": "example_dataset_2026"
+        }
+      ],
       "dcterms:subject": [
         {
           "@id": "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
@@ -611,13 +658,16 @@ export const jsonldGallery: {
       "dcat:distribution": [
         {
           "@type": "dcat:Distribution",
+          "schema:name": "Raw cycling HDF5 archive",
           "dcat:downloadURL": {
             "@id": "https://example.org/lab-data/dataset-1f8r-6v2k-9p4m-3t7x/raw.h5"
           },
           "dcat:mediaType": "application/x-hdf5",
           "spdx:checksum": {
             "@type": "spdx:Checksum",
-            "spdx:checksumAlgorithm": "spdx:checksumAlgorithm_sha256",
+            "spdx:checksumAlgorithm": {
+              "@id": "spdx:checksumAlgorithm_sha256"
+            },
             "spdx:checksumValue": "8fbf34bd0f8a0caef6f5ce6cc1f8e6a2d8f0123982fc624d6f7f3f7e27b95a89"
           }
         }

--- a/web/public/jsonld/dataset.jsonld
+++ b/web/public/jsonld/dataset.jsonld
@@ -3,14 +3,61 @@
   "@type": "http://www.w3.org/ns/dcat#Dataset",
   "@id": "https://w3id.org/battinfo/dataset/1f8r-6v2k-9p4m-3t7x",
   "dcterms:title": "Cell cycling run for BattINFO cell 3m6k9t",
+  "dcterms:description": "Raw cycling and metadata export for one physical cell.",
+  "schema:description": "Raw cycling and metadata export for one physical cell.",
   "dcterms:license": {
     "@id": "https://creativecommons.org/licenses/by/4.0/"
   },
   "dcat:accessURL": {
     "@id": "https://example.org/lab-data/dataset-1f8r-6v2k-9p4m-3t7x"
   },
+  "dcat:keyword": [
+    "battery cycling",
+    "time series",
+    "lithium-ion"
+  ],
+  "schema:keywords": [
+    "battery cycling",
+    "time series",
+    "lithium-ion"
+  ],
   "dcterms:created": "2026-02-22T00:00:00Z",
   "dcterms:modified": "2026-02-22T00:00:00Z",
+  "dcterms:issued": "2026-02-22T00:00:00Z",
+  "schema:datePublished": "2026-02-22T00:00:00Z",
+  "schema:measurementTechnique": [
+    "cycling"
+  ],
+  "schema:measurementMethod": [
+    "galvanostatic cycling"
+  ],
+  "schema:variableMeasured": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "voltage",
+      "schema:unitText": "V"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "current",
+      "schema:unitText": "A"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "capacity",
+      "schema:unitText": "Ah"
+    }
+  ],
+  "schema:citation": [
+    {
+      "@type": "schema:CreativeWork",
+      "@id": "https://doi.org/10.5281/zenodo.1234567",
+      "schema:url": "https://doi.org/10.5281/zenodo.1234567",
+      "schema:additionalType": "dataset",
+      "bibo:doi": "10.5281/zenodo.1234567",
+      "schema:identifier": "example_dataset_2026"
+    }
+  ],
   "dcterms:subject": [
     {
       "@id": "https://w3id.org/battinfo/cell/3m6k-9t2p-7x4h-9nq8"
@@ -22,13 +69,16 @@
   "dcat:distribution": [
     {
       "@type": "dcat:Distribution",
+      "schema:name": "Raw cycling HDF5 archive",
       "dcat:downloadURL": {
         "@id": "https://example.org/lab-data/dataset-1f8r-6v2k-9p4m-3t7x/raw.h5"
       },
       "dcat:mediaType": "application/x-hdf5",
       "spdx:checksum": {
         "@type": "spdx:Checksum",
-        "spdx:checksumAlgorithm": "spdx:checksumAlgorithm_sha256",
+        "spdx:checksumAlgorithm": {
+          "@id": "spdx:checksumAlgorithm_sha256"
+        },
         "spdx:checksumValue": "8fbf34bd0f8a0caef6f5ce6cc1f8e6a2d8f0123982fc624d6f7f3f7e27b95a89"
       }
     }


### PR DESCRIPTION
## What

Fixes three defects found while authoring the Flores half-cell OCV corpus (319 records, Zenodo 20086298) for a permanent deposit. They are G6, G9 and G3 in that batch's readiness report.

1. **G6** — a file digest was emitted under the sha256 term whatever algorithm the record stated, so Zenodo's md5 went out as a sha256.
2. **G9** — `ws.add("cell", names=[...], serial_numbers=[...])` de-duplicated on the display label, so 95 cells sharing 12 public labels silently became 12 cells.
3. **G3** — `record_to_jsonld` dropped a material lot's whole `processing` block, its lot id and notes, plus most dataset discovery fields.

## Why

G6 is the one that blocks a deposit. A digest is an assertion about a file, a deposit is permanent, and relabelling an md5 as a sha256 publishes a claim that is wrong rather than missing. It also tripped 190 "must be a 64-character hexadecimal digest" errors in the gold-standard check, because a 32-character md5 cannot satisfy a sha256 rule.

G9 loses records without failing. The corpus has 95 physical cells behind 12 public labels; the batch came back as 12 cells and nothing said so beyond a `WARNING: ... already in workspace`. A serial number identifies a cell — a name is text a lab writes on a box, and batches reuse it.

G3 loses authored science. `processing.route` is aqueous-vs-NMP, which is the distinction the material *instance* level exists to record (the schema says so: "aqueous vs NMP is not a distinct product"). Dropping it from the semantic view means the graph cannot answer the question the data was collected to answer.

## How

### Checksums (G6)

One shared builder in `jsonld.py` — `checksum_node()` for the SPDX form, `schema_checksum_terms()` for the schema.org form — replaces four hand-rolled emissions. It takes the algorithm from the record, never defaults it, and references the SPDX individual as an IRI rather than a look-alike string. `schema:sha256` names exactly one algorithm, so it is now reserved for a genuine sha256; anything else rides a named `schema:PropertyValue`.

Sweep of every site that emits a checksum:

| site | before | after |
|---|---|---|
| `ws.py` deposit graph, dcat distribution | hard-coded `{"@id": "spdx:checksumAlgorithm_sha256"}` | the record's algorithm |
| `ws.py` deposit graph, schema DataDownload | hard-coded `schema:sha256` | `schema:sha256` only for sha256 |
| `ws.py` `ds_meta` collection | dropped `algorithm`, kept the value | carries the whole checksum block |
| `jsonld.py` `dataset_to_jsonld` | algorithm carried, but as a plain string literal | IRI reference |
| `jsonld.py` `artifact_distribution_node` | predicate `spdx:algorithm` (not an SPDX property) | `spdx:checksumAlgorithm`, via the shared builder |
| `publication.py` `_schema_distribution_node` | already correct | uses the shared builder |
| `api/_resolver.py` `_schema_distribution_value` | returned `None` for any non-sha256 or absent checksum, dropping the **whole distribution** — URL, format and size with it | emits the distribution, with the right checksum form |
| `ws.py` `import_` reader | `.split("_")` on what is a dict — the algorithm never round-tripped | `_spdx_algorithm_name()` accepts the IRI-ref, bare-CURIE and plain-name forms |

Predicate choice: unified on `spdx:checksumAlgorithm`, which is the `slot_uri` in `schema/dataset.yaml`, the contract stated in `docs/reading-a-record.md`, and what two of the three emitters already used. `spdx:algorithm` in `artifact_distribution_node` was the outlier.

Not changed: the RO-Crate and publication-package sites that compute a sha256 from a local file. Those name the algorithm they actually run, so they were honest already.

Before / after, deposit graph, same record:

```jsonc
// before — the digest is a 32-char md5
"spdx:checksum": {
  "@type": "spdx:Checksum",
  "spdx:checksumAlgorithm": { "@id": "spdx:checksumAlgorithm_sha256" },
  "spdx:checksumValue": "7e779f63372291ad56b2e01de6639cc7"
}
"schema:sha256": "7e779f63372291ad56b2e01de6639cc7"

// after
"spdx:checksum": {
  "@type": "spdx:Checksum",
  "spdx:checksumAlgorithm": { "@id": "spdx:checksumAlgorithm_md5" },
  "spdx:checksumValue": "7e779f63372291ad56b2e01de6639cc7"
}
"schema:checksum": {
  "@type": "schema:PropertyValue",
  "schema:propertyID": "md5",
  "schema:name": "md5",
  "schema:value": "7e779f63372291ad56b2e01de6639cc7"
}
```

The graph went from 3 `sha256` mentions and 0 `md5` to the reverse, and the gold-standard checker reports 0 checksum issues on the same document (was 190 across the corpus).

### Cell identity (G9)

De-duplication keys on the serial when one is given, falling back to the name only when there is no serial — the single-label case the old key served. A serial repeated inside one batch is a contradiction in the input and now raises; a repeated bare name is merely indistinguishable, so it warns and keeps the first.

Making shared labels work creates a second hazard: a label that names several cells could still be used as a reference and would silently pick whichever was indexed last. Cell indexing moved into `_index_cell()`, which records such keys as ambiguous, and `_resolve_cell()` raises on them instead of guessing. Filename-to-cell matching reports `AMBIGUOUS` and skips rather than attaching a measurement to an arbitrary cell.

```
# before
ws.add("cell", spec=cs, names=["A","A"], serial_numbers=["x1","x2"])
  cell: A  (IRI auto-assigned)
  -> 1 cell

# after
  cell: A  (IRI auto-assigned)
  cell: A  (IRI auto-assigned)
  -> 2 cells
```

The corpus shape: 95 names over 12 labels returned 12 cells, now returns 95.

### Emission (G3)

**Material.** `processing` becomes the EMMO `Manufacturing` process that produced the lot, hung off the material with `prov:wasGeneratedBy`. The route is a `schema:DefinedTerm` on `dcterms:type` — the same standard predicate the artifact-role token already uses, so no `battinfo:` term is minted (the repo's vocabulary-honesty gate refuses one). The solvent resolves through the curated material-kind vocabulary, so NMP carries its chemical-substance IRI; a solvent the vocabulary does not know still emits with its name rather than being dropped. Where the record states no solvent but the route names one, the route resolves it. `lot_id`/`batch_id` emit as `schema:identifier`, envelope `notes` as `schema:comment` (matching what the publication graph already did).

```jsonc
// before — processing, lot_id and notes absent entirely
{ "@type": "schema:ChemicalSubstance", "schema:name": "NMC811 coating lot 7",
  "schema:isVariantOf": {...}, "hasProperty": {...} }

// after
"schema:identifier": { "@type": "schema:PropertyValue",
                       "schema:name": "lot_id", "schema:value": "LOT-7" },
"prov:wasGeneratedBy": {
  "@type": "Manufacturing",
  "skos:prefLabel": "Manufacturing",
  "dcterms:type": { "@type": "schema:DefinedTerm",
                    "schema:termCode": "nmp",
                    "schema:name": "NMP solvent-based processing" },
  "hasSolvent": {
    "@id": "https://w3id.org/emmo/domain/chemical-substance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c",
    "@type": "NMethyl2Pyrrolidone",
    "schema:name": "N-methyl-2-pyrrolidone"
  },
  "schema:description": "cast at 40 um wet thickness"
},
"schema:comment": "kept in the dry room"
```

Water has no chemical-substance anchor in the bundled ontology, so an aqueous lot gets a labeled node rather than a typed one. That is an ontology gap, not a code one, and is left visible rather than papered over.

**Dataset.** DCAT keeps the catalog skeleton; schema.org carries the discovery layer, because DCAT has no term for most of it and schema.org is what dataset search reads. Where both name a field, both are emitted — the same twinning the publication graph already does. Reuses the node shapes `publication.py` already emits, so the round-trip reader in `bundle.py` reads them back without change. No `@context` change was needed: every predicate resolves through a prefix already in v1, so the append-only context is untouched.

### Dataset field audit

Now emitted (all previously dropped):

| field | predicate |
|---|---|
| `description` | `schema:description` + `dcterms:description` |
| `keywords` | `schema:keywords` + `dcat:keyword` |
| `published_at` | `schema:datePublished` + `dcterms:issued` |
| `measurement_techniques` | `schema:measurementTechnique` |
| `measurement_methods` | `schema:measurementMethod` |
| `variable_measured` | `schema:variableMeasured` → `schema:PropertyValue` |
| `citations` | `schema:citation` → `schema:CreativeWork` (+ `bibo:doi`) |
| dist `name` | `schema:name` |
| dist `description` | `schema:description` |
| dist `content_size` | `dcat:byteSize` (int) + `schema:contentSize` (string) |
| dist `checksum` | `spdx:checksum` with the real algorithm |

Already emitted, unchanged: `id`, `name`, `access_url`, `about`, `license`, `created_at`, `modified_at`, `distributions`, `provenance`, `funding`, `contributor`.

Still not emitted, deliberately:

| field | why not |
|---|---|
| `identifier`, `same_as` | The external-PID set needs one shape decision (PropertyValue vs literal vs `@id`) shared with the DOI/versioning work. Emitting half of it now would set that shape by accident. |
| `creators`, `publisher`, `funders` | The record already emits `schema:contributor` from the envelope. Adding a second, differently-shaped person layer would put two competing attribution stories in one document; it needs reconciling, not appending. |
| `version` | Cannot say anything true until record version vs Zenodo concept version is settled. |
| `additional_type` | Free-form type IRIs; folding them into `@type` would bypass the validator's type allowlist. Needs that policy call first. |
| `is_accessible_for_free`, `conditions_of_access`, dist `access_level` | Access semantics belong together with the embargo work. |
| `temporal_coverage`, `spatial_coverage` | The deposit graph already derives temporal coverage from the data's own timestamps. Emitting an authored value here too would create two sources that can disagree. |
| `main_entity` | CSVW tables need the `csvw` prefix, which is not in the v1 context. v1 is append-only and frozen, so that is a separate, deliberate change. |
| `in_language`, `is_based_on`, `included_in_data_catalog` | Straightforward but unused by this corpus. `included_in_data_catalog` would additionally hard-code a platform into a portable record. |
| `short_id`, `schema_version` | Internal: the IRI tail mirrored, and the record-format version. Metadata about the file, not about the dataset. |
| envelope `notes` | Not in the reported gap for datasets, and the publication graph already carries it. Materials, where it was reported, now emit it. |
| dist `conditions` | Dropped upstream by `bundle._canonical_distribution` before emission — a model-layer gap, not an emitter one. |

## Testing

`tests/test_prepublish_gaps.py`, 21 tests, one per behaviour, keyed to the gap IDs:

- md5 emits an md5-typed node and the document contains no `sha256` anywhere; sha256 still emits sha256; the algorithm term is an IRI reference; an algorithm SPDX does not define keeps its name instead of getting an invented term.
- The deposit graph never publishes an md5 as sha256, on both the DCAT and schema.org sides; the algorithm round-trips back out; the resolver keeps distributions whose checksum is md5 or absent.
- 95 serials over 12 shared names give 95 cells; two cells may share a name; re-adding the same serial+name is a no-op; a repeated serial raises; serial-only batches are unchanged; a shared label refuses to resolve.
- An authored processing block round-trips, aqueous and NMP lots are distinguishable, lot id and notes survive, a lot without processing emits no process node; dataset discovery fields survive; a non-numeric `content_size` is skipped rather than crashing.

Gates, all on this branch:

```
uv run pytest              1749 passed, 3 skipped
uv run ruff check src tests scripts   All checks passed!
uv run mypy                Success: no issues found in 69 source files
```

Generation pipelines re-run: `scripts/gen_web_jsonld.py` and `scripts/gen_web_examples.py` (the shipped gallery artifacts change, since the dataset example now carries the fields it always had in the record), `scripts/gen_battinfo_vocab.py` (no diff — the route predicate was re-homed to `dcterms:type` rather than minted), `scripts/gen_context.py --check` (in sync, 412 terms, v1 untouched).

Also verified against the readiness report's own reproduction: the gold-standard checker reports 0 checksum issues on an md5 deposit graph, down from the 190 digest-length errors the corpus hit.
