### PR TITLE
Parameter sets emit JSON-LD and join the deposit graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Parameter sets emit JSON-LD and reach the deposit graph.** The exemption #347
+  recorded is repaid: a parameter-set record now emits as one `schema:Dataset`
+  node whose claims hang off the claim batch, not the target — asserting Chen
+  2020's diffusivity directly onto graphite would collapse "this source claims
+  X" into "X", which is the epistemic distinction the claim model exists to
+  keep. The target rides `schema:about` (a `material_kind` types itself from the
+  curated vocabulary and identifies as its chemical-substance class IRI, exactly
+  like a material node; spec targets stay plain references so the described node
+  lives in its own record). Scalar claims go through the same EMMO quantity
+  emitter every component uses (`hasProperty` with real units and the labeled
+  fallback for terms EMMO lacks); curve and expression claims ride
+  `schema:variableMeasured` as PropertyValues — the expression string is carried
+  verbatim, a curve is described (points, x-quantity, hysteresis branch) without
+  restating the table the record file beside it already ships. Per-claim
+  provenance class, method, and citation overrides survive onto each claim node;
+  the record-level citation rides the dataset node. `record_to_jsonld` accepts
+  `"parameter-set"`, and the kind moved from `DEPOSIT_COVERAGE_EXEMPT` to
+  `DEPOSIT_STANDALONE_KINDS`, so published parameter sets are described nodes in
+  every deposit rather than files a reader must open blind.
+
 - **Parameter claims: the `parameter-set` record type.** Simulation parameters now
   have a home as *claims*: one record = one source (paper, BPX file, lab fit) making
   claims about one target — a curated `material_kind` ("graphite", "nmc811"), a

--- a/src/battinfo/jsonld.py
+++ b/src/battinfo/jsonld.py
@@ -1070,6 +1070,22 @@ def _material_to_jsonld(record: dict) -> dict:
     return {"@context": doc.get("@context"), **node}
 
 
+def _parameter_set_to_jsonld(record: dict) -> dict:
+    """Transform a parameter-set record (claim batch) to JSON-LD.
+
+    Same delegation as materials: the domain-battery emitter builds the
+    schema:Dataset claim node (scalar claims as EMMO-typed hasProperty
+    quantities, curves/expressions under schema:variableMeasured, the target
+    on schema:about).
+    """
+    from battinfo.transform.json_to_jsonld import to_jsonld
+
+    doc = to_jsonld(record, target="domain-battery")
+    graph = doc.get("@graph") or []
+    node = dict(graph[0]) if graph else {}
+    return {"@context": doc.get("@context"), **node}
+
+
 # Same delegation for component spec/instance records (electrode, separator, …).
 _component_to_jsonld = _material_to_jsonld
 
@@ -1105,6 +1121,8 @@ _TRANSFORMERS = {
     "housing-spec": _component_to_jsonld,
     "housing_spec": _component_to_jsonld,
     "housing":      _component_to_jsonld,
+    "parameter-set": _parameter_set_to_jsonld,
+    "parameter_set": _parameter_set_to_jsonld,
 }
 
 

--- a/src/battinfo/transform/json_to_jsonld.py
+++ b/src/battinfo/transform/json_to_jsonld.py
@@ -2218,6 +2218,173 @@ def _material_node(body: dict[str, Any]) -> dict[str, Any]:
     return node
 
 
+def _parameter_target_node(body: dict[str, Any]) -> dict[str, Any] | None:
+    """The node a parameter set's claims are about (schema:about).
+
+    A material_kind target types itself from the curated vocabulary exactly the
+    way a material node does (kind -> EMMO class, chemsub IRI as the node
+    identity); spec targets are plain IRI references — the described node lives
+    in the target's own record, so the reference must not restate it.
+    """
+    for field in ("material_spec_id", "cell_spec_id"):
+        if isinstance(body.get(field), str) and body[field]:
+            return {"@id": body[field]}
+    kind = body.get("material_kind")
+    if not isinstance(kind, str) or not kind:
+        return None
+    from battinfo.materials import material_kind
+
+    entry = material_kind(kind) or {}
+    node: dict[str, Any] = {"@type": entry.get("emmo") or "schema:ChemicalSubstance"}
+    if entry.get("chemsub"):
+        node["@id"] = entry["chemsub"]
+    node["schema:name"] = entry.get("label") or kind
+    return node
+
+
+def _parameter_claim_annotations(claim: dict[str, Any]) -> dict[str, Any]:
+    """Per-claim decorations shared by both claim emissions."""
+    out: dict[str, Any] = {}
+    if isinstance(claim.get("method"), str) and claim["method"]:
+        out["schema:measurementTechnique"] = claim["method"]
+    if isinstance(claim.get("provenance_class"), str) and claim["provenance_class"]:
+        out["schema:additionalProperty"] = {
+            "@type": "schema:PropertyValue",
+            "schema:name": "provenance_class",
+            "schema:value": claim["provenance_class"],
+        }
+    citation_url = _citation_url_value(claim)
+    if citation_url is not None:
+        citation: dict[str, Any] = {"@id": citation_url, "@type": "schema:CreativeWork"}
+        doi = _citation_doi_value(claim)
+        if doi is not None:
+            citation["bibo:doi"] = doi
+        out["schema:citation"] = citation
+    return out
+
+
+def _parameter_claim_variable_node(claim: dict[str, Any]) -> dict[str, Any] | None:
+    """A curve or expression claim as a schema:PropertyValue.
+
+    The graph carries the claim's identity, shape, and provenance; the full
+    x/y table (or expression string, which IS carried — it is one line) lives
+    in the record file that ships beside the graph in every deposit. Restating
+    a 100-point OCP table inside the publication graph would bloat every
+    deposit for consumers that need the record file anyway.
+    """
+    parameter = claim.get("parameter")
+    if not isinstance(parameter, str) or not parameter:
+        return None
+    node: dict[str, Any] = {"@type": "schema:PropertyValue", "schema:name": parameter}
+    curve = claim.get("curve")
+    expression = claim.get("expression")
+    if isinstance(curve, dict):
+        xs = curve.get("x") if isinstance(curve.get("x"), list) else []
+        parts = [f"tabulated curve vs {curve.get('x_quantity', 'x')}", f"{len(xs)} points"]
+        if isinstance(curve.get("branch"), str):
+            parts.append(f"{curve['branch']} branch")
+        node["schema:description"] = ", ".join(parts)
+        if isinstance(curve.get("y_unit"), str):
+            node["schema:unitText"] = curve["y_unit"]
+    elif isinstance(expression, dict):
+        if isinstance(expression.get("text"), str):
+            node["schema:value"] = expression["text"]
+        language = expression.get("language")
+        node["schema:description"] = (
+            f"expression ({language})" if isinstance(language, str) else "expression"
+        )
+    else:
+        return None
+    node.update(_parameter_claim_annotations(claim))
+    return node
+
+
+def _to_domain_battery_jsonld_parameter_set(data: dict[str, Any]) -> dict[str, Any]:
+    """Emit a parameter-set record as one schema:Dataset node.
+
+    The node is the claim batch, not the target: claims are what one source
+    says, so they hang off the parameter-set node (scalar claims as EMMO-typed
+    ``hasProperty`` quantities through the same emitter every component uses;
+    curves/expressions as schema:PropertyValue under schema:variableMeasured),
+    and the target rides ``schema:about``. Asserting the values directly onto
+    the target node would collapse "Chen 2020 claims D=3.3e-14" into
+    "D=3.3e-14", which is exactly the epistemic distinction the claim model
+    exists to keep.
+    """
+    body = data.get("parameter_set") if isinstance(data.get("parameter_set"), dict) else {}
+    node: dict[str, Any] = {}
+    if isinstance(body.get("id"), str):
+        node["@id"] = body["id"]
+    node["@type"] = "schema:Dataset"
+    if isinstance(body.get("name"), str) and body["name"]:
+        node["schema:name"] = body["name"]
+    if isinstance(body.get("description"), str) and body["description"]:
+        node["schema:description"] = body["description"]
+    about = _parameter_target_node(body)
+    if about is not None:
+        node["schema:about"] = about
+
+    scope_values = [
+        {"@type": "schema:PropertyValue", "schema:name": key, "schema:value": body[key]}
+        for key in ("scope", "electrode_polarity")
+        if isinstance(body.get(key), str) and body[key]
+    ]
+    model_context = body.get("model_context")
+    if isinstance(model_context, dict):
+        scope_values.extend(
+            {"@type": "schema:PropertyValue", "schema:name": f"source_{key}", "schema:value": value}
+            for key, value in sorted(model_context.items())
+            if isinstance(value, str) and value
+        )
+    if scope_values:
+        node["schema:additionalProperty"] = (
+            scope_values[0] if len(scope_values) == 1 else scope_values
+        )
+
+    property_nodes: list[dict[str, Any]] = []
+    variable_nodes: list[dict[str, Any]] = []
+    for claim in body.get("claims") or []:
+        if not isinstance(claim, dict):
+            continue
+        quantity = claim.get("quantity")
+        if isinstance(quantity, dict) and isinstance(claim.get("parameter"), str):
+            for emitted in _descriptor_property_nodes({claim["parameter"]: quantity}):
+                emitted.update(_parameter_claim_annotations(claim))
+                property_nodes.append(emitted)
+            continue
+        variable = _parameter_claim_variable_node(claim)
+        if variable is not None:
+            variable_nodes.append(variable)
+    if property_nodes:
+        node["hasProperty"] = property_nodes[0] if len(property_nodes) == 1 else property_nodes
+    if variable_nodes:
+        node["schema:variableMeasured"] = (
+            variable_nodes[0] if len(variable_nodes) == 1 else variable_nodes
+        )
+
+    citation = _citation_to_jsonld(data.get("provenance"))
+    if citation is not None:
+        node["schema:citation"] = citation
+    notes = [n for n in (data.get("notes") or []) if isinstance(n, str) and n.strip()]
+    if notes:
+        node["schema:comment"] = notes[0] if len(notes) == 1 else notes
+    return {
+        "@context": _base_context(
+            include_battinfo=True,
+            include_has_battery=False,
+            include_has_measurement=False,
+            include_has_property=True,
+            include_bibo=_citation_doi_value(data.get("provenance")) is not None
+            or any(
+                _citation_doi_value(c) is not None
+                for c in (body.get("claims") or [])
+                if isinstance(c, dict)
+            ),
+        ),
+        "@graph": [node],
+    }
+
+
 def _to_domain_battery_jsonld_material(data: dict[str, Any]) -> dict[str, Any]:
     body = data.get("material_spec") if isinstance(data.get("material_spec"), dict) else data.get("material")
     node = _material_node(body if isinstance(body, dict) else {})
@@ -2436,6 +2603,8 @@ def _to_domain_battery_jsonld_component(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _to_domain_battery_jsonld(data: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(data.get("parameter_set"), dict):
+        return _to_domain_battery_jsonld_parameter_set(data)
     if isinstance(data.get("material_spec"), dict) or isinstance(data.get("material"), dict):
         return _to_domain_battery_jsonld_material(data)
     # A first-class electrode record. Checked before the cell-spec branch would

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -838,6 +838,7 @@ DEPOSIT_STANDALONE_KINDS: tuple[str, ...] = (
     "material",
     "electrode-spec",
     "electrode",
+    "parameter-set",
 )
 
 # entity_type -> why a record of that type is not a described node in the deposit
@@ -849,11 +850,6 @@ DEPOSIT_COVERAGE_EXEMPT: dict[str, str] = {
         "on (built from the test's equipment_id), not the product line, so a "
         "spec with no test attached has nothing to attach to. G11 tracks the "
         "wider equipment-family publication gap"
-    ),
-    "parameter-set": (
-        "claim batches save/validate/collate but have no JSON-LD emitter yet; "
-        "promoting them to standalone deposit nodes (EMMO-typed claims) is the "
-        "parameter-campaign Phase 2 follow-up"
     ),
     **{
         entity_type: (

--- a/tests/test_parameter_contract.py
+++ b/tests/test_parameter_contract.py
@@ -16,6 +16,7 @@ Design rules under test:
 """
 from __future__ import annotations
 
+import json
 import re
 
 import pytest
@@ -447,6 +448,90 @@ def test_bpx_reimport_is_idempotent() -> None:
     second = {r["parameter_set"]["name"]: r["parameter_set"]["id"]
               for r in import_bpx_parameters(_bpx(), **kwargs)}
     assert first == second
+
+
+# ── JSON-LD emission ─────────────────────────────────────────────────────────
+
+
+def _emitted(record=None) -> dict:
+    from battinfo.jsonld import record_to_jsonld
+
+    return record_to_jsonld(record or _record(), "parameter-set")
+
+
+def test_jsonld_node_is_a_dataset_about_the_kind() -> None:
+    node = _emitted()
+    assert node["@id"] == _record()["parameter_set"]["id"]
+    assert node["@type"] == "schema:Dataset"
+    about = node["schema:about"]
+    # kind target types itself from the curated vocabulary and identifies as
+    # the chemical-substance class IRI, like a material node does
+    assert about["@type"] == "Graphite"
+    assert about["@id"].startswith("https://w3id.org/emmo/domain/chemical-substance#")
+
+
+def test_jsonld_spec_target_is_a_plain_reference() -> None:
+    record = _record(material_kind=None, material_spec_id=MATERIAL_SPEC_IRI)
+    node = _emitted(record)
+    assert node["schema:about"] == {"@id": MATERIAL_SPEC_IRI}
+
+
+def test_jsonld_scalar_claims_are_emmo_quantities_with_provenance() -> None:
+    node = _emitted()
+    props = node["hasProperty"]
+    props = props if isinstance(props, list) else [props]
+    radius = next(p for p in props if "particleRadius" in str(p.get("@type")))
+    assert radius["hasNumericalPart"]["hasNumberValue"] == 5.86e-06
+    annotation = radius["schema:additionalProperty"]
+    assert annotation["schema:name"] == "provenance_class"
+    assert annotation["schema:value"] == "fitted"
+
+
+def test_jsonld_curve_claims_describe_without_restating_the_table() -> None:
+    node = _emitted()
+    variables = node["schema:variableMeasured"]
+    variables = variables if isinstance(variables, list) else [variables]
+    ocp = next(v for v in variables if v["schema:name"] == "ocp")
+    assert "3 points" in ocp["schema:description"]
+    assert ocp["schema:measurementTechnique"] == "GITT"
+    # the graph describes the curve; the table itself stays in the record file
+    assert "[0.0" not in json.dumps(ocp)
+    assert "schema:value" not in ocp
+
+
+def test_jsonld_expression_claims_carry_the_expression() -> None:
+    node = _emitted()
+    variables = node["schema:variableMeasured"]
+    variables = variables if isinstance(variables, list) else [variables]
+    diffusivity = next(v for v in variables if v["schema:name"] == "solid_diffusivity")
+    assert diffusivity["schema:value"] == "3.3e-14 * x"
+    assert "bpx" in diffusivity["schema:description"]
+
+
+def test_jsonld_claim_citation_overrides_ride_the_claim_node() -> None:
+    record = _record(claims=[{
+        "parameter": "density",
+        "quantity": {"value": 2.26, "unit": "g/cm3"},
+        "provenance_class": "literature",
+        "citation_doi": "10.1039/D0SE00175A",
+    }])
+    node = _emitted(record)
+    prop = node["hasProperty"]
+    prop = prop[0] if isinstance(prop, list) else prop
+    assert prop["schema:citation"]["bibo:doi"] == "10.1039/D0SE00175A"
+    # record-level citation still rides the dataset node
+    assert node["schema:citation"]["bibo:doi"] == "10.1149/1945-7111/ab9050"
+
+
+def test_jsonld_source_context_is_readable() -> None:
+    record = _record(model_context={"tool": "BPX", "name": "Chen2020"})
+    node = _emitted(record)
+    extras = node["schema:additionalProperty"]
+    extras = extras if isinstance(extras, list) else [extras]
+    by_name = {e["schema:name"]: e["schema:value"] for e in extras}
+    assert by_name["source_tool"] == "BPX"
+    assert by_name["source_name"] == "Chen2020"
+    assert by_name["scope"] == "material"
 
 
 # ── workspace integration ────────────────────────────────────────────────────


### PR DESCRIPTION
## What

The JSON-LD emitter for `parameter-set` records, and their promotion from `DEPOSIT_COVERAGE_EXEMPT` to `DEPOSIT_STANDALONE_KINDS`. Repays the exemption #347 recorded.

## Why

Parameter claims that save and collate but never reach a deposit's publication graph would be files a reader must open blind. With the emitter, a published parameter set is a described node: findable by target, citable per claim, and typed with the same EMMO machinery the rest of the corpus uses. This unblocks the content-ingest phase (literature_ocv, About:Energy BPX sets).

## How

- One `schema:Dataset` node per record. Claims hang off the claim batch, not the target: asserting Chen 2020's diffusivity directly onto graphite would collapse 'this source claims X' into 'X', the distinction the claim model exists to keep.
- `schema:about` carries the target. A `material_kind` types itself from the curated vocabulary and identifies as its chemical-substance class IRI (same anchoring as a material node); spec targets stay plain IRI references since the described node lives in its own record.
- Scalar claims go through the shared EMMO quantity emitter (`hasProperty`, real units, labeled `battinfo:/` fallback where EMMO lacks a term). Per-claim provenance class, method, and citation overrides decorate each claim node; the record-level citation rides the dataset node.
- Curves/expressions ride `schema:variableMeasured` as PropertyValues. Expressions are carried verbatim; curves are described (point count, x-quantity, hysteresis branch) without restating the table the record file beside the graph already ships.
- `record_to_jsonld` accepts `"parameter-set"`; scope, polarity, and BPX source context emit as readable `additionalProperty` values.

## Testing

7 new emission contract tests in `tests/test_parameter_contract.py` (dataset node shape, kind vs spec targets, EMMO quantities with provenance, curve-not-restated, expression carried, per-claim citation override, source context). Deposit-coverage sweep now requires the node in the graph (exemption removed). Full suite: 1958 passed, 3 skipped; ruff + mypy clean.