### PR TITLE
Facet modes recurses into step groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The `modes` facet recurses into step groups.** A cycling protocol wrapped
+  in a repeat group faceted as `modes: ["group"]`, so any consumer filtering
+  on `modes` missed every cycling protocol; `control_modes`, `directions`,
+  and the `has_*` flags already recursed. `modes` now lists leaf-step modes
+  in first-encounter order and never contains `group` — group nesting stays
+  visible in the method graph itself. Facets are stamped at publish time, so
+  already-published records carry the old shape until re-emitted (#361).
+
 - **Registry listings paginate; lookups no longer miss older records.** A
   single GET of `/resources` is capped by the server at one page (100 rows,
   newest first), and both the cell-spec search cache and the cell/serial

--- a/src/battinfo/testmethod.py
+++ b/src/battinfo/testmethod.py
@@ -479,7 +479,14 @@ _CONTROL_MODE = {"cc": "current", "cv": "voltage", "cccv": "current", "cp": "pow
 
 
 def compute_facets(steps: Sequence[Step], conditions: dict[str, Quantity] | None = None) -> dict[str, Any]:
-    """Derive a flat, queryable rollup of a method for cheap agent filtering."""
+    """Derive a flat, queryable rollup of a method for cheap agent filtering.
+
+    ``modes`` lists leaf-step modes in first-encounter order; ``group`` is
+    structure, not a mode, and never appears (a cycling protocol wrapped in a
+    repeat group must facet as its cc/cv/rest content, or every ``modes``
+    filter misses it — #361). Group nesting stays visible in the method graph
+    and the ``has_*`` flags.
+    """
     modes: list[str] = []
     directions: set[str] = set()
     control_modes: set[str] = set()
@@ -488,7 +495,7 @@ def compute_facets(steps: Sequence[Step], conditions: dict[str, Quantity] | None
     temperatures: list[float] = []
     tags: set[str] = set()
 
-    for step in steps:
+    for step in _iter_leaf_steps(steps):
         if step.mode not in modes:
             modes.append(step.mode)
     for step in _iter_leaf_steps(steps):

--- a/tests/test_facet_query.py
+++ b/tests/test_facet_query.py
@@ -49,8 +49,11 @@ def test_query_by_c_rate_and_mode(tmp_path: Path) -> None:
     d = _make_dir(tmp_path)
     assert len(query_test_specs(directory=d, c_rate=0.5)) == 1
     assert len(query_test_specs(directory=d, c_rate=1.0)) == 1
-    # A group (cycled) method only appears in the formation spec.
-    assert [r["name"] for r in query_test_specs(directory=d, mode="group")] == ["Formation CCCV"]
+    # modes lists leaf steps (never "group", #361): the cycled formation
+    # method is found by what it does, and its cv hold is not hidden by
+    # the group wrapper.
+    assert [r["name"] for r in query_test_specs(directory=d, mode="cv")] == ["Formation CCCV"]
+    assert query_test_specs(directory=d, mode="group") == []
 
 
 def test_query_combines_facet_and_identity_filters(tmp_path: Path) -> None:

--- a/tests/test_testmethod.py
+++ b/tests/test_testmethod.py
@@ -177,4 +177,14 @@ def test_facets_rollup() -> None:
     assert facets["control_modes"] == ["current", "voltage"]
     assert facets["c_rates"] == [0.02, 0.5, 1.0]
     assert facets["voltage_window_V"] == [2.5, 4.2]
-    assert facets["modes"] == ["group"]
+    # modes recurses into the cycle group: leaf modes in first-encounter
+    # order, never "group" itself (#361).
+    assert facets["modes"] == ["cc", "cv", "rest"]
+
+
+def test_facets_modes_recurse_into_nested_groups() -> None:
+    inner = parse_experiment(["Charge at 1 C until 4.2 V", "Rest for 5 minutes"], cycles=2)
+    outer = Step(mode="group", count=3, steps=inner)
+    facets = compute_facets([outer])
+    assert facets["modes"] == ["cc", "rest"]
+    assert "group" not in facets["modes"]


### PR DESCRIPTION
## What

The `modes` facet in `compute_facets` recurses into step groups: it now lists leaf-step modes in first-encounter order and never contains `group`.

## Why

A cycling protocol wrapped in a repeat group — in practice, every cycling protocol — faceted as `modes: ["group"]`, while `control_modes`, `directions`, and the `has_*` flags already recursed. The live GITT record demonstrates it: `"modes": ["group"]` next to `"control_modes": ["current", "voltage"]`. Any consumer filtering on `modes` (including the record-listing filter in `api/_records.py`) missed every group-wrapped protocol. Second item of #361; the first (protocol resolver parity) is verified fixed in production, see the issue comment.

## How

- The `modes` loop walks `_iter_leaf_steps` instead of top-level steps; order is first-encounter, `group` is treated as structure, not a mode. Documented in the `compute_facets` docstring.
- Facets are stamped at publish time, so already-published records keep the old shape until re-emitted; the #298 re-emission pass picks the refresh up for free. Until a record is re-published, `check_artifact_conformance` may warn about `modes` divergence against a linked artifact — warnings never block, and re-publishing clears them.
- Web showcase regenerated: no drift (the embedded examples are not group-wrapped).
- Changelog entry under Unreleased/Fixed.

## Testing

- `test_facets_rollup` updated: the group-wrapped method now expects `["cc", "cv", "rest"]`; new `test_facets_modes_recurse_into_nested_groups` covers two levels of nesting and asserts `group` never appears.
- `test_query_by_c_rate_and_mode` updated: the cycled formation spec is now found by `mode="cv"` (what it does), and `mode="group"` finds nothing.
- Full suite green locally with the processing extra (2070 passed); ruff and mypy clean.

Closes #361
