### PR TITLE
theoretical_specific_capacity joins the parameter vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`theoretical_specific_capacity` joins the parameter vocabulary.** The curated
+  material-kind reference anchors (graphite 372 mAh/g, silicon 3579, lithium
+  metal 3862, LFP 170) are theoretical stoichiometric capacities, while
+  `specific_capacity` is defined as the practical reversible value a design
+  tool may trust. They get their own key so the anchors can be published as
+  claims without a theoretical value ever satisfying a model tier's
+  practical-capacity requirement. No tier contract changes.
+
 - **Parameter sets emit JSON-LD and reach the deposit graph.** The exemption #347
   recorded is repaid: a parameter-set record now emits as one `schema:Dataset`
   node whose claims hang off the claim batch, not the target — asserting Chen

--- a/src/battinfo/data/vocab/parameters.json
+++ b/src/battinfo/data/vocab/parameters.json
@@ -9,6 +9,13 @@
       "kind": "scalar",
       "description": "Practical (not theoretical) reversible specific capacity of the active material."
     },
+    "theoretical_specific_capacity": {
+      "label": "Theoretical specific capacity",
+      "scopes": ["material"],
+      "unit": "mAh/g",
+      "kind": "scalar",
+      "description": "Theoretical specific capacity from stoichiometry (e.g. LiC6 372 mAh/g). Deliberately a separate key from specific_capacity: theoretical values never satisfy a model tier's practical-capacity requirement, and conflating them would corrupt design estimates."
+    },
     "density": {
       "label": "True density",
       "scopes": ["material"],


### PR DESCRIPTION
## What

One new canonical parameter key, `theoretical_specific_capacity` (material scope, mAh/g), plus a CHANGELOG entry. No tier contract changes.

## Why

The material-kinds vocabulary carries curated reference anchors (graphite 372 mAh/g, silicon 3579, lithium metal 3862, LFP 170) that are theoretical stoichiometric capacities, while `specific_capacity` is defined as the practical reversible value the design tools trust. Publishing the anchors as claims under the practical key would be a false claim and would corrupt BotE resolution (practical graphite is ~344-355, not 372). A separate key keeps the definitions clean: theoretical values never satisfy a tier's practical-capacity requirement.

The immediate consumer is the reference-anchor ingest in battinfo-records (follow-up PR), which turns these curated values into claim records with their citations.

## Testing

44 parameter contract tests pass (the vocabulary invariants sweep covers the new entry: declared scope, no undeclared tier references); ruff clean.