### PR TITLE
Tolerate batterydf main's read() signature in ws.convert

### DIFF
--- a/src/battinfo/processing.py
+++ b/src/battinfo/processing.py
@@ -124,15 +124,23 @@ def _read_bdf_pandas(source: Path, *, validate: bool = False):
     still emits a "tz defaulted to UTC" UserWarning for naive-datetime formats,
     so that specific warning is suppressed here.
     """
+    import inspect  # noqa: PLC0415
     import warnings as _warnings  # noqa: PLC0415
 
     import bdf  # noqa: PLC0415
+
+    # Older batterydf builds default to a LazyFrame and take lazy= to collect
+    # eagerly; current main dropped the kwarg (read() is always eager, scan()
+    # is the lazy path). Sniff the signature so both work.
+    read_kwargs: dict = {"validate": validate, "tz": "UTC"}
+    if "lazy" in inspect.signature(bdf.read).parameters:
+        read_kwargs["lazy"] = False
 
     with _warnings.catch_warnings():
         _warnings.filterwarnings(
             "ignore", message="tz defaulted to UTC", category=UserWarning
         )
-        frame, metadata = bdf.read(source, validate=validate, lazy=False, tz="UTC")
+        frame, metadata = bdf.read(source, **read_kwargs)
     return frame.to_pandas(), metadata
 
 


### PR DESCRIPTION
## What

`_read_bdf_pandas` sniffs `bdf.read`'s signature and passes `lazy=False` only when the installed batterydf accepts it.

## Why

batterydf main dropped the `lazy=` kwarg (read() is always eager; scan() is the lazy path), so `ws.convert()` failed with `read() got an unexpected keyword argument 'lazy'` against a batterydf main install. Found converting a Neware .ndax during the 0.8 publication rehearsal. Since batterydf 0.2.0 will release from main, battinfo must work with both the pinned rev and main.

## How

One call site (`processing.py`) funnels every bdf.read use, including the interop battdat path. `inspect.signature` gates the kwarg; older builds keep `lazy=False` (their default returns a LazyFrame), newer builds get a plain call.

## Testing

Full suite green against the pinned rev (2060 passed); .ndax → BDF conversion verified working against batterydf main in a clean venv. ruff clean.