### PR TITLE
Dataset-series (collection) support

### DIFF
--- a/assets/schemas/dataset.schema.json
+++ b/assets/schemas/dataset.schema.json
@@ -216,6 +216,9 @@
           },
           "uniqueItems": true
         },
+        "series_id": {
+          "$ref": "#/$defs/DatasetIri"
+        },
         "included_in_data_catalog": {
           "anyOf": [
             {

--- a/assets/vocab/battinfo-records.ttl
+++ b/assets/vocab/battinfo-records.ttl
@@ -17,6 +17,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix battery: <https://w3id.org/emmo/domain/battery#> .
 @prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix electrochemistry: <https://w3id.org/emmo/domain/electrochemistry#> .
 @prefix emmo: <https://w3id.org/emmo#> .
 @prefix pav: <http://purl.org/pav/> .
@@ -314,6 +315,11 @@ ns:CellSpecification a owl:Class ;
     rdfs:label "Cell Specification"@en ;
     owl:equivalentClass ns:CellSpec ;
     rdfs:seeAlso battery:battery_1cfbba6c_8824_4932_a23e_2141483acef7 ;
+    rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .
+
+ns:DatasetSeries a rdf:Property ;
+    rdfs:label "Dataset Series"@en ;
+    rdfs:seeAlso dcat:DatasetSeries ;
     rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .
 
 ns:MWh a rdf:Property ;
@@ -741,6 +747,11 @@ ns:impedanceUnit a rdf:Property ;
     rdfs:label "Impedance Unit"@en ;
     rdfs:comment "Measurement unit of impedance."@en ;
     owl:equivalentProperty ns:impedance_unit ;
+    rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .
+
+ns:inSeries a rdf:Property ;
+    rdfs:label "In Series"@en ;
+    rdfs:seeAlso dcat:inSeries ;
     rdfs:isDefinedBy <https://w3id.org/battinfo/ns> .
 
 ns:initial_coulombic_efficiency a rdf:Property ;

--- a/scripts/assemble_context.py
+++ b/scripts/assemble_context.py
@@ -202,6 +202,17 @@ TYPED_TERMS: dict[str, object] = {
     # / schema:expires values (xsd:gYearMonth), so no extra aliases are declared here.
 }
 
+# ── DCAT dataset-series terms ─────────────────────────────────────────────────
+# A collection-level record is an ordinary dataset flavored as a series
+# (additional_type = "DatasetSeries"); membership is the series_id edge. These
+# cannot come from slot_uri extraction because assemble_context drops the ds_*
+# slot names, so the series vocabulary is curated here like the other
+# non-schema-sourced terms.
+DCAT_SERIES_TERMS: dict[str, object] = {
+    "DatasetSeries": "dcat:DatasetSeries",
+    "inSeries":      {"@id": "dcat:inSeries", "@type": "@id"},
+}
+
 # ── Slots whose value is an IRI reference, not a literal ──────────────────────
 # The IRI these expand to lives in the schema (slot_uri); only the JSON-LD typing
 # is declared here, because @type is a serialization concern LinkML has no slot
@@ -318,6 +329,7 @@ def build_context(schema_dir: Path) -> dict:
     ctx.update(keep)
     ctx.update(UNIT_SYMBOLS)
     ctx.update(TYPED_TERMS)
+    ctx.update(DCAT_SERIES_TERMS)
 
     # Guard: a term key in the form of an IRI (contains "/" or ":") must expand to
     # its own definition under JSON-LD 1.1, otherwise a strict processor rejects the

--- a/src/battinfo/_util.py
+++ b/src/battinfo/_util.py
@@ -55,6 +55,20 @@ def _now_unix() -> int:
     return int(datetime.now(timezone.utc).timestamp())
 
 
+def is_dataset_series(additional_type: object) -> bool:
+    """True when a dataset's ``additional_type`` marks it as a dcat:DatasetSeries.
+
+    The marker is the exact string ``"DatasetSeries"`` (DCAT 3 declares
+    dcat:DatasetSeries a subclass of dcat:Dataset, so a series is an ordinary
+    dataset record flavored by this value — not a separate record type).
+    """
+    if isinstance(additional_type, str):
+        return additional_type == "DatasetSeries"
+    if isinstance(additional_type, (list, tuple)):
+        return any(item == "DatasetSeries" for item in additional_type)
+    return False
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:

--- a/src/battinfo/api/_resolver.py
+++ b/src/battinfo/api/_resolver.py
@@ -14,7 +14,7 @@ from typing import Any, Mapping, Sequence
 from battinfo._emmo_instruments import _instrument_node
 from battinfo._jsonio import read_record_json as _load_json
 from battinfo._jsonio import write_json as _write_json
-from battinfo._util import _as_path
+from battinfo._util import _as_path, is_dataset_series
 from battinfo.api._shared import (
     CELL_IRI_RE,
     DEFAULT_PUBLISH_SOURCES,
@@ -469,7 +469,11 @@ def _resolver_jsonld(doc: dict[str, Any]) -> dict[str, Any]:
         out = {
             "@context": context,
             "@id": entity_iri,
-            "@type": "schema:Dataset",
+            "@type": (
+                ["schema:Dataset", "dcat:DatasetSeries"]
+                if is_dataset_series(dataset.get("additional_type"))
+                else "schema:Dataset"
+            ),
             "schema:identifier": _schema_identifier_value(dataset.get("identifier"), uid),
             "schema:name": dataset.get("name") or dataset.get("title"),
             "schema:description": dataset.get("description"),
@@ -554,6 +558,9 @@ def _resolver_jsonld(doc: dict[str, Any]) -> dict[str, Any]:
             refs = [{"@id": item} for item in dataset["is_based_on"] if isinstance(item, str)]
             if refs:
                 out["schema:isBasedOn"] = refs
+        if isinstance(dataset.get("series_id"), str) and dataset["series_id"]:
+            out["dcat:inSeries"] = {"@id": dataset["series_id"]}
+            out["schema:isPartOf"] = {"@id": dataset["series_id"]}
         included_in_data_catalog = dataset.get("included_in_data_catalog")
         included_in_data_catalog_value = _schema_data_catalog_value(included_in_data_catalog)
         if included_in_data_catalog_value is not None:

--- a/src/battinfo/bundle.py
+++ b/src/battinfo/bundle.py
@@ -2654,6 +2654,7 @@ class Dataset(BundleJsonModel):
     temporal_coverage: str | None = Field(default=None, validation_alias=AliasChoices("temporal_coverage", "temporalCoverage"), description="Time interval the data covers (ISO 8601 interval, e.g. '2026-01-01/2026-01-31').")
     spatial_coverage: str | None = Field(default=None, validation_alias=AliasChoices("spatial_coverage", "spatialCoverage"), description="Place the data was collected (free text).")
     is_based_on: _StrList = Field(default_factory=list, validation_alias=AliasChoices("is_based_on", "isBasedOn"), description="URLs of resources this dataset derives from (e.g. a protocol).")
+    series_id: str | None = Field(default=None, validation_alias=AliasChoices("series_id", "seriesId"), description="Canonical IRI of the dataset series (dcat:DatasetSeries record) this dataset belongs to.")
     included_in_data_catalog: str | dict[str, Any] | None = Field(default=None, validation_alias=AliasChoices("included_in_data_catalog", "includedInDataCatalog"), description="Catalog this dataset is listed in (URL or DataCatalog object).")
     main_entity: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("main_entity", "mainEntity"), description="Primary content entities (e.g. a CSVW Table with its tableSchema).")
     distributions: list[dict[str, Any]] = Field(default_factory=list, validation_alias=AliasChoices("distributions", "distribution"), description="DataDownload entries (content_url, encoding_format, checksum); synthesized from download_url/data_format/checksum when omitted.")
@@ -2926,6 +2927,7 @@ class Dataset(BundleJsonModel):
             temporal_coverage=dataset.get("temporal_coverage"),
             spatial_coverage=dataset.get("spatial_coverage"),
             is_based_on=_string_list(dataset.get("is_based_on")),
+            series_id=dataset.get("series_id") if isinstance(dataset.get("series_id"), str) else None,
             included_in_data_catalog=_canonical_data_catalog(dataset.get("included_in_data_catalog")),
             main_entity=[entity for item in _mapping_list(dataset.get("main_entity")) if (entity := _canonical_main_entity(item)) is not None],
             distributions=[dist for item in _mapping_list(distribution) if (dist := _canonical_distribution(item)) is not None],
@@ -3018,6 +3020,8 @@ class Dataset(BundleJsonModel):
             dataset_obj["about"] = about
         if self.is_based_on:
             dataset_obj["is_based_on"] = list(self.is_based_on)
+        if self.series_id is not None:
+            dataset_obj["series_id"] = self.series_id
         if self.included_in_data_catalog is not None:
             dataset_obj["included_in_data_catalog"] = self.included_in_data_catalog
         if self.main_entity:
@@ -3391,6 +3395,7 @@ class BattinfoBundle(BundleJsonModel):
             temporal_coverage=dataset_node.get("schema:temporalCoverage"),
             spatial_coverage=dataset_node.get("schema:spatialCoverage"),
             is_based_on=_ref_ids(dataset_node.get("schema:isBasedOn")) or _text_list(dataset_node.get("schema:isBasedOn")),
+            series_id=_ref_id(dataset_node.get("dcat:inSeries")) or _ref_id(dataset_node.get("schema:isPartOf")),
             included_in_data_catalog=_canonical_data_catalog(
                 _ref_id(dataset_node.get("schema:includedInDataCatalog"))
                 or (

--- a/src/battinfo/canonical_aliases.py
+++ b/src/battinfo/canonical_aliases.py
@@ -38,6 +38,7 @@ _DATASET_TO_SNAKE = {
     "temporalCoverage": "temporal_coverage",
     "spatialCoverage": "spatial_coverage",
     "isBasedOn": "is_based_on",
+    "seriesId": "series_id",
     "includedInDataCatalog": "included_in_data_catalog",
     "mainEntity": "main_entity",
     "distribution": "distributions",

--- a/src/battinfo/data/context/records.context.json
+++ b/src/battinfo/data/context/records.context.json
@@ -181,6 +181,11 @@
     "modified_at": {
       "@id": "dcterms:modified",
       "@type": "xsd:dateTime"
+    },
+    "DatasetSeries": "dcat:DatasetSeries",
+    "inSeries": {
+      "@id": "dcat:inSeries",
+      "@type": "@id"
     }
   }
 }

--- a/src/battinfo/data/context/records.context.v1.json
+++ b/src/battinfo/data/context/records.context.v1.json
@@ -519,6 +519,11 @@
     },
     "WorkingElectrode": "electrochemistry:electrochemistry_fb988878_ee54_4350_9ee9_228c00c3ad35",
     "CounterElectrode": "electrochemistry:electrochemistry_871bc4a4_2d17_4b88_9b0f_7ab85f14afea",
-    "ReferenceElectrode": "electrochemistry:electrochemistry_7729c34e_1ae9_403d_b933_1765885e7f29"
+    "ReferenceElectrode": "electrochemistry:electrochemistry_7729c34e_1ae9_403d_b933_1765885e7f29",
+    "DatasetSeries": "dcat:DatasetSeries",
+    "inSeries": {
+      "@id": "dcat:inSeries",
+      "@type": "@id"
+    }
   }
 }

--- a/src/battinfo/data/schemas/dataset.schema.json
+++ b/src/battinfo/data/schemas/dataset.schema.json
@@ -216,6 +216,9 @@
           },
           "uniqueItems": true
         },
+        "series_id": {
+          "$ref": "#/$defs/DatasetIri"
+        },
         "included_in_data_catalog": {
           "anyOf": [
             {

--- a/src/battinfo/jsonld.py
+++ b/src/battinfo/jsonld.py
@@ -23,6 +23,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable
 
+from battinfo._util import is_dataset_series
+
 _DATA = Path(__file__).parent / "data"
 _CONTEXT_PATH = _DATA / "context" / "records.context.json"
 _CONTEXT_URL  = "https://w3id.org/battinfo/context/records/v1.json"
@@ -921,6 +923,26 @@ def dataset_to_jsonld(record: dict) -> dict:
         "@id":      ds.get("id", ""),
         "dcterms:title": ds.get("name"),
     }
+    if is_dataset_series(ds.get("additional_type")):
+        node["@type"] = [
+            "http://www.w3.org/ns/dcat#Dataset",
+            "http://www.w3.org/ns/dcat#DatasetSeries",
+        ]
+    if ds.get("series_id"):
+        # Twinned like the rest of the emitter: dcat:inSeries is the DCAT 3
+        # membership edge, schema:isPartOf is what dataset search engines read.
+        node["dcat:inSeries"] = {"@id": ds["series_id"]}
+        node["schema:isPartOf"] = {"@id": ds["series_id"]}
+    catalog = ds.get("included_in_data_catalog")
+    if isinstance(catalog, str) and catalog:
+        node["schema:includedInDataCatalog"] = {"@id": catalog} if "://" in catalog else catalog
+    elif isinstance(catalog, Mapping) and isinstance(catalog.get("name"), str):
+        catalog_node: dict = {"@type": "schema:DataCatalog", "schema:name": catalog["name"]}
+        if isinstance(catalog.get("id"), str):
+            catalog_node["@id"] = catalog["id"]
+        if isinstance(catalog.get("url"), str):
+            catalog_node["schema:url"] = catalog["url"]
+        node["schema:includedInDataCatalog"] = catalog_node
     if ds.get("description"):
         node["dcterms:description"] = ds["description"]
         node["schema:description"] = ds["description"]

--- a/src/battinfo/publication.py
+++ b/src/battinfo/publication.py
@@ -15,7 +15,7 @@ from urllib.parse import unquote, urlparse
 from battinfo._emmo_instruments import _instrument_node
 from battinfo._jsonio import read_record_json as _load_json
 from battinfo._jsonio import write_json as _write_json
-from battinfo._util import _as_path, _citation_doi_from_url, _now_iso, _now_unix, _sha256
+from battinfo._util import _as_path, _citation_doi_from_url, _now_iso, _now_unix, _sha256, is_dataset_series
 from battinfo.bundle import (
     ZENODO_CELL_RECORD_FILENAME,
     BattinfoBundle,
@@ -999,9 +999,12 @@ def _dataset_jsonld_node(
     url_override: str | None = None,
 ) -> dict[str, Any]:
     about_refs = [{"@id": cell_id}, {"@id": test_id}]
+    node_types = ["BatteryTestResult", "schema:Dataset"]
+    if is_dataset_series(dataset.additional_type):
+        node_types.append("dcat:DatasetSeries")
     node: dict[str, Any] = {
         "@id": dataset.id,
-        "@type": ["BatteryTestResult", "schema:Dataset"],
+        "@type": node_types,
         "schema:identifier": _schema_identifier_value(dataset.identifier),
         "schema:name": dataset.name,
         "schema:description": dataset.description,
@@ -1061,6 +1064,9 @@ def _dataset_jsonld_node(
         node["schema:spatialCoverage"] = dataset.spatial_coverage
     if dataset.is_based_on:
         node["schema:isBasedOn"] = list(dataset.is_based_on)
+    if dataset.series_id is not None:
+        node["dcat:inSeries"] = {"@id": dataset.series_id}
+        node["schema:isPartOf"] = {"@id": dataset.series_id}
     if dataset.included_in_data_catalog is not None:
         included_in_data_catalog = _schema_data_catalog_node(dataset.included_in_data_catalog)
         if included_in_data_catalog is not None:

--- a/tests/test_dataset_series.py
+++ b/tests/test_dataset_series.py
@@ -1,0 +1,145 @@
+"""DCAT dataset-series support: a collection is an ordinary dataset record
+flavored as a series (additional_type = "DatasetSeries"), membership is the
+series_id edge. No new record type; DCAT 3 declares dcat:DatasetSeries a
+subclass of dcat:Dataset."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.api._resolver import _resolver_jsonld  # noqa: E402
+from battinfo.bundle import Dataset, ProvenanceInfo  # noqa: E402
+from battinfo.jsonld import dataset_to_jsonld  # noqa: E402
+from battinfo.publication import _dataset_jsonld_node  # noqa: E402
+from battinfo.validate.record import validate_record_report  # noqa: E402
+
+SERIES_IRI = "https://w3id.org/battinfo/dataset/aaaa-bbbb-cccc-dddd"
+MEMBER_IRI = "https://w3id.org/battinfo/dataset/aaaa-bbbb-cccc-ffff"
+CELL_IRI = "https://w3id.org/battinfo/cell/aaaa-bbbb-cccc-eeee"
+TEST_IRI = "https://w3id.org/battinfo/test/aaaa-bbbb-cccc-gggg"
+CONTEXT_DIR = ROOT / "src" / "battinfo" / "data" / "context"
+
+_PROVENANCE = ProvenanceInfo(
+    type="catalog",
+    url="https://doi.org/10.5281/zenodo.20086298",
+    retrieved_at=1755648000,
+)
+
+
+def _series() -> Dataset:
+    return Dataset(
+        id=SERIES_IRI,
+        name="Half-cell OCV collection",
+        access_url="https://doi.org/10.5281/zenodo.20086298",
+        additional_type=["DatasetSeries"],
+        cell_instance_id=CELL_IRI,
+        source=_PROVENANCE,
+    )
+
+
+def _member() -> Dataset:
+    return Dataset(
+        id=MEMBER_IRI,
+        name="Half-cell OCV, cell 1",
+        access_url="https://example.org/datasets/member",
+        series_id=SERIES_IRI,
+        cell_instance_id=CELL_IRI,
+        source=_PROVENANCE,
+    )
+
+
+def test_series_id_round_trips_through_the_record() -> None:
+    record = _member().to_record()
+    assert record["dataset"]["series_id"] == SERIES_IRI
+    assert Dataset.from_record(record).series_id == SERIES_IRI
+
+
+def test_series_flavor_round_trips_through_the_record() -> None:
+    record = _series().to_record()
+    assert record["dataset"]["additional_type"] == ["DatasetSeries"]
+    loaded = Dataset.from_record(record)
+    assert loaded.additional_type == ["DatasetSeries"]
+    assert loaded.series_id is None
+
+
+def test_member_emits_both_membership_edges() -> None:
+    doc = dataset_to_jsonld(_member().to_record())
+    assert doc["dcat:inSeries"] == {"@id": SERIES_IRI}
+    assert doc["schema:isPartOf"] == {"@id": SERIES_IRI}
+    assert doc["@type"] == "http://www.w3.org/ns/dcat#Dataset"
+
+
+def test_series_carries_the_dataset_series_type() -> None:
+    doc = dataset_to_jsonld(_series().to_record())
+    assert doc["@type"] == [
+        "http://www.w3.org/ns/dcat#Dataset",
+        "http://www.w3.org/ns/dcat#DatasetSeries",
+    ]
+    assert "dcat:inSeries" not in doc
+
+
+def test_series_and_member_validate_clean_in_strict_mode() -> None:
+    for dataset in (_series(), _member()):
+        report = validate_record_report(dataset.to_record(), policy="strict")
+        assert not report.issues, [issue.message for issue in report.issues]
+
+
+def test_schema_rejects_a_non_dataset_series_iri() -> None:
+    record = _member().to_record()
+    record["dataset"]["series_id"] = "https://example.org/not-a-dataset-iri"
+    report = validate_record_report(record, policy="strict")
+    assert any(issue.path.endswith("series_id") for issue in report.issues)
+
+
+def test_publication_node_emits_series_edges_and_type(tmp_path: Path) -> None:
+    node = _dataset_jsonld_node(
+        _member(), [], tmp_path, TEST_IRI, CELL_IRI, distribution_entries=[]
+    )
+    assert node["dcat:inSeries"] == {"@id": SERIES_IRI}
+    assert node["schema:isPartOf"] == {"@id": SERIES_IRI}
+
+    series_node = _dataset_jsonld_node(
+        _series(), [], tmp_path, TEST_IRI, CELL_IRI, distribution_entries=[]
+    )
+    assert "dcat:DatasetSeries" in series_node["@type"]
+    assert "dcat:inSeries" not in series_node
+
+
+def test_resolver_emits_series_edges_and_type() -> None:
+    member_doc = _resolver_jsonld(_member().to_record())
+    assert member_doc["dcat:inSeries"] == {"@id": SERIES_IRI}
+    assert member_doc["schema:isPartOf"] == {"@id": SERIES_IRI}
+    assert member_doc["@type"] == "schema:Dataset"
+
+    series_doc = _resolver_jsonld(_series().to_record())
+    assert series_doc["@type"] == ["schema:Dataset", "dcat:DatasetSeries"]
+
+
+def test_records_contexts_define_the_series_terms() -> None:
+    for filename in ("records.context.json", "records.context.v1.json"):
+        context = json.loads((CONTEXT_DIR / filename).read_text(encoding="utf-8"))["@context"]
+        assert context["DatasetSeries"] == "dcat:DatasetSeries"
+        assert context["inSeries"] == {"@id": "dcat:inSeries", "@type": "@id"}
+
+
+def test_data_catalog_membership_reaches_the_record_emitter() -> None:
+    member = _member()
+    member.included_in_data_catalog = {
+        "type": "DataCatalog",
+        "id": "https://example.org/catalog",
+        "name": "Example Battery Catalog",
+        "url": "https://example.org/catalog",
+    }
+    doc = dataset_to_jsonld(member.to_record())
+    catalog = doc["schema:includedInDataCatalog"]
+    assert catalog["@id"] == "https://example.org/catalog"
+    assert catalog["schema:name"] == "Example Battery Catalog"
+
+    member.included_in_data_catalog = "https://example.org/catalog"
+    doc = dataset_to_jsonld(member.to_record())
+    assert doc["schema:includedInDataCatalog"] == {"@id": "https://example.org/catalog"}

--- a/web/lib/records-context.generated.ts
+++ b/web/lib/records-context.generated.ts
@@ -525,6 +525,11 @@ export const recordsContext: Record<string, unknown> = {
     },
     "WorkingElectrode": "electrochemistry:electrochemistry_fb988878_ee54_4350_9ee9_228c00c3ad35",
     "CounterElectrode": "electrochemistry:electrochemistry_871bc4a4_2d17_4b88_9b0f_7ab85f14afea",
-    "ReferenceElectrode": "electrochemistry:electrochemistry_7729c34e_1ae9_403d_b933_1765885e7f29"
+    "ReferenceElectrode": "electrochemistry:electrochemistry_7729c34e_1ae9_403d_b933_1765885e7f29",
+    "DatasetSeries": "dcat:DatasetSeries",
+    "inSeries": {
+      "@id": "dcat:inSeries",
+      "@type": "@id"
+    }
   }
 };

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -2729,6 +2729,9 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
               },
               "uniqueItems": true
             },
+            "series_id": {
+              "$ref": "#/$defs/DatasetIri"
+            },
             "included_in_data_catalog": {
               "anyOf": [
                 {


### PR DESCRIPTION
## What

DCAT dataset-series support, Phase 1: a collection-level object (e.g. the Flores 2026 half-cell OCV corpus) is an ordinary dataset record flavored as a series, plus one new membership edge.

- New optional `series_id` field on the dataset record (DatasetIri shape), the canonical IRI of the series the dataset belongs to. The `_id` suffix is deliberate: the registry's generic edge machinery keys on it.
- A record with `additional_type = "DatasetSeries"` is the series itself; no new record type (DCAT 3 declares `dcat:DatasetSeries` a subclass of `dcat:Dataset`).
- All three dataset emitters (`dataset_to_jsonld`, the publication dataset node, the perma-id resolver) emit `series_id` as both `dcat:inSeries` and `schema:isPartOf` IRI nodes, and add `dcat:DatasetSeries` to the `@type` list for series-flavored records.
- Context gains `inSeries` and `DatasetSeries` (both dcat), curated in `assemble_context.py` and regenerated through the pipeline; v1 is append-only and only appended to.

## Why

The Flores half-cell OCV corpus (95 dataset records live on the registry) needs a collection anchor on its Zenodo deposit DOI. Members point at the collection with a forward link the registry can already render as forward + reverse edges.

## How

- `assets/schemas/dataset.schema.json` is the schema source of truth; the packaged copy under `src/battinfo/data/schemas/` is synced from it (the LinkML yaml only feeds context assembly and does not carry the dataset body fields).
- `Dataset.series_id` on the pydantic model with full round-trip: `to_record`/`from_record`, publication-bundle rehydration (reads `dcat:inSeries`, falls back to `schema:isPartOf` on the dataset node), and the `seriesId` camelCase alias in `canonical_aliases.py`.
- The series marker check is one shared helper (`is_dataset_series` in `_util.py`) used by all three emitters.
- Context terms are curated in `assemble_context.py` (the `ds_*` slot names are dropped from slot-uri extraction, so curation is the mechanism for dataset-body vocabulary); `records.context.json` and `records.context.v1.json` regenerated via the scripts.
- `assets/vocab/battinfo-records.ttl` regenerated by running `gen_battinfo_vocab.py` (script untouched). Note for merge ordering with #350: the diff is 11 lines (dcat prefix + `ns:DatasetSeries` + `ns:inSeries`); the current generator types `ns:DatasetSeries` as `rdf:Property`, so #350's ns# sweep rewrite may re-type it. Whichever lands second should just re-run the generator.
- `dataset_to_jsonld` also now emits `schema:includedInDataCatalog`; the field was already emitted by the publication and resolver paths, the canonical record emitter was the gap.
- Web vendored copies (`schemas.generated.ts`, `records-context.generated.ts`) re-synced via their scripts.

## Testing

- New `tests/test_dataset_series.py` (10 tests): record round-trip for member and series, all three emitters (`dcat:inSeries` + `schema:isPartOf` + `DatasetSeries` @type), strict-mode validation with zero issues, schema rejection of a non-dataset IRI in `series_id`, context term presence in both context files, and the includedInDataCatalog emission.
- Full suite: 1963 passed, 3 failed - the same three pre-existing failures on main (`test_convert_drops_corrupt_parquet_cache`, `test_quickstart_recipe_runs_offline`, `test_convert_page_matrix_matches_the_library_guidance`). Zero new failures.
- CI gates run locally: ruff clean, identifier-policy lint pass, `assemble_context.py --check` + `gen_context.py --check` in sync, packaged examples in sync, web `sync:schemas`/`sync:context` --check in sync, `check:agreement`, `check:workbench`, `check:create-model` all pass.

## Merge prerequisite for downstream use

Records carrying `series_id` cannot publish until battinfo-registry re-vendors the updated dataset schema (Phase 2, separate PR there). Phase 3 (corpus v5: the collection record + `series_id` on the 95 datasets, collection published first) and Phase 4 (platform surfaces) follow.