### PR TITLE
Close the three electrode emission gaps: validator drift, deposit graph, inline seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The deposit graph dropped the whole electrode layer (readiness finding E2).**
+  `_assemble_zenodo_jsonld` promoted standalone `material-spec` and `material`
+  records to first-class deposit nodes and nothing else, so `electrode-spec` and
+  `electrode` records were read off disk, never used, and absent from
+  `deposit.jsonld`: 301 nodes for the Flores corpus's 323 records, with the
+  processing routes, compositions and design values missing from the published
+  artifact. Both types are now promoted with their full emission. The set is
+  named in `ws.DEPOSIT_STANDALONE_KINDS`, and `tests/test_deposit_coverage.py`
+  sweeps every registered entity kind against `ws.DEPOSIT_COVERAGE_EXEMPT`, so a
+  record type that cannot reach a deposit is a test failure rather than a report
+  footnote.
+
+- **The inline electrode-spec seam was not authorable (readiness finding E1).**
+  `positive_electrode.electrode_spec_id` was in the JSON schema, read by the
+  JSON-LD emitter and vendored by the registry, but the pydantic `Electrode`
+  holder is `extra="forbid"` and had no such field, so the seam
+  `docs/electrodes-model.md` recommends could only be written by hand-editing
+  the record. Added to the model, along with `CurrentCollector.material_spec_id`
+  (the same schema-only seam on the foil material, now also emitted as
+  `schema:isVariantOf`), which the extended parity guard found alongside it. The
+  doc now says which of the two spec seams to prefer and why they state
+  different things.
+
+- **The semantic validator warned about electrode design values it maps
+  (readiness finding E5).** `_component_property_terms()` listed the emitter's
+  holder term tables one by one and was never extended with the electrode table
+  added in #342, so a correct `areal_capacity` on an electrode spec warned
+  `semantic.property_unmapped` — three warnings for zero defects in the Flores
+  corpus, breaking the invariant the helper's own docstring claims.
+  `_MATERIAL_PROPERTY_TERMS` had drifted the same way for eight more keys
+  (`bet_surface_area`, `specific_capacity`, `particle_size_d50` and friends). The
+  emitter now exports one registry, `COMPONENT_PROPERTY_TERM_TABLES`, the
+  validator derives its key set from it, and a guard test fails if any
+  `_<holder>_PROPERTY_TERMS` table is missing from the registry.
+
 - **`RoundTripEfficiencyValueShape` and `CapacityFadeValueShape`** targeted only the
   pre-0.37.1 classes, so the plausibility ranges silently stopped applying to
   records typed with the new ones. Both now target the new and the published IRI.

--- a/docs/electrodes-model.md
+++ b/docs/electrodes-model.md
@@ -159,15 +159,20 @@ itself, and the processing route as `prov:wasGeneratedBy`. A batch emits
 
 ## Cells reference electrodes
 
-A cell-spec can cite a designed electrode two ways, both optional and both
-additive — existing embedded electrode fields stay valid:
+A cell-spec can cite a designed electrode two ways, both optional and both additive — existing embedded electrode fields stay valid. They say different things, so pick on meaning rather than taste:
 
-- top-level `positive_electrode_spec_id` / `negative_electrode_spec_id`, which
-  merge the spec's `@id` onto the emitted electrode node;
-- `electrode_spec_id` **inside** the `positive_electrode` / `negative_electrode`
-  holder, which emits `schema:isVariantOf` — the same seam
-  `material_spec_id` gives an inline material, for cells that describe their
-  electrode inline *and* want to say which design it realizes.
+- **Prefer** the top-level `positive_electrode_spec_id` / `negative_electrode_spec_id` when the cell spec's electrode simply *is* the published design. The spec's `@id` merges onto the emitted electrode node, so the cell spec and the design are one node in the graph.
+- Use `electrode_spec_id` **inside** the `positive_electrode` / `negative_electrode` holder when the inline description is a *variant* of the design, or when both electrodes need independent inline detail. It emits `schema:isVariantOf` — the same seam `material_spec_id` gives an inline material — which states that the holder realizes the design without claiming to be it.
+
+Both are authorable from the model:
+
+```python
+cs.positive_electrode_spec_id = "https://w3id.org/battinfo/spec/rkf4-xz0y-h8kz-rmxz"   # preferred
+cs.negative_electrode = electrode(bom=bom(active_material=material("Graphite")))
+cs.negative_electrode.electrode_spec_id = "https://w3id.org/battinfo/spec/d7qr-n581-74c3-7g7r"
+```
+
+An inline current collector cites the foil material the same way, through `current_collector.material_spec_id`.
 
 Cell instances do not yet reference electrode batches; there is no natural slot on
 `cell_instance` today, and inventing one was out of scope for the promotion.

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -971,6 +971,7 @@ class CurrentCollector(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
+    material_spec_id: str | None = Field(default=None, description="Optional canonical IRI of a standalone material-spec for the foil material — the same MaterialSpec -> component reference seam MaterialComponent carries.")
     manufacturer: str | None = None
     supplier: str | None = None
     product_id: str | None = None
@@ -1002,8 +1003,25 @@ class CurrentCollectorTab(BaseModel):
 
 
 class Electrode(BaseModel):
+    """An electrode described inline on a cell spec.
+
+    Two seams cite a standalone electrode-spec record, and both round-trip and
+    emit:
+
+    * ``CellSpec.positive_electrode_spec_id`` / ``negative_electrode_spec_id`` —
+      the top-level sibling. **Preferred** for a cell spec whose electrode IS the
+      published design: the emitter merges the referenced ``@id`` onto the
+      emitted electrode node, so the cell spec and the design are one node.
+    * ``Electrode.electrode_spec_id`` (this field) — the inline holder cites a
+      design it realizes while keeping its own embedded fields, emitted as
+      ``schema:isVariantOf``. Use it when the inline description differs from the
+      design (a variant), or when both electrodes of one cell spec need
+      independent inline detail.
+    """
+
     model_config = ConfigDict(extra="forbid")
 
+    electrode_spec_id: str | None = Field(default=None, description="Optional canonical IRI of a standalone electrode-spec this inline holder realizes; emitted as schema:isVariantOf. Prefer CellSpec.positive_electrode_spec_id / negative_electrode_spec_id when the cell spec's electrode simply IS that design.")
     coating: Coating | None = None
     current_collector: CurrentCollector | None = None
     tab: CurrentCollectorTab | None = None

--- a/src/battinfo/transform/json_to_jsonld.py
+++ b/src/battinfo/transform/json_to_jsonld.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import warnings
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from functools import lru_cache
 from importlib import resources
@@ -501,6 +502,12 @@ _ELECTRODE_PROPERTY_TERMS: dict[str, str] = {
     "nominal_areal_capacity": "AreicCapacity",
     "reversible_areal_capacity": "AreicCapacity",
 }
+
+# NOTE: a new ``_<holder>_PROPERTY_TERMS`` table must be registered in
+# :data:`COMPONENT_PROPERTY_TERM_TABLES` (defined below, once every table exists).
+# The semantic validator derives its "resolves without the curated map" key set from
+# that tuple, so an unregistered table makes the validator warn about keys the
+# emitter maps — the drift that shipped ``areal_capacity`` warnings.
 
 
 def _descriptor_property_nodes(
@@ -1889,6 +1896,27 @@ _MATERIAL_PROPERTY_TERMS: dict[str, str] = {
     "average_voltage": "Voltage",
     "mass": "Mass",
 }
+
+
+# Every holder ``property`` term table the component emitters pass to
+# :func:`_descriptor_property_nodes` as ``term_overrides``. This is the single
+# source the semantic validator reads to decide which property keys resolve
+# WITHOUT the curated map (``validate.semantic._component_property_terms``), so
+# the validator accepts exactly what the emitters map.
+#
+# Registration is enforced by a guard test: every module-level
+# ``_<holder>_PROPERTY_TERMS`` must appear here, and the validator's key set must
+# equal this union. Tables that drive blocks the validator does not check as a
+# holder ``property`` dict (``_ASSEMBLY_QUANTITY_TERMS`` for construction
+# quantities, ``_MEASUREMENT_PARAMETER_TERMS`` for test conditions) are
+# deliberately named differently and stay out.
+COMPONENT_PROPERTY_TERM_TABLES: tuple[Mapping[str, str], ...] = (
+    _FRACTION_PROPERTY_TERMS,
+    _DESCRIPTOR_PROPERTY_TERMS,
+    _DESCRIPTOR_COATING_PROPERTY_TERMS,
+    _ELECTRODE_PROPERTY_TERMS,
+    _MATERIAL_PROPERTY_TERMS,
+)
 
 
 # Processing-route token -> human label. The tokens are the `route` enum of

--- a/src/battinfo/transform/json_to_jsonld.py
+++ b/src/battinfo/transform/json_to_jsonld.py
@@ -1408,6 +1408,10 @@ def _descriptor_current_collector_to_jsonld(cc: dict[str, Any] | None) -> dict[s
     The name (e.g. 'Aluminium foil') is parsed to build an @type list that stacks the
     substrate material and physical form onto CurrentCollector:
         'Aluminium foil' → ['CurrentCollector', 'Aluminium', 'Foil']
+
+    ``material_spec_id`` cites the standalone material-spec for the foil material,
+    emitted as ``schema:isVariantOf`` — the same reference seam a material
+    component and an inline electrode carry.
     """
     if not isinstance(cc, dict):
         return None
@@ -1416,6 +1420,9 @@ def _descriptor_current_collector_to_jsonld(cc: dict[str, Any] | None) -> dict[s
     node: dict[str, Any] = {"@type": cc_types if len(cc_types) > 1 else cc_types[0]}
     if name:
         node["schema:name"] = name
+    spec_ref = cc.get("material_spec_id")
+    if isinstance(spec_ref, str) and spec_ref.strip():
+        node["schema:isVariantOf"] = {"@id": spec_ref}
     prop_nodes = _descriptor_property_nodes(cc.get("property"))
     if prop_nodes:
         node["hasProperty"] = prop_nodes[0] if len(prop_nodes) == 1 else prop_nodes

--- a/src/battinfo/validate/semantic.py
+++ b/src/battinfo/validate/semantic.py
@@ -572,23 +572,21 @@ def _curated_property_map() -> dict[str, str]:
 def _component_property_terms() -> frozenset[str]:
     """Property keys the component emitters resolve WITHOUT the curated map.
 
-    Imported from the transform itself (fraction keys and the descriptor /
-    coating term tables), so this set can never drift from what the JSON-LD
-    emitters actually accept.
-    """
-    from battinfo.transform.json_to_jsonld import (
-        _DESCRIPTOR_COATING_PROPERTY_TERMS,
-        _DESCRIPTOR_PROPERTY_TERMS,
-        _FRACTION_PROPERTY_TERMS,
-    )
+    Derived from ``COMPONENT_PROPERTY_TERM_TABLES`` — the transform's own
+    registry of every holder ``property`` term table — rather than by naming the
+    tables here, so this set cannot drift from what the JSON-LD emitters accept.
+    Listing them by hand is what let ``_ELECTRODE_PROPERTY_TERMS`` be added to
+    the emitter without reaching the validator, which then warned that a mapped
+    ``areal_capacity`` had no mapping.
 
-    return frozenset(
-        {
-            *_FRACTION_PROPERTY_TERMS,
-            *_DESCRIPTOR_PROPERTY_TERMS,
-            *_DESCRIPTOR_COATING_PROPERTY_TERMS,
-        }
-    )
+    The set is a union across holders, not a per-holder table: a key any
+    component emitter maps is accepted on every component. That is deliberately
+    permissive (a coating term on an electrolyte body does not warn) and matches
+    the behaviour this check has always had.
+    """
+    from battinfo.transform.json_to_jsonld import COMPONENT_PROPERTY_TERM_TABLES
+
+    return frozenset(key for table in COMPONENT_PROPERTY_TERM_TABLES for key in table)
 
 
 def _validate_property_mappability(
@@ -962,10 +960,11 @@ def validate_semantic_report(
         if isinstance(body, Mapping) and isinstance(body.get("property"), Mapping):
             _validate_specs(body["property"], issues, resource_type, hard_issue_severity)
 
-    # Every component body's property block gets the mappability check, with
-    # the transform's descriptor/fraction keys treated as known (they resolve
-    # without the curated map). Coating properties resolve through the coating
-    # term table, so electrode coatings are checked too.
+    # Every component body's property block gets the mappability check, with the
+    # transform's own holder term tables (fraction, descriptor, coating,
+    # electrode, material) treated as known — they resolve without the curated
+    # map. Coating properties resolve through the coating term table, so
+    # electrode coatings are checked too.
     _component_known = _component_property_terms()
 
     def _check_props(block: Any, prefix: str) -> None:

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -821,6 +821,49 @@ def _provider(creators: list[dict] | None, contributors: list[dict] | None) -> t
 # Derived from the entity registry so new record types are picked up automatically.
 _RECORD_SET_DIRS = record_set_dirs()
 
+# Record types :meth:`AuthoringWorkspace._assemble_zenodo_jsonld` promotes to
+# standalone deposit nodes by emitting each record on its own. Every other type
+# reaches the graph through a dedicated builder (cell specs, cells, tests, test
+# protocols, datasets) or through the record that references it (equipment and
+# channels, from the tests that ran on them).
+#
+# A type in neither group is read off disk by :func:`_read_record_sets` and then
+# silently dropped — records that save, validate and emit cleanly but never reach
+# the artifact a reader gets. That is what happened to the whole electrode layer.
+# ``tests/test_deposit_coverage.py`` sweeps ``ENTITY_KINDS`` against
+# :data:`DEPOSIT_COVERAGE_EXEMPT` so the next type added fails a test rather than
+# going missing from a deposit.
+DEPOSIT_STANDALONE_KINDS: tuple[str, ...] = (
+    "material-spec",
+    "material",
+    "electrode-spec",
+    "electrode",
+)
+
+# entity_type -> why a record of that type is not a described node in the deposit
+# graph. Equipment and channels are NOT here: the test emitter builds a described
+# node for each unit and channel a test ran on (hasTestEquipment / prov:used).
+DEPOSIT_COVERAGE_EXEMPT: dict[str, str] = {
+    "equipment-spec": (
+        "the model behind a unit: the deposit describes the units the tests ran "
+        "on (built from the test's equipment_id), not the product line, so a "
+        "spec with no test attached has nothing to attach to. G11 tracks the "
+        "wider equipment-family publication gap"
+    ),
+    **{
+        entity_type: (
+            "generic component family: described inline on the cell spec that uses "
+            "it, not yet promoted to a standalone deposit node"
+        )
+        for entity_type in (
+            "separator-spec", "separator",
+            "current-collector-spec", "current-collector",
+            "electrolyte-spec", "electrolyte",
+            "housing-spec", "housing",
+        )
+    },
+}
+
 
 def _read_record_sets(source_root: Path) -> dict[str, list[dict]]:
     """Load a workspace's saved records into the canonical ``record_sets`` mapping.
@@ -5699,14 +5742,17 @@ class AuthoringWorkspace:
             catalog_node["schema:keywords"] = sorted(_kw)
             catalog_node["dcat:keyword"]    = sorted(_kw)   # DCAT mirror of schema:keywords
 
-        # Standalone material records (Level 2 spec / Level 3 instance) become
-        # first-class deposit nodes: the domain-battery emitter types each by its
-        # kind (kind -> EMMO class + chemical-substance sameAs, labeled fallback
-        # where a class is missing), and the consolidated context resolves those
-        # terms. Cells reference these via material_spec_id on their electrode
-        # components; publishing the standalone nodes makes the links resolve.
-        material_nodes: builtins.list[dict] = []
-        for _mkey in ("material-spec", "material"):
+        # Standalone material and electrode records (Level 2 spec / Level 3
+        # instance) become first-class deposit nodes: the domain-battery emitter
+        # types each by its kind (kind -> EMMO class + chemical-substance sameAs
+        # for materials, chemistry + polarity classes for electrodes, labeled
+        # fallback where a class is missing) and carries its composition,
+        # processing and spec link; the consolidated context resolves those
+        # terms. Cells reference these via material_spec_id / electrode_spec_id
+        # on their components, so publishing the standalone nodes is what makes
+        # those links resolve inside the deposit.
+        standalone_nodes: builtins.list[dict] = []
+        for _mkey in DEPOSIT_STANDALONE_KINDS:
             for _mrec in record_sets.get(_mkey, []):
                 if not isinstance(_mrec, dict):
                     continue
@@ -5714,7 +5760,7 @@ class AuthoringWorkspace:
 
                 _mg = (to_jsonld(_mrec, target="domain-battery").get("@graph") or [])
                 if _mg:
-                    material_nodes.append(dict(_mg[0]))
+                    standalone_nodes.append(dict(_mg[0]))
 
         graph = (
             [catalog_node]
@@ -5725,7 +5771,7 @@ class AuthoringWorkspace:
             + test_spec_nodes
             + instance_nodes
             + test_nodes
-            + material_nodes
+            + standalone_nodes
             # Equipment provenance: the units/channels the tests actually ran on,
             # so hasTestEquipment / prov:used resolve to described nodes.
             + [equipment_nodes[k] for k in sorted(equipment_nodes)]

--- a/tests/test_deposit_coverage.py
+++ b/tests/test_deposit_coverage.py
@@ -1,0 +1,264 @@
+"""Guard: every record type either reaches the deposit graph or says why not.
+
+The Flores half-cell corpus published 323 records and got a ``deposit.jsonld``
+with 301 nodes. All 24 missing ones were electrodes: ``_assemble_zenodo_jsonld``
+promoted standalone ``material-spec``/``material`` records to first-class deposit
+nodes and nothing else, so the electrode layer was read off disk by
+``_read_record_sets``, never used, and silently absent from the artifact a reader
+downloads. Records that save cleanly, validate cleanly and emit cleanly still did
+not get published.
+
+Nothing failed. The gap was found by a human diffing record counts against node
+counts and writing it up as a report footnote, which is not a mechanism.
+
+This module is the mechanism: it builds one record of every registered
+:data:`ENTITY_KINDS` type, wires them into a single record set, assembles the
+deposit graph and asserts each record's IRI is a node in it — or that the type is
+listed in :data:`battinfo.ws.DEPOSIT_COVERAGE_EXEMPT` with a reason. Registering a
+new record type without giving it a path into the deposit therefore fails a test,
+and (as with ``KNOWN_GAPS`` in the parity sweep) an exemption that stops being
+true also fails, so the list cannot become a graveyard.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api import (  # noqa: E402
+    create_channel,
+    create_component_instance,
+    create_component_spec,
+    create_electrode,
+    create_electrode_spec,
+    create_equipment,
+    create_equipment_spec,
+    create_material,
+    create_material_spec,
+)
+from battinfo.bundle import Cell, CellSpec, Dataset, ProvenanceInfo, Test, TestSpec  # noqa: E402
+from battinfo.entities import COMPONENT_FAMILIES, ENTITY_KINDS  # noqa: E402
+from battinfo.ws import (  # noqa: E402
+    DEPOSIT_COVERAGE_EXEMPT,
+    DEPOSIT_STANDALONE_KINDS,
+    AuthoringWorkspace,
+)
+
+UID = "aaaa-bbbb-cccc-dddd"
+CELL_SPEC_IRI = f"https://w3id.org/battinfo/spec/{UID}"
+CELL_IRI = f"https://w3id.org/battinfo/cell/{UID}"
+TEST_IRI = f"https://w3id.org/battinfo/test/{UID}"
+TEST_SPEC_IRI = "https://w3id.org/battinfo/spec/bbbb-cccc-dddd-eeee"
+DATASET_IRI = f"https://w3id.org/battinfo/dataset/{UID}"
+EQUIPMENT_IRI = f"https://w3id.org/battinfo/equipment/{UID}"
+CHANNEL_IRI = f"https://w3id.org/battinfo/channel/{UID}"
+MATERIAL_SPEC_IRI = "https://w3id.org/battinfo/spec/cccc-dddd-eeee-ffff"
+ELECTRODE_SPEC_IRI = "https://w3id.org/battinfo/spec/dddd-eeee-ffff-gggg"
+
+
+def _record_sets() -> dict[str, list[dict]]:
+    """One wired record of every registered type, keyed by on-disk subdir.
+
+    Wired the way a real corpus is (cell spec -> cell -> test -> dataset, test on
+    a channel of a unit, electrode batch on its design, powder under it), because
+    several types reach the graph only through the record that references them.
+    """
+    material_spec = create_material_spec(
+        validate=False, uid=MATERIAL_SPEC_IRI.rsplit("/", 1)[-1], name="Graphite powder",
+        kind="graphite",
+    )
+    material = create_material(
+        validate=False, uid="1111-2222-3333-4444", name="Graphite lot",
+        material_spec_id=material_spec["material_spec"]["id"], lot="LOT-1",
+    )
+    electrode_spec = create_electrode_spec(
+        validate=False, uid=ELECTRODE_SPEC_IRI.rsplit("/", 1)[-1], name="Graphite anode",
+        kind="graphite", active_material_spec_id=material_spec["material_spec"]["id"],
+        property={"areal_capacity": {"value": 3.4, "unit": "mA.h/cm2"}},
+    )
+    electrode = create_electrode(
+        validate=False, uid="2222-3333-4444-5555", name="Coating batch A",
+        electrode_spec_id=electrode_spec["electrode_spec"]["id"], batch="B-1",
+    )
+    equipment_spec = create_equipment_spec(
+        validate=False, uid="3333-4444-5555-6666", name="MC3000",
+    )
+    equipment = create_equipment(
+        validate=False, uid=UID, equipment_spec_id=equipment_spec["equipment_spec"]["id"],
+        serial_number="SN-1",
+    )
+    channel = create_channel(validate=False, uid=UID, equipment_id=EQUIPMENT_IRI, index=1)
+
+    cell_spec = CellSpec(
+        id=CELL_SPEC_IRI, name="Demo half cell", manufacturer="Demo Co", model="DEMO-1",
+        format="coin", chemistry="lithium_ion",
+        positive_electrode_spec_id=electrode_spec["electrode_spec"]["id"],
+        source=ProvenanceInfo(type="datasheet"),
+    ).to_record()
+    cell = Cell(
+        id=CELL_IRI, name="cell-001", cell_spec_id=CELL_SPEC_IRI, serial_number="cell-001",
+        source=ProvenanceInfo(type="measurement"),
+    ).to_record()
+    test_spec = TestSpec(
+        id=TEST_SPEC_IRI, name="pOCV protocol", source=ProvenanceInfo(type="protocol"),
+    ).to_record()
+    test = Test(
+        id=TEST_IRI, name="pOCV run", kind="cycling", cell_id=CELL_IRI,
+        protocol_id=TEST_SPEC_IRI, equipment_id=EQUIPMENT_IRI, channel_id=CHANNEL_IRI,
+        dataset_ids=[DATASET_IRI], source=ProvenanceInfo(type="measurement"),
+    ).to_record()
+    dataset = Dataset(
+        id=DATASET_IRI, name="pOCV curves", cell_instance_id=CELL_IRI, test_id=TEST_IRI,
+        access_url="https://example.org/data.parquet",
+        source=ProvenanceInfo(type="measurement"),
+    ).to_record()
+
+    sets: dict[str, list[dict]] = {
+        "cell-spec": [cell_spec],
+        "cell-instance": [cell],
+        "test-protocol": [test_spec],
+        "test": [test],
+        "dataset": [dataset],
+        "material-spec": [material_spec],
+        "material": [material],
+        "electrode-spec": [electrode_spec],
+        "electrode": [electrode],
+        "equipment-spec": [equipment_spec],
+        "equipment": [equipment],
+        "channel": [channel],
+    }
+    # Generic component families (separator, current-collector, electrolyte,
+    # housing): spec + instance, so the sweep sees them too.
+    for index, family in enumerate(COMPONENT_FAMILIES):
+        hyphen = family.replace("_", "-")
+        spec_uid = f"{index}aaa-bbbb-cccc-dddd"
+        inst_uid = f"{index}eee-ffff-gggg-hhhh"
+        spec = create_component_spec(
+            family, validate=False, uid=spec_uid, name=f"{hyphen} spec",
+        )
+        sets[f"{hyphen}-spec"] = [spec]
+        sets[hyphen] = [
+            create_component_instance(
+                family, validate=False, uid=inst_uid,
+                spec_id=f"https://w3id.org/battinfo/spec/{spec_uid}",
+            )
+        ]
+    return sets
+
+
+def _record_iri(record: dict) -> str:
+    for body in record.values():
+        if isinstance(body, dict) and isinstance(body.get("id"), str):
+            return body["id"]
+    raise AssertionError(f"record carries no body id: {sorted(record)}")
+
+
+def _deposit_graph(record_sets: dict[str, list[dict]]) -> dict:
+    return AuthoringWorkspace._assemble_zenodo_jsonld(
+        record_sets,
+        zenodo_record_id=1,
+        prereserved_doi="10.5281/zenodo.1",
+        record_url="https://zenodo.org/records/1",
+        data_filenames=[],
+        title="coverage sweep",
+    )
+
+
+def _deposit_node_ids(record_sets: dict[str, list[dict]]) -> set[str]:
+    """IRIs of the TOP-LEVEL ``@graph`` members.
+
+    Deliberately not a recursive walk: a nested ``{"@id": ...}`` is a reference to
+    a node, not a described one, and a deposit whose electrode IRIs appeared only
+    as dangling references would be exactly the artifact this guard exists to
+    reject.
+    """
+    return {
+        node["@id"]
+        for node in _deposit_graph(record_sets)["@graph"]
+        if isinstance(node, dict) and isinstance(node.get("@id"), str)
+    }
+
+
+def _coverage() -> dict[str, bool]:
+    """entity_type -> whether that type's record reached the deposit graph."""
+    record_sets = _record_sets()
+    ids = _deposit_node_ids(record_sets)
+    return {
+        kind.entity_type: all(_record_iri(rec) in ids for rec in record_sets[kind.subdir])
+        for kind in ENTITY_KINDS
+    }
+
+
+def test_every_record_type_reaches_the_deposit_graph_or_is_exempt() -> None:
+    """The E2 guard: a saved record type absent from the deposit fails here."""
+    missing = [
+        entity_type
+        for entity_type, covered in _coverage().items()
+        if not covered and entity_type not in DEPOSIT_COVERAGE_EXEMPT
+    ]
+    assert not missing, (
+        "record types read by _read_record_sets but absent from the assembled "
+        "deposit graph. Promote them in _assemble_zenodo_jsonld (see "
+        "DEPOSIT_STANDALONE_KINDS), or add them to DEPOSIT_COVERAGE_EXEMPT with a "
+        f"reason: {sorted(missing)}"
+    )
+
+
+def test_the_electrode_layer_is_in_the_deposit_graph() -> None:
+    """E2 by name: the specific regression the corpus found, pinned."""
+    record_sets = _record_sets()
+    ids = _deposit_node_ids(record_sets)
+    for entity_type in ("electrode-spec", "electrode"):
+        iri = _record_iri(record_sets[entity_type][0])
+        assert iri in ids, f"{entity_type} record {iri} is missing from deposit.jsonld"
+
+
+def test_electrode_nodes_carry_their_full_emission() -> None:
+    """A promoted node must be the emitter's node, not a stub.
+
+    The electrode specs are where the chemistry, polarity, processing route and
+    design values live; promoting a bare ``@id`` would satisfy the coverage sweep
+    while still losing what makes the layer worth publishing.
+    """
+    record_sets = _record_sets()
+    doc = _deposit_graph(record_sets)
+    by_id = {n["@id"]: n for n in doc["@graph"] if isinstance(n.get("@id"), str)}
+
+    spec_node = by_id[_record_iri(record_sets["electrode-spec"][0])]
+    types = spec_node["@type"] if isinstance(spec_node["@type"], list) else [spec_node["@type"]]
+    assert "GraphiteElectrode" in types, types           # chemistry from the kind
+    assert "NegativeElectrode" in types, types           # polarity derived from the kind
+    assert spec_node["hasProperty"]["@type"][0] == "AreicCapacity"
+
+    batch_node = by_id[_record_iri(record_sets["electrode"][0])]
+    assert batch_node["schema:isVariantOf"] == {"@id": ELECTRODE_SPEC_IRI}
+
+
+@pytest.mark.parametrize("entity_type", sorted(DEPOSIT_COVERAGE_EXEMPT))
+def test_exemptions_are_still_real(entity_type: str) -> None:
+    """Delete the entry when the type starts reaching the deposit on its own."""
+    assert not _coverage()[entity_type], (
+        f"{entity_type} now reaches the deposit graph; remove it from "
+        "DEPOSIT_COVERAGE_EXEMPT"
+    )
+
+
+def test_exemptions_name_registered_types_and_carry_a_reason() -> None:
+    registered = {kind.entity_type for kind in ENTITY_KINDS}
+    unknown = sorted(set(DEPOSIT_COVERAGE_EXEMPT) - registered)
+    assert not unknown, f"DEPOSIT_COVERAGE_EXEMPT names unregistered types: {unknown}"
+    empty = [key for key, reason in DEPOSIT_COVERAGE_EXEMPT.items() if not reason.strip()]
+    assert not empty, f"DEPOSIT_COVERAGE_EXEMPT entries without a reason: {empty}"
+
+
+def test_standalone_kinds_are_registered_types() -> None:
+    registered = {kind.entity_type for kind in ENTITY_KINDS}
+    unknown = sorted(set(DEPOSIT_STANDALONE_KINDS) - registered)
+    assert not unknown, f"DEPOSIT_STANDALONE_KINDS names unregistered types: {unknown}"
+    overlap = sorted(set(DEPOSIT_STANDALONE_KINDS) & set(DEPOSIT_COVERAGE_EXEMPT))
+    assert not overlap, f"types both promoted and exempt: {overlap}"

--- a/tests/test_electrodes_first_class.py
+++ b/tests/test_electrodes_first_class.py
@@ -358,6 +358,68 @@ def test_cell_spec_electrode_holder_may_cite_an_electrode_spec() -> None:
     assert node["hasNegativeElectrode"]["schema:isVariantOf"] == {"@id": SPEC_IRI}
 
 
+def test_both_electrode_spec_seams_are_authorable_and_round_trip() -> None:
+    """E1: the inline seam was schema-only, so only one of the two was authorable.
+
+    Both must survive to_record -> from_record. They do NOT emit the same
+    statement, and must not: the top-level field says the cell spec's electrode
+    IS that design (the @id merges onto the electrode node), the inline field
+    says this holder is a variant OF it (schema:isVariantOf). See
+    docs/electrodes-model.md for which to reach for.
+    """
+    from battinfo.bundle import CellSpec, Electrode
+    from battinfo.transform.json_to_jsonld import to_jsonld
+
+    cs = CellSpec(
+        id="https://w3id.org/battinfo/spec/1111-2222-3333-4444",
+        name="Demo cell", manufacturer="Demo Co", model="Demo",
+        format="coin", chemistry="lithium_ion",
+        positive_electrode_spec_id=SPEC_IRI,
+        negative_electrode=Electrode(
+            coating={"component": {"active_material": [{"name": "Graphite"}]}},
+        ),
+    )
+    cs.negative_electrode.electrode_spec_id = SPEC_IRI
+
+    record = cs.to_record()
+    assert record["positive_electrode_spec_id"] == SPEC_IRI
+    assert record["negative_electrode"]["electrode_spec_id"] == SPEC_IRI
+
+    reloaded = CellSpec.from_record(record)
+    assert reloaded.positive_electrode_spec_id == SPEC_IRI
+    assert reloaded.negative_electrode.electrode_spec_id == SPEC_IRI
+    assert reloaded.to_record() == record
+
+    node = to_jsonld(record, target="domain-battery")["@graph"][0]
+    assert node["hasPositiveElectrode"]["@id"] == SPEC_IRI
+    assert node["hasNegativeElectrode"]["schema:isVariantOf"] == {"@id": SPEC_IRI}
+
+
+def test_inline_current_collector_cites_its_foil_material_spec() -> None:
+    """Found by extending the parity guard to nested holders, same family as E1."""
+    from battinfo.bundle import CellSpec, CurrentCollector, Electrode
+    from battinfo.transform.json_to_jsonld import to_jsonld
+
+    material_spec = "https://w3id.org/battinfo/spec/9999-8888-7777-6666"
+    cs = CellSpec(
+        id="https://w3id.org/battinfo/spec/1111-2222-3333-4444",
+        name="Demo cell", manufacturer="Demo Co", model="Demo",
+        format="coin", chemistry="lithium_ion",
+        positive_electrode=Electrode(
+            current_collector=CurrentCollector(
+                name="Aluminium foil", material_spec_id=material_spec,
+            ),
+        ),
+    )
+    record = cs.to_record()
+    assert record["positive_electrode"]["current_collector"]["material_spec_id"] == material_spec
+    assert CellSpec.from_record(record).to_record() == record
+
+    node = to_jsonld(record, target="domain-battery")["@graph"][0]
+    collector = node["hasPositiveElectrode"]["hasCurrentCollector"]
+    assert collector["schema:isVariantOf"] == {"@id": material_spec}
+
+
 def test_electrode_spec_reference_only_holder_is_valid() -> None:
     from battinfo.validate.record import validate_record
 

--- a/tests/test_schema_model_parity.py
+++ b/tests/test_schema_model_parity.py
@@ -1,6 +1,6 @@
 """Guard: every JSON-schema property of every record type is reachable through a model.
 
-Three bugs of one family were found one at a time, each by a human authoring real
+Four bugs of one family were found one at a time, each by a human authoring real
 data rather than by a test:
 
 * ``Test.conditions`` — the schema defined it, the ``Test`` model had no such
@@ -9,12 +9,22 @@ data rather than by a test:
   it on save (fixed in #334).
 * ``TestSpec.conditions`` — typed ``dict[str, Quantity]``, so the textual
   conditions the schema permits are inexpressible (open; listed below as M4).
+* ``positive_electrode.electrode_spec_id`` — the schema defined it, the JSON-LD
+  emitter read it and the registry vendored it, but the inline ``Electrode``
+  holder is ``extra="forbid"`` and had no such field, so the seam the electrode
+  docs recommend could not be authored at all (readiness finding E1).
+
+E1 escaped this module for a structural reason worth naming: the sweep walked the
+record body and its top-level siblings and stopped there, so a component holder
+was checked as one property (``positive_electrode`` reaches the model) and never
+opened. :func:`test_every_nested_component_property_is_reachable` opens it.
 
 The schema is the save-time contract and the models are the authoring surface, so
 a property that exists in one and not the other is data a user cannot express, or
 data they express and silently lose. This module sweeps all of it: for every
-registered entity kind, every property the JSON schema declares (record body plus
-the top-level siblings) must be either
+registered entity kind, every property the JSON schema declares (record body,
+top-level siblings, and the closed object schemas nested under either) must be
+either
 
 * **reachable** — the model/builder accepts it under its own name or a declared
   authoring alias, and
@@ -322,6 +332,22 @@ def _unknown_property_error(exc: Exception, prop: str) -> bool:
     return False
 
 
+def _unknown_nested_error(exc: Exception, path: tuple[str, ...]) -> bool:
+    """True when *exc* rejects the nested key at *path* as not modeled.
+
+    Pydantic reports the full location of a rejected key inside a nested model
+    (``('positive_electrode', 'electrode_spec_id')``), so match on the tail: the
+    holder may sit under a list index or an alias that shifts the head.
+    """
+    if not isinstance(exc, ValidationError):
+        return False
+    return any(
+        error["type"] in {"extra_forbidden", "unexpected_keyword_argument"}
+        and tuple(str(part) for part in error["loc"])[-len(path):] == path
+        for error in exc.errors()
+    )
+
+
 def _schema_properties(kind: Any) -> list[tuple[str, str, dict]]:
     """``(location, property, subschema)`` for the record body and its siblings."""
     root = _load_schema(kind.schema_file)
@@ -384,6 +410,152 @@ def _sweep() -> tuple[list[str], list[str], int]:
                 dropped.append(f"{entity_type}.{prop} ({location}) accepted a value but to_record() omitted it")
 
     return unreachable, dropped, exercised
+
+
+# ── The nested sweep ──────────────────────────────────────────────────────────
+# The sweep above treats a component holder as one property. This one opens it:
+# for every closed object schema (``additionalProperties: false`` with declared
+# properties) reachable from a record type, each of its own properties must be
+# authorable through the model that holds it, and scalars must survive to the
+# record. That is where E1 lived, and where the same seam on the current
+# collector was found with it.
+
+# Nested location -> why it is not reachable, same contract as KNOWN_GAPS.
+KNOWN_NESTED_GAPS: dict[tuple[str, str], str] = {}
+
+# How deep to open holders. 3 reaches cell-spec.positive_electrode.coating
+# .component (holder -> sub-holder -> material component), which is the deepest
+# closed object the component schemas define.
+_MAX_NESTED_DEPTH = 3
+
+
+def _closed_object(subschema: dict, root: dict, base: str) -> tuple[dict, dict, str] | None:
+    """(schema, root, base) when *subschema* is a closed object with properties."""
+    schema, root, base = _deref(subschema, root, base)
+    kind = schema.get("type")
+    if isinstance(kind, list):
+        kind = next((entry for entry in kind if entry != "null"), None)
+    if kind != "object" or schema.get("additionalProperties") is not False:
+        return None
+    if not isinstance(schema.get("properties"), dict) or not schema["properties"]:
+        return None
+    return schema, root, base
+
+
+def _nested_sweep() -> tuple[list[str], list[str], int]:
+    """(unreachable, dropped-on-save, nested properties actually exercised)."""
+    unreachable: list[str] = []
+    dropped: list[str] = []
+    exercised = 0
+
+    for kind in ENTITY_KINDS:
+        entity_type = kind.entity_type
+        build = BUILDERS[entity_type]
+        root = _load_schema(kind.schema_file)
+        baseline = build()
+
+        def walk(
+            subschema: dict, sub_root: dict, base: str,
+            path: tuple[str, ...], record_path: tuple[str, ...], depth: int,
+            *, _entity_type: str = entity_type, _build: Any = build,
+        ) -> None:
+            nonlocal exercised
+            opened = _closed_object(subschema, sub_root, base)
+            if opened is None or depth > _MAX_NESTED_DEPTH:
+                return
+            obj_schema, obj_root, obj_base = opened
+            # A schema-valid payload satisfies the holder's own required keys, so
+            # a model that normalizes on a required field (an agent needs a name)
+            # is not misread as dropping the property under test.
+            required = {
+                name: sample_value(obj_schema["properties"][name], obj_root, name, obj_base)
+                for name in obj_schema.get("required", [])
+                if name in obj_schema["properties"]
+            }
+            for name, nested_schema in obj_schema["properties"].items():
+                if (_entity_type, ".".join(path + (name,))) in KNOWN_NESTED_GAPS:
+                    continue
+                value = sample_value(nested_schema, obj_root, name, obj_base)
+                if value is None:
+                    continue
+                payload: Any = {**required, name: value}
+                for segment in reversed(path[1:]):
+                    payload = {segment: payload}
+                exercised += 1
+                try:
+                    record = _build(**{path[0]: payload})
+                except Exception as exc:  # noqa: BLE001 - classified here
+                    if _unknown_nested_error(exc, path[1:] + (name,)):
+                        unreachable.append(f"{_entity_type}.{'.'.join(path + (name,))}")
+                    continue  # anything else is a sample-shape mismatch, not a gap
+
+                if _is_scalar(nested_schema, obj_root, obj_base):
+                    cursor: Any = record
+                    for segment in record_path + path:
+                        cursor = cursor.get(segment) if isinstance(cursor, dict) else None
+                        if cursor is None:
+                            break
+                    if not isinstance(cursor, dict) or name not in cursor:
+                        dropped.append(f"{_entity_type}.{'.'.join(path + (name,))}")
+                walk(nested_schema, obj_root, obj_base, path + (name,), record_path, depth + 1)
+
+        for location, prop, subschema in _schema_properties(kind):
+            target = baseline.get(kind.record_key, {}) if location == "body" else baseline
+            if prop in target:
+                continue  # derived: the builder writes the whole block itself
+            record_path = () if location == "top" else (kind.record_key,)
+            walk(subschema, root, kind.schema_file, (prop,), record_path, 0)
+
+    return unreachable, dropped, exercised
+
+
+def test_every_nested_component_property_is_reachable() -> None:
+    """E1's family: a closed holder must model every property its schema declares."""
+    unreachable, _, _ = _nested_sweep()
+    assert not unreachable, (
+        "properties of nested component schemas with no authoring path. Add the "
+        "field to the holder model, or add it to KNOWN_NESTED_GAPS with a "
+        "reason:\n  " + "\n  ".join(sorted(unreachable))
+    )
+
+
+def test_no_nested_property_is_dropped_between_the_model_and_the_record() -> None:
+    """A nested value the model accepts must reach the record."""
+    _, dropped, _ = _nested_sweep()
+    assert not dropped, (
+        "nested values accepted by the model but missing from the built record:\n  "
+        + "\n  ".join(sorted(dropped))
+    )
+
+
+def test_nested_sweep_actually_exercises_the_corpus() -> None:
+    """The sweep that would have caught E1 must keep opening holders."""
+    _, _, exercised = _nested_sweep()
+    assert exercised >= 800, (
+        f"only {exercised} nested properties round-tripped a value; the nested sweep is degrading"
+    )
+
+
+def test_known_nested_gaps_all_carry_a_reason() -> None:
+    empty = [key for key, reason in KNOWN_NESTED_GAPS.items() if not reason.strip()]
+    assert not empty, f"KNOWN_NESTED_GAPS entries without a reason: {empty}"
+
+
+def test_electrode_holder_models_both_spec_seams() -> None:
+    """E1 by name, on both polarities, through the blessed authoring path."""
+    from battinfo.bundle import Electrode
+
+    inline = CellSpec(
+        id=SPEC_IRI, name="probe",
+        positive_electrode=Electrode(electrode_spec_id=SPEC_IRI),
+        negative_electrode=Electrode(electrode_spec_id=SPEC_IRI),
+    )
+    # Assignment after construction is the shape the readiness report used.
+    inline.positive_electrode.electrode_spec_id = SPEC_IRI
+    record = inline.to_record()
+    assert record["positive_electrode"]["electrode_spec_id"] == SPEC_IRI
+    assert record["negative_electrode"]["electrode_spec_id"] == SPEC_IRI
+    assert CellSpec.from_record(record).positive_electrode.electrode_spec_id == SPEC_IRI
 
 
 def test_every_schema_property_is_reachable_through_a_model() -> None:

--- a/tests/test_validation_semantic.py
+++ b/tests/test_validation_semantic.py
@@ -209,3 +209,82 @@ def test_property_unmapped_message_matches_transform_reality() -> None:
     assert "fallback" in issue.message
     assert "OMITTED" not in issue.message
 
+
+# ── The validator must accept exactly what the emitters map ───────────────────
+# _component_property_terms() used to name the transform's term tables one by
+# one. #342 added _ELECTRODE_PROPERTY_TERMS to the emitter and nothing added it
+# here, so a correct electrode design value warned that it had no mapping — while
+# the helper's own docstring claimed the set "can never drift". Three warnings
+# for zero defects in the Flores corpus (E5), and _MATERIAL_PROPERTY_TERMS had
+# drifted the same way for eight more keys.
+
+
+@pytest.mark.parametrize(
+    "key", ["areal_capacity", "nominal_areal_capacity", "reversible_areal_capacity"]
+)
+def test_electrode_design_values_do_not_warn(key: str) -> None:
+    """E5: the electrode emitter maps these to AreicCapacity; nothing may warn."""
+    rec = {
+        "schema_version": "0.2.0",
+        "electrode_spec": {
+            "id": "https://w3id.org/battinfo/electrode-spec/aaaa-bbbb-cccc-dddd",
+            "name": "Purchased graphite electrode",
+            "kind": "graphite",
+            "property": {key: {"value": 3.4, "unit": "mA.h/cm2"}},
+        },
+        "provenance": {"source_type": "datasheet"},
+    }
+    report = validate_semantic_report(rec, policy=STRICT_SEMANTIC)
+    assert [i.code for i in report.issues] == []
+
+
+@pytest.mark.parametrize("key", ["bet_surface_area", "specific_capacity", "particle_size_d50"])
+def test_material_datasheet_values_do_not_warn(key: str) -> None:
+    """Same drift on _MATERIAL_PROPERTY_TERMS: ordinary powder datasheet keys."""
+    rec = {
+        "schema_version": "0.2.0",
+        "material_spec": {
+            "id": "https://w3id.org/battinfo/material-spec/aaaa-bbbb-cccc-dddd",
+            "name": "Graphite powder",
+            "property": {key: {"value": 2.5, "unit": "m2/g"}},
+        },
+        "provenance": {"source_type": "datasheet"},
+    }
+    hits = [
+        i.path
+        for i in validate_semantic_report(rec, policy=STRICT_SEMANTIC).issues
+        if i.code == "semantic.property_unmapped"
+    ]
+    assert hits == []
+
+
+def test_every_emitter_property_table_is_registered() -> None:
+    """A new holder term table must join the registry the validator reads.
+
+    Naming the tables in two places is what allowed the drift. The emitter now
+    exports one registry; this pins that no ``_<holder>_PROPERTY_TERMS`` can be
+    added to the transform without appearing in it.
+    """
+    from battinfo.transform import json_to_jsonld as emitter
+
+    registered = {id(table) for table in emitter.COMPONENT_PROPERTY_TERM_TABLES}
+    unregistered = sorted(
+        name
+        for name in dir(emitter)
+        if name.endswith("_PROPERTY_TERMS") and id(getattr(emitter, name)) not in registered
+    )
+    assert not unregistered, (
+        "property term tables the emitter uses but COMPONENT_PROPERTY_TERM_TABLES "
+        "does not list, so the semantic validator will warn about keys the emitter "
+        f"maps: {unregistered}"
+    )
+
+
+def test_validator_known_keys_equal_the_emitter_registry() -> None:
+    """The invariant the docstring claims, asserted rather than assumed."""
+    from battinfo.transform.json_to_jsonld import COMPONENT_PROPERTY_TERM_TABLES
+    from battinfo.validate.semantic import _component_property_terms
+
+    expected = {key for table in COMPONENT_PROPERTY_TERM_TABLES for key in table}
+    assert set(_component_property_terms()) == expected
+


### PR DESCRIPTION
## What

Fixes the three defects that block a clean corpus republish and Zenodo deposit, reported as findings E1, E2 and E5 in `battinfo-records#6` (`data/flores-ocv-halfcells`, `READINESS-REPORT.md`):

- **E5** — the semantic validator warned `semantic.property_unmapped` on `electrode_spec.property.areal_capacity`, which the emitter maps to `AreicCapacity`.
- **E2** — `_assemble_zenodo_jsonld` never promoted `electrode-spec` / `electrode` records, so all 24 electrode records were absent from `deposit.jsonld`.
- **E1** — `positive_electrode.electrode_spec_id` was in the JSON schema and read by the emitter, but not on the pydantic `Electrode` holder, which is `extra="forbid"`, so it could not be authored.

Extending the parity guard to nested holders found a fourth instance of the E1 family: `current_collector.material_spec_id`.

## Why

All three shipped through every existing gate. The Flores corpus saved 323 records with 0 strict-save errors and 0 SHACL findings, and still got 3 false warnings and a `deposit.jsonld` with 301 nodes. The electrode specs are where the processing route, composition and design values live, so the layer that was missing from the deposit is the one the model was promoted for.

Each is a mechanism failure rather than a typo, so each fix closes the mechanism:

- E5: `_component_property_terms()` listed the emitter's term tables by hand, so #342 could add `_ELECTRODE_PROPERTY_TERMS` to the emitter without the validator hearing about it — while the helper's docstring claimed the set "can never drift".
- E2: the deposit builder hardcoded which record types become nodes, and `_read_record_sets` is derived from the entity registry, so any type added to the registry is read off disk and silently dropped.
- E1: `test_schema_model_parity` exists for this exact bug family. It walked the record body and its top-level siblings and stopped, so a component holder was checked as one property (`positive_electrode` reaches the model) and never opened.

## How

**E5.** `transform/json_to_jsonld` exports `COMPONENT_PROPERTY_TERM_TABLES`, the one registry of every holder `property` term table, and `validate/semantic._component_property_terms()` derives its key set from it. Registering `_MATERIAL_PROPERTY_TERMS`, which had drifted the same way, removes 8 further false positives (`bet_surface_area`, `specific_capacity`, `particle_size_d50`, `true_density`, `tap_density`, `molar_mass`, `average_voltage`, `specific_discharge_capacity`). The union stays a union across holders, not a per-holder table, which is the behaviour this check has always had.

**E2.** Both electrode types are promoted through the same emitter path as materials, so they arrive with their chemistry and polarity classes, processing, composition and spec link. The promoted set is named in `ws.DEPOSIT_STANDALONE_KINDS`; `ws.DEPOSIT_COVERAGE_EXEMPT` records, with a reason, the types that legitimately do not become their own node. Equipment and channels are not exempt: the test emitter already builds a described node for each unit and channel a test ran on.

**E1.** `electrode_spec_id` added to `bundle.Electrode`, `material_spec_id` added to `bundle.CurrentCollector` and emitted as `schema:isVariantOf` so the new field is not a dead end. The two electrode-spec seams stay deliberately distinct and are not collapsed: the top-level `positive_electrode_spec_id` merges the spec's `@id` onto the electrode node (the cell spec's electrode *is* that design), the inline `electrode_spec_id` emits `schema:isVariantOf` (this holder *realizes* it). Both now round-trip through `to_record`/`from_record`; `docs/electrodes-model.md` says which to prefer and why.

## Testing

`uv run pytest` 1828 passed, 1 skipped. `ruff check src tests scripts` clean. `mypy` clean on 70 files. `scripts/assemble_context.py --check` up to date; no schema or shipped-artifact change, so no regeneration and no v1 context edit.

New guards, each verified to fail against the pre-fix tree:

- `tests/test_deposit_coverage.py` (new) builds one record of every registered entity kind, assembles a deposit and asserts each is a described top-level `@graph` node or is exempt with a reason. Exemptions are re-checked, so the list cannot become a graveyard. Reverting `DEPOSIT_STANDALONE_KINDS` to materials-only fails it.
- `test_schema_model_parity.test_every_nested_component_property_is_reachable` opens every closed object schema to depth 3, 1122 nested properties exercised. Removing either new model field fails it.
- `test_validation_semantic.test_every_emitter_property_table_is_registered` fails if a `_<holder>_PROPERTY_TERMS` table is not in the registry.
- Named regression tests for each finding: `test_electrode_design_values_do_not_warn`, `test_the_electrode_layer_is_in_the_deposit_graph`, `test_electrode_nodes_carry_their_full_emission`, `test_both_electrode_spec_seams_are_authorable_and_round_trip`, `test_inline_current_collector_cites_its_foil_material_spec`.

Checked end to end against the real corpus (323 records from `data/flores-ocv-halfcells`):

| | before | after |
|---|---|---|
| semantic warnings | 3 | 0 |
| record types in the deposit graph | 6 of 8 | 8 of 8 |
| deposit graph nodes | 301 | 325 |
| publication-validation issues | 96 warnings, 95 errors | unchanged |

The remaining publication findings are the already-tracked G7 (`dataset` `about` dropped by the graph builder); the 24 new electrode nodes add none.
