### PR TITLE
Bump transitive nanoid to 3.3.18

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2016,9 +2016,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Refreshes `web/package-lock.json` so transitive nanoid moves 3.3.17 -> 3.3.18.

## Why

GHSA-2v37-7h3g-55p8 (high): nanoid custom generators can loop indefinitely when size is zero; fixed in 3.3.18. Dependabot's grouped npm update only landed the fast-uri half (#376), leaving open alert 53. nanoid is transitive via postcss (`^3.3.16`), so the patched version is accepted by a plain lockfile refresh.

## How

`npm update nanoid` in `web/`; lockfile-only, no manifest change.

## Testing

`npm audit` clean after the bump. Local `next build` on Windows fails on max-path in the temp worktree (pre-existing, unrelated); the Website CI job is the build verification.
