### PR TITLE
Exempt series-flavored datasets from the missing-cell-link rule

### DIFF
--- a/src/battinfo/validate/semantic.py
+++ b/src/battinfo/validate/semantic.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from importlib import resources
 from typing import Any, Mapping
 
+from battinfo._util import is_dataset_series
 from battinfo.canonical_aliases import record_to_snake_aliases
 from battinfo.validate.core import (
     DEFAULT_POLICY,
@@ -881,7 +882,11 @@ def _validate_dataset_semantics(
         cell_ids = related_entities.get("cell_ids")
         if isinstance(cell_ids, list):
             has_battery_link = any(isinstance(item, str) and item.startswith(CELL_IRI_PREFIX) for item in cell_ids)
-    if not has_battery_link:
+    # A series-flavored dataset (dcat:DatasetSeries) is a grouping record: its
+    # member datasets carry the cell links and point here via series_id, so
+    # requiring a direct cell link on the collection would force redundancy.
+    # A collection MAY still state cells/specs in `about`; it just isn't made to.
+    if not has_battery_link and not is_dataset_series(dataset.get("additional_type")):
         _append_issue(
             issues,
             code="semantic.dataset_missing_cell_link",

--- a/tests/test_dataset_series.py
+++ b/tests/test_dataset_series.py
@@ -32,12 +32,13 @@ _PROVENANCE = ProvenanceInfo(
 
 
 def _series() -> Dataset:
+    # Deliberately no cell link: a collection is a grouping record whose members
+    # carry the cell links (and point here via series_id).
     return Dataset(
         id=SERIES_IRI,
         name="Half-cell OCV collection",
         access_url="https://doi.org/10.5281/zenodo.20086298",
         additional_type=["DatasetSeries"],
-        cell_instance_id=CELL_IRI,
         source=_PROVENANCE,
     )
 
@@ -87,6 +88,24 @@ def test_series_and_member_validate_clean_in_strict_mode() -> None:
     for dataset in (_series(), _member()):
         report = validate_record_report(dataset.to_record(), policy="strict")
         assert not report.issues, [issue.message for issue in report.issues]
+
+
+def test_series_without_cell_link_is_exempt_but_plain_dataset_is_not() -> None:
+    # The dataset_missing_cell_link rule stays for ordinary datasets; only the
+    # series flavor is exempt (its members carry the cell links).
+    plain = Dataset(
+        id=MEMBER_IRI,
+        name="no links at all",
+        access_url="https://example.org/datasets/orphan",
+        source=_PROVENANCE,
+    )
+    report = validate_record_report(plain.to_record(), policy="strict")
+    assert any(issue.code == "semantic.dataset_missing_cell_link" for issue in report.issues)
+
+    series_report = validate_record_report(_series().to_record(), policy="strict")
+    assert not any(
+        issue.code == "semantic.dataset_missing_cell_link" for issue in series_report.issues
+    )
 
 
 def test_schema_rejects_a_non_dataset_series_iri() -> None:


### PR DESCRIPTION
## What

The semantic validator no longer raises `semantic.dataset_missing_cell_link` for a dataset flavored as a series (`additional_type = "DatasetSeries"`). Ordinary datasets keep the rule unchanged.

## Why

Discovered while preparing the Flores collection record (Phase 3 of the dataset-series plan): a real collection has no single cell to point at, so it failed strict validation with a hard error. #351's acceptance test happened to carry a cell link on the series fixture, which masked this. A series is a grouping record; its members carry the cell links and point at it via `series_id`, so the graph stays connected transitively. A collection may still state cells or specs in `about` - it just isn't required to.

The alternative was to require the collection's `about` to list member cell-spec IRIs. That needs no code but forces redundant content on every collection record; happy to switch to that instead if preferred.

## How

One condition in `_validate_dataset_semantics`, using the shared `is_dataset_series` helper from #351. Semantic checks run client-side in the BattINFO publish path, so this needs no registry re-vendor.

## Testing

- Series fixture in `tests/test_dataset_series.py` now has no cell link, so the strict-mode clean-validation test exercises the exemption.
- New test asserts the rule still fires for an ordinary dataset without a cell link and not for the series.
- Full suite: 1964 passed, 3 failed - the same three pre-existing failures on main. Ruff clean.