### PR TITLE
Paginate registry listings: search and cell lookup see the whole corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Registry listings paginate; lookups no longer miss older records.** A
+  single GET of `/resources` is capped by the server at one page (100 rows,
+  newest first), and both the cell-spec search cache and the cell/serial
+  lookup treated that first page as the whole catalog. Once the corpus
+  outgrew a page, `ws.search` reported registered specs as missing and the
+  cell lookup silently re-minted IRIs for serials that already had canonical
+  ones (#340, #341). The client now pages with `limit`/`offset` until the
+  listing is exhausted, and stops safely against a registry that predates
+  pagination support.
+
 ### Added
 
 - **`Step` gains an optional `step_id`.** A test-protocol method step can now

--- a/src/battinfo/ws.py
+++ b/src/battinfo/ws.py
@@ -3097,22 +3097,49 @@ class AuthoringWorkspace:
             return
         self._index_saved_cells()
 
-    def _registry_resources(self, resource_type: str, q: str | None = None) -> builtins.list[dict]:
-        """GET /resources?resource_type=... [&q=...] — raw summaries, [] if unreachable."""
+    _RESOURCES_PAGE_LIMIT = 1000  # registry's maximum limit= for /resources
+
+    def _fetch_resource_pages(self, params: dict, *, timeout: int = 60) -> builtins.list[dict]:
+        """GET /resources with exhaustive offset pagination.
+
+        A single GET of /resources is capped by the server (default 100 rows,
+        newest first), so listings silently truncate once the corpus outgrows
+        one page — the trap that made lookups miss registered records and
+        re-mint duplicate IRIs. Pages by advancing offset until a short page
+        signals exhaustion. A server that ignores offset (pre-pagination
+        deployment) returns the same page again; that repeat is detected and
+        the loop stops with the rows it has rather than spinning forever.
+        """
         import urllib.parse
         import urllib.request
 
+        rows: list[dict] = []
+        prev_page: list | None = None
+        offset = 0
+        while True:
+            query = dict(params, limit=self._RESOURCES_PAGE_LIMIT, offset=offset)
+            url = f"{self._registry_url}/resources?" + urllib.parse.urlencode(query)
+            req = urllib.request.Request(url, headers={"User-Agent": "battinfo-client/1.0"})
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+                page = json.loads(resp.read().decode())
+            if not isinstance(page, list) or (offset and page == prev_page):
+                return rows
+            rows.extend(page)
+            if len(page) < self._RESOURCES_PAGE_LIMIT:
+                return rows
+            prev_page = page
+            offset += self._RESOURCES_PAGE_LIMIT
+
+    def _registry_resources(self, resource_type: str, q: str | None = None) -> builtins.list[dict]:
+        """GET /resources?resource_type=... [&q=...] — raw summaries, [] if unreachable."""
         if not self._registry_url:
             print("  No registry configured (registry_url=None).")
             return []
         params = {"resource_type": resource_type}
         if q:
             params["q"] = q
-        url = f"{self._registry_url}/resources?" + urllib.parse.urlencode(params)
         try:
-            req = urllib.request.Request(url, headers={"User-Agent": "battinfo-client/1.0"})
-            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
-                return json.loads(resp.read().decode())
+            return self._fetch_resource_pages(params, timeout=30)
         except Exception as exc:  # registry down / network - degrade gracefully
             print(f"  Registry unreachable ({exc}).")
             return []
@@ -6415,11 +6442,7 @@ class AuthoringWorkspace:
 
     def _build_api_cache(self) -> builtins.list[dict]:
         """Fetch all published cell-spec summaries from the registry API."""
-        import urllib.request
-        url = f"{self._registry_url}/resources?resource_type=cell_spec"
-        req = urllib.request.Request(url, headers={"User-Agent": "battinfo-client/1.0"})
-        with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
-            data = json.loads(resp.read().decode())
+        data = self._fetch_resource_pages({"resource_type": "cell_spec"})
 
         entries: list[dict] = []
         for r in data:

--- a/tests/test_registry_pagination.py
+++ b/tests/test_registry_pagination.py
@@ -1,0 +1,140 @@
+"""Registry listing pagination (#340/#341).
+
+A single GET of /resources is capped by the server at one page (default 100
+rows, newest first), so the client-side caches that treated one response as
+the full catalog silently lost every record older than the first page — and
+the workspace then re-minted IRIs for records that were already registered.
+These tests pin the exhaustive-pagination behavior of _fetch_resource_pages
+and its two consumers (_registry_resources, _build_api_cache).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from battinfo.ws import AuthoringWorkspace  # noqa: E402
+
+PAGE_LIMIT = AuthoringWorkspace._RESOURCES_PAGE_LIMIT
+
+
+class _Resp:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_Resp":
+        return self
+
+    def __exit__(self, *a: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _paginating_server(corpus: list[dict], seen_urls: list[str], *, ignore_offset: bool = False):
+    """Fake urlopen serving slices of ``corpus``, honoring limit/offset."""
+
+    def _open(req, timeout=0):  # noqa: ARG001
+        url = req.full_url
+        seen_urls.append(url)
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        limit = int(params.get("limit", ["100"])[0])
+        offset = 0 if ignore_offset else int(params.get("offset", ["0"])[0])
+        return _Resp(corpus[offset : offset + limit])
+
+    return _open
+
+
+def _ws(tmp_path: Path) -> AuthoringWorkspace:
+    return AuthoringWorkspace(root=tmp_path, registry_url="https://registry.example")
+
+
+def _cell_row(i: int, serial: str | None = None) -> dict:
+    return {
+        "canonical_iri": f"https://w3id.org/battinfo/cell/{i:04d}",
+        "canonical_id": f"{i:04d}",
+        "title": f"Cell {i}",
+        "metadata": {"serial_number": serial or f"SN{i:05d}", "batch_id": "b1"},
+    }
+
+
+def test_registry_resources_paginates_past_first_page(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.request
+
+    corpus = [_cell_row(i) for i in range(2 * PAGE_LIMIT + 500)]
+    urls: list[str] = []
+    monkeypatch.setattr(urllib.request, "urlopen", _paginating_server(corpus, urls))
+
+    rows = _ws(tmp_path)._registry_resources("cell")
+    assert len(rows) == len(corpus)
+    offsets = [urllib.parse.parse_qs(urllib.parse.urlparse(u).query)["offset"][0] for u in urls]
+    assert offsets == ["0", str(PAGE_LIMIT), str(2 * PAGE_LIMIT)]
+
+
+def test_offset_ignoring_server_does_not_loop_forever(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pre-pagination registry ignores offset and serves the same first page
+    again; the client must stop after the repeat, not spin."""
+    import urllib.request
+
+    corpus = [_cell_row(i) for i in range(PAGE_LIMIT)]  # exactly one full page
+    urls: list[str] = []
+    monkeypatch.setattr(urllib.request, "urlopen", _paginating_server(corpus, urls, ignore_offset=True))
+
+    rows = _ws(tmp_path)._registry_resources("cell")
+    assert len(rows) == PAGE_LIMIT  # first page kept once, repeat discarded
+    assert len(urls) == 2
+
+
+def test_q_parameter_is_passed_through(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.request
+
+    urls: list[str] = []
+    monkeypatch.setattr(urllib.request, "urlopen", _paginating_server([_cell_row(1)], urls))
+
+    _ws(tmp_path)._registry_resources("cell", q="TRFFC")
+    params = urllib.parse.parse_qs(urllib.parse.urlparse(urls[0]).query)
+    assert params["q"] == ["TRFFC"]
+    assert params["resource_type"] == ["cell"]
+
+
+def test_query_registry_cells_finds_serial_beyond_first_page(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The #341 repro: a cell registered early sorts past the first page once
+    newer cells accumulate; serial lookup must still resolve it."""
+    import urllib.request
+
+    corpus = [_cell_row(i) for i in range(PAGE_LIMIT + 100)]
+    corpus[PAGE_LIMIT + 50] = _cell_row(PAGE_LIMIT + 50, serial="TRFFC00197")
+    monkeypatch.setattr(urllib.request, "urlopen", _paginating_server(corpus, []))
+
+    hits = _ws(tmp_path)._query_registry_cells(serials=["TRFFC00197"])
+    assert [h["serial_number"] for h in hits] == ["TRFFC00197"]
+    assert hits[0]["id"] == corpus[PAGE_LIMIT + 50]["canonical_iri"]
+
+
+def test_build_api_cache_paginates(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The #340 repro: a spec older than the first page must enter the search cache."""
+    import urllib.request
+
+    corpus = [
+        {
+            "canonical_iri": f"https://w3id.org/battinfo/spec/{i:04d}",
+            "canonical_id": f"{i:04d}",
+            "title": f"Maker Model{i}",
+            "metadata": {"manufacturer": "Maker", "model": f"Model{i}"},
+        }
+        for i in range(PAGE_LIMIT + 200)
+    ]
+    monkeypatch.setattr(urllib.request, "urlopen", _paginating_server(corpus, []))
+
+    entries = _ws(tmp_path)._build_api_cache()
+    assert len(entries) == len(corpus)
+    ids = {e["id"] for e in entries}
+    assert corpus[-1]["canonical_iri"] in ids  # oldest row survived pagination


### PR DESCRIPTION
## What

Registry `/resources` listings are now fetched with exhaustive `limit`/`offset` pagination. A shared `_fetch_resource_pages` helper replaces the single-GET fetches in `_registry_resources` (cell/serial lookups) and `_build_api_cache` (the cell-spec search cache).

## Why

The registry caps one listing response at a page (default 100 rows, newest first). Both client paths treated the first page as the whole catalog, so once the corpus outgrew a page, `ws.search` reported registered specs as missing (#340) and cell lookup silently returned empty for older serials, letting `ws.add("cell", ...)` re-mint IRIs that already had canonical ones (#341). The MORROW spec and the 97 TRFFC cells from May are the recorded casualties.

## How

- `_fetch_resource_pages` requests `limit=1000` (the server max) and advances `offset` until a short page signals exhaustion.
- A registry deployment that predates pagination support ignores `offset` and serves the first page again; the helper detects the repeated page and stops with what it has instead of looping.
- `q` and `resource_type` filters pass through unchanged. Error handling is unchanged: `_registry_resources` still degrades to `[]` with a message, `_build_api_cache` still propagates so `search()` falls back to the local clone.
- Changelog entry under Unreleased/Fixed.

## Testing

- New `tests/test_registry_pagination.py` (5 tests): multi-page aggregation with correct offsets, the offset-ignoring-server guard, `q` passthrough, the #341 serial-beyond-first-page repro, and the #340 search-cache repro.
- Full suite green locally; ruff and mypy clean.

Closes #340
Closes #341
