### PR TITLE
Material kinds carry roles: the slots a substance is known to fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **The material-kind `family` axis collapses to `active_material` / `other`.**
-  The vocabulary no longer assigns a side to an active material
-  (`active_anode` / `active_cathode` are gone): which electrode a material
-  serves is system-relative — graphite is the positive electrode of every
-  lithium-counter half cell — so role lives where the material is used,
-  never on the kind. With it goes the whole polarity-derivation chain:
-  `create_electrode_spec` no longer stamps a `polarity` derived from the
-  kind (authored polarity is untouched), the emitted `@type` carries the
-  polarity class only when polarity is authored, and the
-  `semantic.electrode_polarity_conflict` check is retired. The role-flavored
-  single-member families (`conductive_additive`, `separator_material`,
-  `current_collector_material`, `binder`, `electrolyte_salt`,
-  `electrolyte_solvent`) fold into `other` for the same reason: the coating
-  role slots, electrolyte constituent slots, and component specs already
-  state each role at the place it is true. `electrode_polarity_for_kind`
-  (module-level, never exported from the package root) is removed;
-  `electrode_kind()` no longer injects a `polarity` key. Vocabulary version
-  0.2.0 → 0.3.0. The registry re-vendors `material_kinds.json` after this
-  merge.
+- **Material kinds carry `roles` (a list), replacing the single-valued
+  `family`.** The old axis forced one role onto substances that legitimately
+  play several and took sides on active materials (`active_anode` /
+  `active_cathode`) — but roles are system-relative: graphite is the positive
+  electrode of every lithium-counter half cell, FEC is both co-solvent and
+  additive, CMC both binder and thickener. `roles` lists the use-site slots a
+  substance is known to fill (coating roles, electrolyte constituents,
+  component films/foils/coatings); it is informative, never normative — no
+  validator rejects a use outside the listed roles. `active_material` is the
+  one load-bearing role: it gates `electrode_spec.kind` and anchors reference
+  properties. VC is refiled from solvent to additive; NMP carries an empty
+  list (a processing solvent fills no composition slot). With the sides gone,
+  the polarity-derivation chain retires: `create_electrode_spec` stamps
+  `polarity` only when authored, the emitted `@type` carries a polarity class
+  only for authored polarity, `semantic.electrode_polarity_conflict` is
+  removed, and `electrode_polarity_for_kind` (never exported from the package
+  root) is gone. Vocabulary 0.2.0 → 0.3.0. The registry re-vendors
+  `material_kinds.json` after this merge.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **The material-kind `family` axis collapses to `active_material` / `other`.**
+  The vocabulary no longer assigns a side to an active material
+  (`active_anode` / `active_cathode` are gone): which electrode a material
+  serves is system-relative — graphite is the positive electrode of every
+  lithium-counter half cell — so role lives where the material is used,
+  never on the kind. With it goes the whole polarity-derivation chain:
+  `create_electrode_spec` no longer stamps a `polarity` derived from the
+  kind (authored polarity is untouched), the emitted `@type` carries the
+  polarity class only when polarity is authored, and the
+  `semantic.electrode_polarity_conflict` check is retired. The role-flavored
+  single-member families (`conductive_additive`, `separator_material`,
+  `current_collector_material`, `binder`, `electrolyte_salt`,
+  `electrolyte_solvent`) fold into `other` for the same reason: the coating
+  role slots, electrolyte constituent slots, and component specs already
+  state each role at the place it is true. `electrode_polarity_for_kind`
+  (module-level, never exported from the package root) is removed;
+  `electrode_kind()` no longer injects a `polarity` key. Vocabulary version
+  0.2.0 → 0.3.0. The registry re-vendors `material_kinds.json` after this
+  merge.
+
 ### Fixed
 
 - **The `modes` facet recurses into step groups.** A cycling protocol wrapped

--- a/assets/schemas/electrode-spec.schema.json
+++ b/assets/schemas/electrode-spec.schema.json
@@ -48,7 +48,7 @@
             "negative",
             "unknown"
           ],
-          "description": "Electrode polarity. Derived from the kind's family when not authored (active_cathode -> positive, active_anode -> negative)."
+          "description": "Electrode polarity, authored when the design has a side to state. Never derived from the kind: which side an active material sits on is system-relative (graphite is the positive electrode of a lithium-counter half cell). Role-based cells (half / three-electrode) name electrodes by role instead."
         },
         "grade": {
           "type": "string",

--- a/docs/records/_fragments/electrodes.md
+++ b/docs/records/_fragments/electrodes.md
@@ -36,9 +36,11 @@ too; leave it out and you lose the powder link, not the record.
 
 A `kind` that resolves but is not an active material (a binder, a salt) is a
 **warning**, not an error — the record is still usable, and the author is better
-placed than the validator to fix the mix-up. `polarity` is **derived** from the
-kind's family, so a record never states the same fact twice; stating a polarity
-that contradicts the kind ("LFP anode") warns.
+placed than the validator to fix the mix-up. `polarity` is **authored or
+absent, never derived from the kind**: which side an active material sits on
+is the cell's fact, not the material's — graphite is the positive electrode
+of every lithium-counter half cell, so an "LFP negative electrode" is a
+legitimate design, not a typo, and nothing warns about it.
 
 ### Composition is the cell-spec coating shape
 

--- a/docs/records/_fragments/materials.md
+++ b/docs/records/_fragments/materials.md
@@ -16,11 +16,14 @@ identifier for graphite. So kinds are a **shipped, versioned, curated vocabulary
 governed by PR — like the property vocabulary — **not** a user-authored record
 type. If level 1 were records, the corpus would grow fifty graphites.
 
-Each kind carries a canonical `key` (the ergonomic handle), a `label`, a `family`
-(`active_material` or `other` — deliberately minimal: a material's *role* is
-system-relative and is stated where the material is used, in the coating role
-slots, the electrolyte constituent slots, or the component spec that
-references it, never on the kind), an optional `formula`, tolerant-import
+Each kind carries a canonical `key` (the ergonomic handle), a `label`, its
+`roles` — the use-site slots this substance is *known* to fill, as a list
+because roles are system-relative (FEC is both co-solvent and additive, CMC
+both binder and thickener). The list is informative, never normative: the
+role a material actually plays in a given cell is stated at the use site
+(coating role slots, electrolyte constituent slots, the component spec that
+references it), and a use outside the listed roles is never an error. Then
+an optional `formula`, tolerant-import
 `aliases` ("NMC 811", "LiNi0.8Mn0.1Co0.1O2", "Si/Gr"), and — the anchor — its
 `chemsub`: the material's **chemical-substance domain-ontology class IRI** (the EMMO
 ecosystem's `domain-chemical-substance`). The battinfo `key` is just the handle;
@@ -71,12 +74,11 @@ Adding a kind is a PR against `src/battinfo/data/vocab/material_kinds.json`; the
 tests check that each new `emmo` class resolves in the bundled context and names the
 same substance as its `chemsub` anchor.
 
-Only the active flag is intrinsic enough to live on the kind: it gates which
-kinds an electrode may name, and it is where reference anchors such as
-specific capacity attach. Everything else — binders, salts, solvents,
-separator films, conductive carbons — sits under `other`, with a
-`family_note` where the placement deserves a word (NMP, for example, is a
-processing solvent, not an electrolyte solvent).
+One role is load-bearing: `active_material` gates which kinds an electrode
+may name and is where reference anchors such as specific capacity attach.
+The rest are browse-and-discovery knowledge. An empty list is honest too:
+NMP fills no composition slot at all — it is a processing solvent, which its
+`roles_note` says.
 
 ## Level 2 — material-spec (first-class record)
 

--- a/docs/records/_fragments/materials.md
+++ b/docs/records/_fragments/materials.md
@@ -17,9 +17,10 @@ governed by PR — like the property vocabulary — **not** a user-authored reco
 type. If level 1 were records, the corpus would grow fifty graphites.
 
 Each kind carries a canonical `key` (the ergonomic handle), a `label`, a `family`
-(`active_anode`, `active_cathode`, `binder`, `conductive_additive`,
-`electrolyte_solvent`, `electrolyte_salt`, `separator_material`,
-`current_collector_material`, `other`), an optional `formula`, tolerant-import
+(`active_material` or `other` — deliberately minimal: a material's *role* is
+system-relative and is stated where the material is used, in the coating role
+slots, the electrolyte constituent slots, or the component spec that
+references it, never on the kind), an optional `formula`, tolerant-import
 `aliases` ("NMC 811", "LiNi0.8Mn0.1Co0.1O2", "Si/Gr"), and — the anchor — its
 `chemsub`: the material's **chemical-substance domain-ontology class IRI** (the EMMO
 ecosystem's `domain-chemical-substance`). The battinfo `key` is just the handle;
@@ -70,10 +71,12 @@ Adding a kind is a PR against `src/battinfo/data/vocab/material_kinds.json`; the
 tests check that each new `emmo` class resolves in the bundled context and names the
 same substance as its `chemsub` anchor.
 
-One placement is worth flagging: NMP is a **processing** solvent (slurry casting),
-not an electrolyte solvent, and the family list has no `processing_solvent` value, so
-it sits under `other` with a `family_note` saying why. Add the family when a second
-processing solvent arrives rather than stretching `electrolyte_solvent` to cover it.
+Only the active flag is intrinsic enough to live on the kind: it gates which
+kinds an electrode may name, and it is where reference anchors such as
+specific capacity attach. Everything else — binders, salts, solvents,
+separator films, conductive carbons — sits under `other`, with a
+`family_note` where the placement deserves a word (NMP, for example, is a
+processing solvent, not an electrolyte solvent).
 
 ## Level 2 — material-spec (first-class record)
 

--- a/docs/records/_fragments/materials.md
+++ b/docs/records/_fragments/materials.md
@@ -135,7 +135,7 @@ No `ws._ws` is required for materials.
 Electrode composition components (and electrolyte solvents/salts, separator
 materials) reference a material at whichever level you know:
 
-- a **kind key** — minimum ("the anode is graphite"), resolves to the vocabulary
+- a **kind key** — minimum ("the active material is graphite"), resolves to the vocabulary
   IRI / EMMO class;
 - a **material-spec IRI** — better ("Targray NMC811 grade X");
 - a **material-instance IRI** — best ("this lot"), typically on the cell *build*.
@@ -169,7 +169,7 @@ A reusable material specification. Top-level key `material_spec`.
 | `kind` | ✓ (at save) | Level-1 [MaterialKind](#level-1-materialkind-a-curated-vocabulary) key from the curated vocabulary (`graphite`, `lfp`, `nmc811`, …). The genome's aggregation axis; resolves to the kind's chemical-substance class IRI. Aliases resolve on input; an unknown kind is rejected at save. See `battinfo.materials.material_kind_keys()` |
 | `grade` | | Manufacturer grade / product version; part of spec identity |
 | `material_class` | | `active_material`, `binder`, `conductive_additive`, `current_collector`, `separator_material`, `electrolyte_salt`, `electrolyte_solvent`, `electrolyte_additive`, `metal_electrode`, `coating`, `other` |
-| `electrode_polarity` | | `positive` / `negative` / `none` (for active materials) |
+| `electrode_polarity` | | `positive` / `negative` / `none`. A material has no side of its own (system-relative — graphite is the positive electrode of a lithium-counter half cell); the side belongs to the cell that uses it. Field remains in the schema pending review; prefer leaving it unset |
 | `formula` | | Idealized composition, e.g. `LiFePO4`, `C`, `Zn`, `(C2H2F2)n` |
 | `chemistry_family` | | Coarse family label, e.g. `olivine`, `layered-oxide`, `spinel` |
 | `manufacturer` / `supplier` | | Organization reference — a plain name string **or** an `{type: Organization, name, id}` object whose `id` links to an `organization` record |
@@ -297,7 +297,6 @@ from battinfo.api import (
 spec = create_material_spec(
     name="LFP",
     material_class="active_material",
-    electrode_polarity="positive",
     formula="LiFePO4",
     chemistry_family="olivine",
     manufacturer="Canrud",
@@ -323,7 +322,7 @@ Canonical examples live in [`examples/material-spec/`](https://github.com/BIG-MA
 [`examples/material/`](https://github.com/BIG-MAP/BattINFO/tree/main/examples/material) (the single source of truth, mirrored into
 the wheel by `scripts/sync_examples.py`). Coverage spans graphite, LFP, NMC811, NMC622,
 LCO, LMFP, LNMO, zinc, carbon black, PVDF, and the KOH / LiPF6 / EC / EMC electrolyte
-constituents. The Li-ion cathode/anode actives and electrolyte salts/solvents are
+constituents. The Li-ion actives and electrolyte salts/solvents are
 grounded in the DIGIBAT Discovery-Benchmark coin-cell corpus; LNMO, zinc, and KOH are
 synthetic reference examples.
 

--- a/docs/records/electrodes.md
+++ b/docs/records/electrodes.md
@@ -46,9 +46,11 @@ too; leave it out and you lose the powder link, not the record.
 
 A `kind` that resolves but is not an active material (a binder, a salt) is a
 **warning**, not an error — the record is still usable, and the author is better
-placed than the validator to fix the mix-up. `polarity` is **derived** from the
-kind's family, so a record never states the same fact twice; stating a polarity
-that contradicts the kind ("LFP anode") warns.
+placed than the validator to fix the mix-up. `polarity` is **authored or
+absent, never derived from the kind**: which side an active material sits on
+is the cell's fact, not the material's — graphite is the positive electrode
+of every lithium-counter half cell, so an "LFP negative electrode" is a
+legitimate design, not a typo, and nothing warns about it.
 
 ### Composition is the cell-spec coating shape
 
@@ -1207,7 +1209,7 @@ Schema: [`electrode-spec.schema.json`](https://w3id.org/battinfo/schema/electrod
 | `short_id` | → ShortId |  |  |
 | `name` | string | yes | Human-readable electrode name / designation (e.g. 'Si-Gr anode, aqueous', 'NMC811 cathode 96/2/2'). |
 | `kind` | string |  | Required Level-1 kind naming the ACTIVE material of this electrode, from the curated material-kind vocabulary (e.g. 'graphite', 'silicon_graphite', 'nmc811', 'lfp'). Required so a purchased electrode whose powder provenance is unknown is still queryable on the same aggregation axis as one built from an authored material-spec. Aliases resolve on input; an unknown kind is rejected at save time. See battinfo.electrodes.electrode_kind_keys(). |
-| `polarity` | `positive` \| `negative` \| `unknown` |  | Electrode polarity. Derived from the kind's family when not authored (active_cathode -> positive, active_anode -> negative). |
+| `polarity` | `positive` \| `negative` \| `unknown` |  | Electrode polarity, authored when the design has a side to state. Never derived from the kind: which side an active material sits on is system-relative (graphite is the positive electrode of a lithium-counter half cell). Role-based cells (half / three-electrode) name electrodes by role instead. |
 | `grade` | string |  | Producer grade / design version (e.g. 'v2', 'rev B'). Part of spec identity together with the producer and the electrode name. |
 | `active_material_spec_id` | → MaterialSpecIri |  | Optional canonical IRI of the material-spec for this electrode's active material, present when the powder is known and authored. Absent for a purchased electrode of known chemistry but unknown powder — 'kind' still carries the chemistry. |
 | `coating` | → electrode-coating |  | Coating composition and coating-level design values. 'component.active_material / binder / additive' each carry a weight fraction under property.mass_fraction — the same shape a cell-spec's inline electrode coating uses, so a composition authored here is the composition a cell reads. |

--- a/docs/records/electrodes.md
+++ b/docs/records/electrodes.md
@@ -302,7 +302,6 @@ record = create_electrode_spec(
     "short_id": "kxwy5f",
     "name": "NMC811 cathode design A",
     "kind": "nmc811",
-    "polarity": "positive",
     "active_material_spec_id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5"
   },
   "provenance": {
@@ -327,10 +326,7 @@ Emitted by `record_to_jsonld`, hosted-context mode.
       "battinfo": "https://w3id.org/battinfo/"
     }
   ],
-  "@type": [
-    "LithiumNickelManganeseCobaltOxideElectrode",
-    "PositiveElectrode"
-  ],
+  "@type": "LithiumNickelManganeseCobaltOxideElectrode",
   "@id": "https://w3id.org/battinfo/spec/kxwy-5f5f-f682-hhch",
   "schema:name": "NMC811 cathode design A",
   "hasActiveMaterial": {

--- a/docs/records/materials.md
+++ b/docs/records/materials.md
@@ -27,9 +27,10 @@ governed by PR — like the property vocabulary — **not** a user-authored reco
 type. If level 1 were records, the corpus would grow fifty graphites.
 
 Each kind carries a canonical `key` (the ergonomic handle), a `label`, a `family`
-(`active_anode`, `active_cathode`, `binder`, `conductive_additive`,
-`electrolyte_solvent`, `electrolyte_salt`, `separator_material`,
-`current_collector_material`, `other`), an optional `formula`, tolerant-import
+(`active_material` or `other` — deliberately minimal: a material's *role* is
+system-relative and is stated where the material is used, in the coating role
+slots, the electrolyte constituent slots, or the component spec that
+references it, never on the kind), an optional `formula`, tolerant-import
 `aliases` ("NMC 811", "LiNi0.8Mn0.1Co0.1O2", "Si/Gr"), and — the anchor — its
 `chemsub`: the material's **chemical-substance domain-ontology class IRI** (the EMMO
 ecosystem's `domain-chemical-substance`). The battinfo `key` is just the handle;
@@ -80,10 +81,12 @@ Adding a kind is a PR against `src/battinfo/data/vocab/material_kinds.json`; the
 tests check that each new `emmo` class resolves in the bundled context and names the
 same substance as its `chemsub` anchor.
 
-One placement is worth flagging: NMP is a **processing** solvent (slurry casting),
-not an electrolyte solvent, and the family list has no `processing_solvent` value, so
-it sits under `other` with a `family_note` saying why. Add the family when a second
-processing solvent arrives rather than stretching `electrolyte_solvent` to cover it.
+Only the active flag is intrinsic enough to live on the kind: it gates which
+kinds an electrode may name, and it is where reference anchors such as
+specific capacity attach. Everything else — binders, salts, solvents,
+separator films, conductive carbons — sits under `other`, with a
+`family_note` where the placement deserves a word (NMP, for example, is a
+processing solvent, not an electrolyte solvent).
 
 ## Level 2 — material-spec (first-class record)
 

--- a/docs/records/materials.md
+++ b/docs/records/materials.md
@@ -26,11 +26,14 @@ identifier for graphite. So kinds are a **shipped, versioned, curated vocabulary
 governed by PR — like the property vocabulary — **not** a user-authored record
 type. If level 1 were records, the corpus would grow fifty graphites.
 
-Each kind carries a canonical `key` (the ergonomic handle), a `label`, a `family`
-(`active_material` or `other` — deliberately minimal: a material's *role* is
-system-relative and is stated where the material is used, in the coating role
-slots, the electrolyte constituent slots, or the component spec that
-references it, never on the kind), an optional `formula`, tolerant-import
+Each kind carries a canonical `key` (the ergonomic handle), a `label`, its
+`roles` — the use-site slots this substance is *known* to fill, as a list
+because roles are system-relative (FEC is both co-solvent and additive, CMC
+both binder and thickener). The list is informative, never normative: the
+role a material actually plays in a given cell is stated at the use site
+(coating role slots, electrolyte constituent slots, the component spec that
+references it), and a use outside the listed roles is never an error. Then
+an optional `formula`, tolerant-import
 `aliases` ("NMC 811", "LiNi0.8Mn0.1Co0.1O2", "Si/Gr"), and — the anchor — its
 `chemsub`: the material's **chemical-substance domain-ontology class IRI** (the EMMO
 ecosystem's `domain-chemical-substance`). The battinfo `key` is just the handle;
@@ -81,12 +84,11 @@ Adding a kind is a PR against `src/battinfo/data/vocab/material_kinds.json`; the
 tests check that each new `emmo` class resolves in the bundled context and names the
 same substance as its `chemsub` anchor.
 
-Only the active flag is intrinsic enough to live on the kind: it gates which
-kinds an electrode may name, and it is where reference anchors such as
-specific capacity attach. Everything else — binders, salts, solvents,
-separator films, conductive carbons — sits under `other`, with a
-`family_note` where the placement deserves a word (NMP, for example, is a
-processing solvent, not an electrolyte solvent).
+One role is load-bearing: `active_material` gates which kinds an electrode
+may name and is where reference anchors such as specific capacity attach.
+The rest are browse-and-discovery knowledge. An empty list is honest too:
+NMP fills no composition slot at all — it is a processing solvent, which its
+`roles_note` says.
 
 ## Level 2 — material-spec (first-class record)
 

--- a/docs/records/materials.md
+++ b/docs/records/materials.md
@@ -145,7 +145,7 @@ No `ws._ws` is required for materials.
 Electrode composition components (and electrolyte solvents/salts, separator
 materials) reference a material at whichever level you know:
 
-- a **kind key** — minimum ("the anode is graphite"), resolves to the vocabulary
+- a **kind key** — minimum ("the active material is graphite"), resolves to the vocabulary
   IRI / EMMO class;
 - a **material-spec IRI** — better ("Targray NMC811 grade X");
 - a **material-instance IRI** — best ("this lot"), typically on the cell *build*.
@@ -179,7 +179,7 @@ A reusable material specification. Top-level key `material_spec`.
 | `kind` | ✓ (at save) | Level-1 [MaterialKind](#level-1-materialkind-a-curated-vocabulary) key from the curated vocabulary (`graphite`, `lfp`, `nmc811`, …). The genome's aggregation axis; resolves to the kind's chemical-substance class IRI. Aliases resolve on input; an unknown kind is rejected at save. See `battinfo.materials.material_kind_keys()` |
 | `grade` | | Manufacturer grade / product version; part of spec identity |
 | `material_class` | | `active_material`, `binder`, `conductive_additive`, `current_collector`, `separator_material`, `electrolyte_salt`, `electrolyte_solvent`, `electrolyte_additive`, `metal_electrode`, `coating`, `other` |
-| `electrode_polarity` | | `positive` / `negative` / `none` (for active materials) |
+| `electrode_polarity` | | `positive` / `negative` / `none`. A material has no side of its own (system-relative — graphite is the positive electrode of a lithium-counter half cell); the side belongs to the cell that uses it. Field remains in the schema pending review; prefer leaving it unset |
 | `formula` | | Idealized composition, e.g. `LiFePO4`, `C`, `Zn`, `(C2H2F2)n` |
 | `chemistry_family` | | Coarse family label, e.g. `olivine`, `layered-oxide`, `spinel` |
 | `manufacturer` / `supplier` | | Organization reference — a plain name string **or** an `{type: Organization, name, id}` object whose `id` links to an `organization` record |
@@ -307,7 +307,6 @@ from battinfo.api import (
 spec = create_material_spec(
     name="LFP",
     material_class="active_material",
-    electrode_polarity="positive",
     formula="LiFePO4",
     chemistry_family="olivine",
     manufacturer="Canrud",
@@ -333,7 +332,7 @@ Canonical examples live in [`examples/material-spec/`](https://github.com/BIG-MA
 [`examples/material/`](https://github.com/BIG-MAP/BattINFO/tree/main/examples/material) (the single source of truth, mirrored into
 the wheel by `scripts/sync_examples.py`). Coverage spans graphite, LFP, NMC811, NMC622,
 LCO, LMFP, LNMO, zinc, carbon black, PVDF, and the KOH / LiPF6 / EC / EMC electrolyte
-constituents. The Li-ion cathode/anode actives and electrolyte salts/solvents are
+constituents. The Li-ion actives and electrolyte salts/solvents are
 grounded in the DIGIBAT Discovery-Benchmark coin-cell corpus; LNMO, zinc, and KOH are
 synthetic reference examples.
 

--- a/scripts/migrate_electrode_ids.py
+++ b/scripts/migrate_electrode_ids.py
@@ -6,7 +6,8 @@ uid it was handed, so existing corpora carry electrode-spec / electrode records
 whose ids say nothing about what they identify. This script re-mints them the way
 the engine now does — electrode-spec from (producer, product, grade, kind,
 processing route); electrode batch from (spec_id, batch) — backfills the required
-``kind`` (and the polarity it implies) from the record's own active material,
+``kind`` from the record's own active material (never a polarity — which side
+a material sits on is the cell's fact, not the material's),
 rewrites the record files, fixes cross-references (electrode batch -> spec;
 cell-spec ``positive/negative_electrode_spec_id`` and inline-holder
 ``electrode_spec_id``), and prints the old-id -> new-id map.
@@ -32,7 +33,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from battinfo.electrodes import electrode_polarity_for_kind, resolve_electrode_kind
+from battinfo.electrodes import resolve_electrode_kind
 from battinfo.entities import (
     electrode_identity_seed,
     electrode_spec_identity_seed,
@@ -135,9 +136,6 @@ def migrate(source_root: Path, *, write: bool) -> dict[str, str]:
         kind = _resolved_kind(body)
         if kind and body.get("kind") != kind:
             body["kind"] = kind
-        polarity = electrode_polarity_for_kind(kind)
-        if polarity and not body.get("polarity"):
-            body["polarity"] = polarity
         new_uid = _spec_uid(body, kind)
         new_id = f"{_SPEC_BASE}{new_uid}"
         if new_id != old_id:

--- a/src/battinfo/api/_components.py
+++ b/src/battinfo/api/_components.py
@@ -561,7 +561,6 @@ def _electrode_spec_identity_uid(draft: ElectrodeSpecInput, kind_key: str | None
 
 
 def _record_from_electrode_spec(draft: ElectrodeSpecInput) -> dict[str, Any]:
-    from battinfo.electrodes import electrode_polarity_for_kind
 
     kind_key = _resolve_electrode_kind_or_raise(draft.kind, draft.name, draft.product_id)
     if draft.id is not None:
@@ -594,11 +593,10 @@ def _record_from_electrode_spec(draft: ElectrodeSpecInput) -> dict[str, Any]:
     spec.update(draft.body or {})
     if kind_key is not None:
         spec["kind"] = kind_key
-    # Polarity is derived from the kind's family when not authored, so a record
-    # never has to state the same fact twice (and cannot disagree with itself).
-    polarity = draft.polarity or electrode_polarity_for_kind(kind_key)
-    if polarity is not None:
-        spec["polarity"] = polarity
+    # Polarity is authored or absent — never derived from the kind: which side
+    # an active material sits on is the cell's fact, not the material's.
+    if draft.polarity is not None:
+        spec["polarity"] = draft.polarity
     for field_name in ("grade", "active_material_spec_id", "product_id", "description", "comment"):
         value = getattr(draft, field_name)
         if value is not None:

--- a/src/battinfo/data/schemas/electrode-spec.schema.json
+++ b/src/battinfo/data/schemas/electrode-spec.schema.json
@@ -48,7 +48,7 @@
             "negative",
             "unknown"
           ],
-          "description": "Electrode polarity. Derived from the kind's family when not authored (active_cathode -> positive, active_anode -> negative)."
+          "description": "Electrode polarity, authored when the design has a side to state. Never derived from the kind: which side an active material sits on is system-relative (graphite is the positive electrode of a lithium-counter half cell). Role-based cells (half / three-electrode) name electrodes by role instead."
         },
         "grade": {
           "type": "string",

--- a/src/battinfo/data/vocab/material_kinds.json
+++ b/src/battinfo/data/vocab/material_kinds.json
@@ -1,14 +1,22 @@
 {
   "version": "0.3.0",
-  "description": "Curated, shipped vocabulary of generic material kinds (Level 1 of the three-level materials model). A kind is the universal reference identity of a material (graphite, LFP, NMC811, ...): the aggregation axis of the Battery Genome. Every material-spec carries a required `kind`; every material instance links a spec. Each kind's canonical semantic identity is its chemical-substance domain-ontology class IRI (`chemsub`); the battinfo `key` is the ergonomic handle. Kinds missing an ontology class omit `chemsub` and go on the ontology-additions backlog (labeled ns# fallback until upstreamed). This is a governance-by-PR vocabulary, NOT a user-authored record type. `chemsub` values use the domain-chemical-substance namespace (https://w3id.org/emmo/domain/chemical-substance#), verified against release 0.15.0. `emmo` values are the domain-battery class local-name used to type JSON-LD nodes (must resolve in the bundled domain-battery context). `reference_properties` carry curated, citable generic anchors (value/unit/citation) that the genome compares datasheet- and measurement-reported distributions against; present only where a citable source exists. Optional EXTERNAL IDENTITY ANCHORS (`wikidata_qid`, `inchikey`, `pubchem_cid`, `mp_id`, `cas_rn`) tie a kind to the identifier systems the rest of materials science already uses; each is emitted as a `skos:exactMatch` link. They are populated only where the value has been verified — an absent anchor means unverified, never guessed. `mp_id` denotes a representative ORDERED structure in the Materials Project, so solid-solution families (NMC, NCA, LMFP) legitimately carry none. The `family` axis is deliberately minimal — `active_material` or `other`: a material's ROLE (binder, solvent, conductive additive, separator film, ...) is system-relative and is stated where the material is used (coating role slots, electrolyte constituent slots, the component spec that references it), never on the kind. Only the active flag is intrinsic enough to live here: it gates electrode kinds and is where reference anchors like specific capacity attach.",
-  "families": [
+  "description": "Curated, shipped vocabulary of generic material kinds (Level 1 of the three-level materials model). A kind is the universal reference identity of a material (graphite, LFP, NMC811, ...): the aggregation axis of the Battery Genome. Every material-spec carries a required `kind`; every material instance links a spec. Each kind's canonical semantic identity is its chemical-substance domain-ontology class IRI (`chemsub`); the battinfo `key` is the ergonomic handle. Kinds missing an ontology class omit `chemsub` and go on the ontology-additions backlog (labeled ns# fallback until upstreamed). This is a governance-by-PR vocabulary, NOT a user-authored record type. `chemsub` values use the domain-chemical-substance namespace (https://w3id.org/emmo/domain/chemical-substance#), verified against release 0.15.0. `emmo` values are the domain-battery class local-name used to type JSON-LD nodes (must resolve in the bundled domain-battery context). `reference_properties` carry curated, citable generic anchors (value/unit/citation) that the genome compares datasheet- and measurement-reported distributions against; present only where a citable source exists. Optional EXTERNAL IDENTITY ANCHORS (`wikidata_qid`, `inchikey`, `pubchem_cid`, `mp_id`, `cas_rn`) tie a kind to the identifier systems the rest of materials science already uses; each is emitted as a `skos:exactMatch` link. They are populated only where the value has been verified — an absent anchor means unverified, never guessed. `mp_id` denotes a representative ORDERED structure in the Materials Project, so solid-solution families (NMC, NCA, LMFP) legitimately carry none. Each kind carries `roles`: the use-site slots this substance is KNOWN to fill (coating roles, electrolyte constituents, component films/foils/coatings). The list is informative, never normative — it means 'known to serve as', not 'may only serve as': roles are system-relative (FEC is both co-solvent and additive; CMC both binder and thickener), a use outside the listed roles is never an error, and the role a material actually plays in a given cell is stated at the use site. `active_material` is the one load-bearing role: it gates electrode kinds and anchors reference properties. An empty list (NMP) means the kind fills no composition slot at all.",
+  "roles": [
     "active_material",
-    "other"
+    "binder",
+    "conductive_additive",
+    "other_additive",
+    "salt",
+    "solvent",
+    "additive",
+    "separator",
+    "current_collector",
+    "coating"
   ],
   "kinds": {
     "graphite": {
       "label": "Graphite",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303",
       "emmo": "Graphite",
@@ -23,7 +31,7 @@
     },
     "silicon": {
       "label": "Silicon",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "Si",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733",
       "emmo": "Silicon",
@@ -36,7 +44,7 @@
     },
     "silicon_graphite": {
       "label": "Silicon-graphite composite",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "Si/C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3f061928_e90f_4414_9308_d4c843ebb79a",
       "emmo": "SiliconGraphite",
@@ -44,7 +52,7 @@
     },
     "hard_carbon": {
       "label": "Hard carbon",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_5cee19d2_f916_4264_a8ed_efed13a808d2",
       "emmo": "HardCarbon",
@@ -52,7 +60,7 @@
     },
     "lto": {
       "label": "Lithium titanate (LTO)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "Li4Ti5O12",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_acdb232f_8041_4e11_8a11_5db2d2baae4d",
       "emmo": "LithiumTitanate",
@@ -60,7 +68,7 @@
     },
     "lithium_metal": {
       "label": "Lithium metal",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "Li",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c109ca45_08c7_4436_a818_a9c575785e2f",
       "mp_id": "mp-135",
@@ -71,7 +79,7 @@
     },
     "zinc": {
       "label": "Zinc metal",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "Zn",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc",
       "emmo": "Zinc",
@@ -79,7 +87,7 @@
     },
     "lfp": {
       "label": "Lithium iron phosphate (LFP)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiFePO4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90",
       "emmo": "LithiumIronPhosphate",
@@ -93,7 +101,7 @@
     },
     "lmfp": {
       "label": "Lithium manganese iron phosphate (LMFP)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiMnxFe1-xPO4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_40c605fd_4e47_4e90_a055_185f749d834c",
       "emmo": "LithiumManganeseIronPhosphate",
@@ -101,7 +109,7 @@
     },
     "lco": {
       "label": "Lithium cobalt oxide (LCO)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiCoO2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af",
       "emmo": "LithiumCobaltOxide",
@@ -110,7 +118,7 @@
     },
     "lmo": {
       "label": "Lithium manganese oxide (LMO)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiMn2O4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827",
       "emmo": "LithiumManganeseOxide",
@@ -119,7 +127,7 @@
     },
     "lnmo": {
       "label": "Lithium nickel manganese oxide (LNMO)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiNi0.5Mn1.5O4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f3e7979a_e3ef_450a_8762_7d8778afe478",
       "emmo": "LithiumNickelManganeseOxide",
@@ -127,7 +135,7 @@
     },
     "nmc111": {
       "label": "NMC111 (LiNi1/3Mn1/3Co1/3O2)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiNi0.33Mn0.33Co0.33O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_a0b57956_8ba1_4021_ade9_44a87d103d90",
       "emmo": "LithiumNickelManganeseCobaltOxide111",
@@ -135,7 +143,7 @@
     },
     "nmc532": {
       "label": "NMC532 (LiNi0.5Mn0.3Co0.2O2)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiNi0.5Mn0.3Co0.2O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_592acd61_23c8_4a1a_b41b_1eeabedc0710",
       "emmo": "LithiumNickelManganeseCobaltOxide532",
@@ -144,7 +152,7 @@
     },
     "nmc622": {
       "label": "NMC622 (LiNi0.6Mn0.2Co0.2O2)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiNi0.6Mn0.2Co0.2O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_cfcde9c2_3a9c_4add_b27e_0ba0cedf1c70",
       "emmo": "LithiumNickelManganeseCobaltOxide622",
@@ -153,7 +161,7 @@
     },
     "nmc811": {
       "label": "NMC811 (LiNi0.8Mn0.1Co0.1O2)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiNi0.8Mn0.1Co0.1O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_e877987f_3b08_4e21_8f2e_c280e6bef52f",
       "emmo": "LithiumNickelManganeseCobaltOxide811",
@@ -162,7 +170,7 @@
     },
     "nca": {
       "label": "NCA (lithium nickel cobalt aluminium oxide)",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "LiNixCoyAlzO2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_cd17ca33_ae3d_4738_8930_547673bf6c1f",
       "emmo": "LithiumNickelCobaltAluminiumOxide",
@@ -170,14 +178,14 @@
     },
     "mno2": {
       "label": "Manganese dioxide",
-      "family": "active_material",
+      "roles": ["active_material"],
       "formula": "MnO2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618",
       "aliases": ["mno2", "manganese dioxide", "manganese(iv) oxide", "emd"]
     },
     "pvdf": {
       "label": "Polyvinylidene fluoride (PVDF)",
-      "family": "other",
+      "roles": ["binder"],
       "formula": "(C2H2F2)n",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8",
       "emmo": "PolyvinylideneFluoride",
@@ -185,21 +193,21 @@
     },
     "cmc": {
       "label": "Carboxymethyl cellulose (CMC)",
-      "family": "other",
+      "roles": ["binder", "other_additive"],
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51",
       "emmo": "CarboxymethylCellulose",
       "aliases": ["cmc", "carboxymethyl cellulose", "carboxymethylcellulose", "sodium cmc"]
     },
     "sbr": {
       "label": "Styrene-butadiene rubber (SBR)",
-      "family": "other",
+      "roles": ["binder"],
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_210edf30_ad63_438c_97db_f817942db49b",
       "emmo": "StyreneButadiene",
       "aliases": ["sbr", "styrene butadiene rubber", "styrene-butadiene", "styrene-butadiene rubber"]
     },
     "carbon_black": {
       "label": "Carbon black",
-      "family": "other",
+      "roles": ["conductive_additive"],
       "formula": "C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0a5cb747_60cf_4929_a54a_712c54b49f3b",
       "emmo": "CarbonBlack",
@@ -207,7 +215,7 @@
     },
     "lipf6": {
       "label": "Lithium hexafluorophosphate (LiPF6)",
-      "family": "other",
+      "roles": ["salt"],
       "formula": "LiPF6",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771",
       "emmo": "LithiumHexafluorophosphate",
@@ -218,7 +226,7 @@
     },
     "litfsi": {
       "label": "Lithium bis(trifluoromethanesulfonyl)imide (LiTFSI)",
-      "family": "other",
+      "roles": ["salt"],
       "formula": "LiC2F6NO4S2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_8267551d_7572_42f6_888d_96ff0c78f3aa",
       "emmo": "LithiumBistrifluoromethanesulfonylimide",
@@ -226,7 +234,7 @@
     },
     "lifsi": {
       "label": "Lithium bis(fluorosulfonyl)imide (LiFSI)",
-      "family": "other",
+      "roles": ["salt"],
       "formula": "LiF2NO4S2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731",
       "emmo": "LithiumBisfluorosulfonylimide",
@@ -234,7 +242,7 @@
     },
     "koh": {
       "label": "Potassium hydroxide (KOH)",
-      "family": "other",
+      "roles": ["salt"],
       "formula": "KOH",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_ccdce7d4_b695_4871_84c2_13679807d077",
       "emmo": "PotassiumHydroxide",
@@ -242,7 +250,7 @@
     },
     "ec": {
       "label": "Ethylene carbonate (EC)",
-      "family": "other",
+      "roles": ["solvent"],
       "formula": "C3H4O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_57339d90_0553_4a96_8da9_ff6c3684e226",
       "emmo": "EthyleneCarbonate",
@@ -252,7 +260,7 @@
     },
     "emc": {
       "label": "Ethyl methyl carbonate (EMC)",
-      "family": "other",
+      "roles": ["solvent"],
       "formula": "C4H8O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_bb20bdea_343c_4911_8c45_37fc1077d22f",
       "emmo": "EthylMethylCarbonate",
@@ -260,7 +268,7 @@
     },
     "dmc": {
       "label": "Dimethyl carbonate (DMC)",
-      "family": "other",
+      "roles": ["solvent"],
       "formula": "C3H6O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c4a7d7bd_497e_457e_b858_ff73254266d0",
       "emmo": "DimethylCarbonate",
@@ -268,7 +276,7 @@
     },
     "pc": {
       "label": "Propylene carbonate (PC)",
-      "family": "other",
+      "roles": ["solvent"],
       "formula": "C4H6O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156",
       "emmo": "PropyleneCarbonate",
@@ -276,7 +284,7 @@
     },
     "fec": {
       "label": "Fluoroethylene carbonate (FEC)",
-      "family": "other",
+      "roles": ["solvent", "additive"],
       "formula": "C3H3FO3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_20004d19_02cf_4667_a09f_b5c595b44b1f",
       "emmo": "FluoroethyleneCarbonate",
@@ -284,7 +292,7 @@
     },
     "vc": {
       "label": "Vinylene carbonate (VC)",
-      "family": "other",
+      "roles": ["additive"],
       "formula": "C3H2O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_31d0d139_7b45_4d1e_8603_92cc12da2fad",
       "emmo": "VinyleneCarbonate",
@@ -292,7 +300,7 @@
     },
     "polypropylene": {
       "label": "Polypropylene (PP) separator",
-      "family": "other",
+      "roles": ["separator"],
       "formula": "(C3H6)n",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b",
       "emmo": "Polypropylene",
@@ -300,7 +308,7 @@
     },
     "polyethylene": {
       "label": "Polyethylene (PE) separator",
-      "family": "other",
+      "roles": ["separator"],
       "formula": "(C2H4)n",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_79220ea3_3426_47a0_9b41_33012d565fc2",
       "emmo": "Polyethylene",
@@ -308,7 +316,7 @@
     },
     "aluminium": {
       "label": "Aluminium current collector",
-      "family": "other",
+      "roles": ["current_collector"],
       "formula": "Al",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4",
       "emmo": "Aluminium",
@@ -316,7 +324,7 @@
     },
     "copper": {
       "label": "Copper current collector",
-      "family": "other",
+      "roles": ["current_collector"],
       "formula": "Cu",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9",
       "emmo": "Copper",
@@ -324,15 +332,15 @@
     },
     "alumina": {
       "label": "Alumina (Al2O3) coating",
-      "family": "other",
+      "roles": ["coating"],
       "formula": "Al2O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_a2b46543_4d0f_488a_b51a_7ed3a4149170",
       "aliases": ["alumina", "aluminium oxide", "aluminum oxide", "al2o3", "al2o3 particles"]
     },
     "nmp": {
       "label": "N-methyl-2-pyrrolidone (NMP)",
-      "family": "other",
-      "family_note": "Processing solvent (slurry casting), not an electrolyte solvent.",
+      "roles": [],
+      "roles_note": "Processing solvent (slurry casting): fills no composition slot, hence no roles.",
       "formula": "C5H9NO",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c",
       "emmo": "NMethyl2Pyrrolidone",

--- a/src/battinfo/data/vocab/material_kinds.json
+++ b/src/battinfo/data/vocab/material_kinds.json
@@ -1,21 +1,14 @@
 {
-  "version": "0.2.0",
-  "description": "Curated, shipped vocabulary of generic material kinds (Level 1 of the three-level materials model). A kind is the universal reference identity of a material (graphite, LFP, NMC811, ...): the aggregation axis of the Battery Genome. Every material-spec carries a required `kind`; every material instance links a spec. Each kind's canonical semantic identity is its chemical-substance domain-ontology class IRI (`chemsub`); the battinfo `key` is the ergonomic handle. Kinds missing an ontology class omit `chemsub` and go on the ontology-additions backlog (labeled ns# fallback until upstreamed). This is a governance-by-PR vocabulary, NOT a user-authored record type. `chemsub` values use the domain-chemical-substance namespace (https://w3id.org/emmo/domain/chemical-substance#), verified against release 0.15.0. `emmo` values are the domain-battery class local-name used to type JSON-LD nodes (must resolve in the bundled domain-battery context). `reference_properties` carry curated, citable generic anchors (value/unit/citation) that the genome compares datasheet- and measurement-reported distributions against; present only where a citable source exists. Optional EXTERNAL IDENTITY ANCHORS (`wikidata_qid`, `inchikey`, `pubchem_cid`, `mp_id`, `cas_rn`) tie a kind to the identifier systems the rest of materials science already uses; each is emitted as a `skos:exactMatch` link. They are populated only where the value has been verified — an absent anchor means unverified, never guessed. `mp_id` denotes a representative ORDERED structure in the Materials Project, so solid-solution families (NMC, NCA, LMFP) legitimately carry none. NMP is a processing solvent, not an electrolyte solvent; the families enum has no processing-solvent value, so it sits under `other` until one is added.",
+  "version": "0.3.0",
+  "description": "Curated, shipped vocabulary of generic material kinds (Level 1 of the three-level materials model). A kind is the universal reference identity of a material (graphite, LFP, NMC811, ...): the aggregation axis of the Battery Genome. Every material-spec carries a required `kind`; every material instance links a spec. Each kind's canonical semantic identity is its chemical-substance domain-ontology class IRI (`chemsub`); the battinfo `key` is the ergonomic handle. Kinds missing an ontology class omit `chemsub` and go on the ontology-additions backlog (labeled ns# fallback until upstreamed). This is a governance-by-PR vocabulary, NOT a user-authored record type. `chemsub` values use the domain-chemical-substance namespace (https://w3id.org/emmo/domain/chemical-substance#), verified against release 0.15.0. `emmo` values are the domain-battery class local-name used to type JSON-LD nodes (must resolve in the bundled domain-battery context). `reference_properties` carry curated, citable generic anchors (value/unit/citation) that the genome compares datasheet- and measurement-reported distributions against; present only where a citable source exists. Optional EXTERNAL IDENTITY ANCHORS (`wikidata_qid`, `inchikey`, `pubchem_cid`, `mp_id`, `cas_rn`) tie a kind to the identifier systems the rest of materials science already uses; each is emitted as a `skos:exactMatch` link. They are populated only where the value has been verified — an absent anchor means unverified, never guessed. `mp_id` denotes a representative ORDERED structure in the Materials Project, so solid-solution families (NMC, NCA, LMFP) legitimately carry none. The `family` axis is deliberately minimal — `active_material` or `other`: a material's ROLE (binder, solvent, conductive additive, separator film, ...) is system-relative and is stated where the material is used (coating role slots, electrolyte constituent slots, the component spec that references it), never on the kind. Only the active flag is intrinsic enough to live here: it gates electrode kinds and is where reference anchors like specific capacity attach.",
   "families": [
-    "active_anode",
-    "active_cathode",
-    "binder",
-    "conductive_additive",
-    "electrolyte_solvent",
-    "electrolyte_salt",
-    "separator_material",
-    "current_collector_material",
+    "active_material",
     "other"
   ],
   "kinds": {
     "graphite": {
       "label": "Graphite",
-      "family": "active_anode",
+      "family": "active_material",
       "formula": "C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303",
       "emmo": "Graphite",
@@ -30,7 +23,7 @@
     },
     "silicon": {
       "label": "Silicon",
-      "family": "active_anode",
+      "family": "active_material",
       "formula": "Si",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733",
       "emmo": "Silicon",
@@ -43,7 +36,7 @@
     },
     "silicon_graphite": {
       "label": "Silicon-graphite composite",
-      "family": "active_anode",
+      "family": "active_material",
       "formula": "Si/C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_3f061928_e90f_4414_9308_d4c843ebb79a",
       "emmo": "SiliconGraphite",
@@ -51,7 +44,7 @@
     },
     "hard_carbon": {
       "label": "Hard carbon",
-      "family": "active_anode",
+      "family": "active_material",
       "formula": "C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_5cee19d2_f916_4264_a8ed_efed13a808d2",
       "emmo": "HardCarbon",
@@ -59,7 +52,7 @@
     },
     "lto": {
       "label": "Lithium titanate (LTO)",
-      "family": "active_anode",
+      "family": "active_material",
       "formula": "Li4Ti5O12",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_acdb232f_8041_4e11_8a11_5db2d2baae4d",
       "emmo": "LithiumTitanate",
@@ -67,7 +60,7 @@
     },
     "lithium_metal": {
       "label": "Lithium metal",
-      "family": "active_anode",
+      "family": "active_material",
       "formula": "Li",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c109ca45_08c7_4436_a818_a9c575785e2f",
       "mp_id": "mp-135",
@@ -78,7 +71,7 @@
     },
     "zinc": {
       "label": "Zinc metal",
-      "family": "active_anode",
+      "family": "active_material",
       "formula": "Zn",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc",
       "emmo": "Zinc",
@@ -86,7 +79,7 @@
     },
     "lfp": {
       "label": "Lithium iron phosphate (LFP)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiFePO4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90",
       "emmo": "LithiumIronPhosphate",
@@ -100,7 +93,7 @@
     },
     "lmfp": {
       "label": "Lithium manganese iron phosphate (LMFP)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiMnxFe1-xPO4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_40c605fd_4e47_4e90_a055_185f749d834c",
       "emmo": "LithiumManganeseIronPhosphate",
@@ -108,7 +101,7 @@
     },
     "lco": {
       "label": "Lithium cobalt oxide (LCO)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiCoO2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af",
       "emmo": "LithiumCobaltOxide",
@@ -117,7 +110,7 @@
     },
     "lmo": {
       "label": "Lithium manganese oxide (LMO)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiMn2O4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827",
       "emmo": "LithiumManganeseOxide",
@@ -126,7 +119,7 @@
     },
     "lnmo": {
       "label": "Lithium nickel manganese oxide (LNMO)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiNi0.5Mn1.5O4",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f3e7979a_e3ef_450a_8762_7d8778afe478",
       "emmo": "LithiumNickelManganeseOxide",
@@ -134,7 +127,7 @@
     },
     "nmc111": {
       "label": "NMC111 (LiNi1/3Mn1/3Co1/3O2)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiNi0.33Mn0.33Co0.33O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_a0b57956_8ba1_4021_ade9_44a87d103d90",
       "emmo": "LithiumNickelManganeseCobaltOxide111",
@@ -142,7 +135,7 @@
     },
     "nmc532": {
       "label": "NMC532 (LiNi0.5Mn0.3Co0.2O2)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiNi0.5Mn0.3Co0.2O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_592acd61_23c8_4a1a_b41b_1eeabedc0710",
       "emmo": "LithiumNickelManganeseCobaltOxide532",
@@ -151,7 +144,7 @@
     },
     "nmc622": {
       "label": "NMC622 (LiNi0.6Mn0.2Co0.2O2)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiNi0.6Mn0.2Co0.2O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_cfcde9c2_3a9c_4add_b27e_0ba0cedf1c70",
       "emmo": "LithiumNickelManganeseCobaltOxide622",
@@ -160,7 +153,7 @@
     },
     "nmc811": {
       "label": "NMC811 (LiNi0.8Mn0.1Co0.1O2)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiNi0.8Mn0.1Co0.1O2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_e877987f_3b08_4e21_8f2e_c280e6bef52f",
       "emmo": "LithiumNickelManganeseCobaltOxide811",
@@ -169,7 +162,7 @@
     },
     "nca": {
       "label": "NCA (lithium nickel cobalt aluminium oxide)",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "LiNixCoyAlzO2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_cd17ca33_ae3d_4738_8930_547673bf6c1f",
       "emmo": "LithiumNickelCobaltAluminiumOxide",
@@ -177,14 +170,14 @@
     },
     "mno2": {
       "label": "Manganese dioxide",
-      "family": "active_cathode",
+      "family": "active_material",
       "formula": "MnO2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618",
       "aliases": ["mno2", "manganese dioxide", "manganese(iv) oxide", "emd"]
     },
     "pvdf": {
       "label": "Polyvinylidene fluoride (PVDF)",
-      "family": "binder",
+      "family": "other",
       "formula": "(C2H2F2)n",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8",
       "emmo": "PolyvinylideneFluoride",
@@ -192,21 +185,21 @@
     },
     "cmc": {
       "label": "Carboxymethyl cellulose (CMC)",
-      "family": "binder",
+      "family": "other",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51",
       "emmo": "CarboxymethylCellulose",
       "aliases": ["cmc", "carboxymethyl cellulose", "carboxymethylcellulose", "sodium cmc"]
     },
     "sbr": {
       "label": "Styrene-butadiene rubber (SBR)",
-      "family": "binder",
+      "family": "other",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_210edf30_ad63_438c_97db_f817942db49b",
       "emmo": "StyreneButadiene",
       "aliases": ["sbr", "styrene butadiene rubber", "styrene-butadiene", "styrene-butadiene rubber"]
     },
     "carbon_black": {
       "label": "Carbon black",
-      "family": "conductive_additive",
+      "family": "other",
       "formula": "C",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0a5cb747_60cf_4929_a54a_712c54b49f3b",
       "emmo": "CarbonBlack",
@@ -214,7 +207,7 @@
     },
     "lipf6": {
       "label": "Lithium hexafluorophosphate (LiPF6)",
-      "family": "electrolyte_salt",
+      "family": "other",
       "formula": "LiPF6",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771",
       "emmo": "LithiumHexafluorophosphate",
@@ -225,7 +218,7 @@
     },
     "litfsi": {
       "label": "Lithium bis(trifluoromethanesulfonyl)imide (LiTFSI)",
-      "family": "electrolyte_salt",
+      "family": "other",
       "formula": "LiC2F6NO4S2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_8267551d_7572_42f6_888d_96ff0c78f3aa",
       "emmo": "LithiumBistrifluoromethanesulfonylimide",
@@ -233,7 +226,7 @@
     },
     "lifsi": {
       "label": "Lithium bis(fluorosulfonyl)imide (LiFSI)",
-      "family": "electrolyte_salt",
+      "family": "other",
       "formula": "LiF2NO4S2",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731",
       "emmo": "LithiumBisfluorosulfonylimide",
@@ -241,7 +234,7 @@
     },
     "koh": {
       "label": "Potassium hydroxide (KOH)",
-      "family": "electrolyte_salt",
+      "family": "other",
       "formula": "KOH",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_ccdce7d4_b695_4871_84c2_13679807d077",
       "emmo": "PotassiumHydroxide",
@@ -249,7 +242,7 @@
     },
     "ec": {
       "label": "Ethylene carbonate (EC)",
-      "family": "electrolyte_solvent",
+      "family": "other",
       "formula": "C3H4O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_57339d90_0553_4a96_8da9_ff6c3684e226",
       "emmo": "EthyleneCarbonate",
@@ -259,7 +252,7 @@
     },
     "emc": {
       "label": "Ethyl methyl carbonate (EMC)",
-      "family": "electrolyte_solvent",
+      "family": "other",
       "formula": "C4H8O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_bb20bdea_343c_4911_8c45_37fc1077d22f",
       "emmo": "EthylMethylCarbonate",
@@ -267,7 +260,7 @@
     },
     "dmc": {
       "label": "Dimethyl carbonate (DMC)",
-      "family": "electrolyte_solvent",
+      "family": "other",
       "formula": "C3H6O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c4a7d7bd_497e_457e_b858_ff73254266d0",
       "emmo": "DimethylCarbonate",
@@ -275,7 +268,7 @@
     },
     "pc": {
       "label": "Propylene carbonate (PC)",
-      "family": "electrolyte_solvent",
+      "family": "other",
       "formula": "C4H6O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156",
       "emmo": "PropyleneCarbonate",
@@ -283,7 +276,7 @@
     },
     "fec": {
       "label": "Fluoroethylene carbonate (FEC)",
-      "family": "electrolyte_solvent",
+      "family": "other",
       "formula": "C3H3FO3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_20004d19_02cf_4667_a09f_b5c595b44b1f",
       "emmo": "FluoroethyleneCarbonate",
@@ -291,7 +284,7 @@
     },
     "vc": {
       "label": "Vinylene carbonate (VC)",
-      "family": "electrolyte_solvent",
+      "family": "other",
       "formula": "C3H2O3",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_31d0d139_7b45_4d1e_8603_92cc12da2fad",
       "emmo": "VinyleneCarbonate",
@@ -299,7 +292,7 @@
     },
     "polypropylene": {
       "label": "Polypropylene (PP) separator",
-      "family": "separator_material",
+      "family": "other",
       "formula": "(C3H6)n",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b",
       "emmo": "Polypropylene",
@@ -307,7 +300,7 @@
     },
     "polyethylene": {
       "label": "Polyethylene (PE) separator",
-      "family": "separator_material",
+      "family": "other",
       "formula": "(C2H4)n",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_79220ea3_3426_47a0_9b41_33012d565fc2",
       "emmo": "Polyethylene",
@@ -315,7 +308,7 @@
     },
     "aluminium": {
       "label": "Aluminium current collector",
-      "family": "current_collector_material",
+      "family": "other",
       "formula": "Al",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4",
       "emmo": "Aluminium",
@@ -323,7 +316,7 @@
     },
     "copper": {
       "label": "Copper current collector",
-      "family": "current_collector_material",
+      "family": "other",
       "formula": "Cu",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9",
       "emmo": "Copper",
@@ -339,7 +332,7 @@
     "nmp": {
       "label": "N-methyl-2-pyrrolidone (NMP)",
       "family": "other",
-      "family_note": "Processing solvent (slurry casting), not an electrolyte solvent. The families enum has no processing_solvent value yet, so this sits under `other`.",
+      "family_note": "Processing solvent (slurry casting), not an electrolyte solvent.",
       "formula": "C5H9NO",
       "chemsub": "https://w3id.org/emmo/domain/chemical-substance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c",
       "emmo": "NMethyl2Pyrrolidone",

--- a/src/battinfo/electrodes.py
+++ b/src/battinfo/electrodes.py
@@ -21,13 +21,14 @@ from __future__ import annotations
 import re
 from typing import Any
 
-# The one kind family that names an ACTIVE material. A kind outside it (a
-# binder, a salt) is a semantic warning, not a hard error — tolerant import
-# beats a rejected record. The vocabulary deliberately does NOT encode which
-# side an active material sits on: that is system-relative (graphite is the
-# positive electrode of every lithium-counter half cell), so polarity is
-# authored on the electrode or implied by the cell, never derived from the kind.
-ACTIVE_MATERIAL_FAMILY = "active_material"
+# The one load-bearing role in the kind vocabulary. A kind without it (a
+# binder, a salt) is a semantic warning as an electrode kind, not a hard
+# error — tolerant import beats a rejected record. Roles are informative and
+# system-relative; in particular the vocabulary does NOT encode which side an
+# active material sits on (graphite is the positive electrode of every
+# lithium-counter half cell), so polarity is authored on the electrode or
+# implied by the cell, never derived from the kind.
+ACTIVE_MATERIAL_ROLE = "active_material"
 
 #: Polarity -> the EMMO electrode-side class stacked onto an electrode node's
 #: ``@type``. Lives here, in a leaf module, so the JSON-LD emitter and the JSON-LD
@@ -120,7 +121,7 @@ def electrode_kind_keys() -> list[str]:
     """Sorted active-material kind keys — the values ``electrode_spec.kind`` names.
 
     A subset of :func:`battinfo.materials.material_kind_keys`: the kinds whose
-    family is an active-material family. Any material kind resolves on input
+    roles include ``active_material``. Any material kind resolves on input
     (tolerant), but only these are *meaningful* for an electrode, so they are
     what the error messages and docs advertise.
     """
@@ -128,7 +129,7 @@ def electrode_kind_keys() -> list[str]:
 
     kinds = material_kinds().get("kinds", {})
     return sorted(
-        key for key, entry in kinds.items() if entry.get("family") == ACTIVE_MATERIAL_FAMILY
+        key for key, entry in kinds.items() if ACTIVE_MATERIAL_ROLE in (entry.get("roles") or ())
     )
 
 
@@ -144,7 +145,7 @@ def resolve_electrode_kind(value: Any) -> str | None:
 
 
 def electrode_kind(value: Any) -> dict[str, Any] | None:
-    """Vocabulary entry for an electrode kind (label, family, formula, chemsub,
+    """Vocabulary entry for an electrode kind (label, roles, formula, chemsub,
     emmo, aliases, …), or ``None`` for an unknown kind.
 
     Deliberately carries no polarity: which side an active material sits on is
@@ -161,4 +162,4 @@ def electrode_kind(value: Any) -> dict[str, Any] | None:
 def is_active_kind(value: Any) -> bool:
     """True when *value* resolves to a kind in the active-material family."""
     entry = electrode_kind(value)
-    return entry is not None and entry.get("family") == ACTIVE_MATERIAL_FAMILY
+    return entry is not None and ACTIVE_MATERIAL_ROLE in (entry.get("roles") or ())

--- a/src/battinfo/electrodes.py
+++ b/src/battinfo/electrodes.py
@@ -21,13 +21,13 @@ from __future__ import annotations
 import re
 from typing import Any
 
-# Kind families that name an ACTIVE material, and the electrode polarity each
-# implies. A kind outside these families (a binder, a salt) is a semantic
-# warning, not a hard error — tolerant import beats a rejected record.
-ACTIVE_KIND_FAMILIES: dict[str, str] = {
-    "active_cathode": "positive",
-    "active_anode": "negative",
-}
+# The one kind family that names an ACTIVE material. A kind outside it (a
+# binder, a salt) is a semantic warning, not a hard error — tolerant import
+# beats a rejected record. The vocabulary deliberately does NOT encode which
+# side an active material sits on: that is system-relative (graphite is the
+# positive electrode of every lithium-counter half cell), so polarity is
+# authored on the electrode or implied by the cell, never derived from the kind.
+ACTIVE_MATERIAL_FAMILY = "active_material"
 
 #: Polarity -> the EMMO electrode-side class stacked onto an electrode node's
 #: ``@type``. Lives here, in a leaf module, so the JSON-LD emitter and the JSON-LD
@@ -128,7 +128,7 @@ def electrode_kind_keys() -> list[str]:
 
     kinds = material_kinds().get("kinds", {})
     return sorted(
-        key for key, entry in kinds.items() if entry.get("family") in ACTIVE_KIND_FAMILIES
+        key for key, entry in kinds.items() if entry.get("family") == ACTIVE_MATERIAL_FAMILY
     )
 
 
@@ -144,28 +144,21 @@ def resolve_electrode_kind(value: Any) -> str | None:
 
 
 def electrode_kind(value: Any) -> dict[str, Any] | None:
-    """Vocabulary entry for an electrode kind, with its derived ``polarity``.
+    """Vocabulary entry for an electrode kind (label, family, formula, chemsub,
+    emmo, aliases, …), or ``None`` for an unknown kind.
 
-    Returns the material-kind entry (label, family, formula, chemsub, emmo,
-    aliases, …) plus ``polarity``, which is ``"positive"``/``"negative"`` for an
-    active family and ``None`` otherwise.
+    Deliberately carries no polarity: which side an active material sits on is
+    a fact about the cell it is built into, not about the material.
     """
     from battinfo.materials import material_kind
 
     entry = material_kind(value)
     if entry is None:
         return None
-    resolved = dict(entry)
-    resolved["polarity"] = ACTIVE_KIND_FAMILIES.get(str(entry.get("family")))
-    return resolved
-
-
-def electrode_polarity_for_kind(value: Any) -> str | None:
-    """Polarity implied by an electrode kind, or ``None`` when it implies none."""
-    entry = electrode_kind(value)
-    return entry.get("polarity") if entry is not None else None
+    return dict(entry)
 
 
 def is_active_kind(value: Any) -> bool:
-    """True when *value* resolves to a kind in an active-material family."""
-    return electrode_polarity_for_kind(value) is not None
+    """True when *value* resolves to a kind in the active-material family."""
+    entry = electrode_kind(value)
+    return entry is not None and entry.get("family") == ACTIVE_MATERIAL_FAMILY

--- a/src/battinfo/materials.py
+++ b/src/battinfo/materials.py
@@ -37,7 +37,7 @@ def _load_material_kinds_file() -> dict[str, Any]:
     if asset_path.is_file():
         with asset_path.open("r", encoding="utf-8") as handle:
             return json.load(handle)
-    return {"version": "0", "families": [], "kinds": {}}
+    return {"version": "0", "roles": [], "kinds": {}}
 
 
 @lru_cache(maxsize=1)
@@ -64,8 +64,8 @@ def _material_kind_alias_index() -> dict[str, str]:
 def material_kinds() -> dict[str, Any]:
     """Return the curated MaterialKind vocabulary (Level 1), as a deep copy.
 
-    Shape: ``{"version", "families": [...], "kinds": {"<key>": {"label",
-    "family", "formula"?, "chemsub"?, "emmo"?, "aliases": [...],
+    Shape: ``{"version", "roles": [...], "kinds": {"<key>": {"label",
+    "roles": [...], "formula"?, "chemsub"?, "emmo"?, "aliases": [...],
     "reference_properties"?}}}``. ``chemsub`` is the material's canonical
     semantic identity — its chemical-substance domain-ontology class IRI.
     """

--- a/src/battinfo/validate/semantic.py
+++ b/src/battinfo/validate/semantic.py
@@ -582,24 +582,10 @@ def _validate_electrode_kind(
             resource_type=resource_type,
         )
         return
-    # Polarity and kind must agree: an LFP anode is a typo, not a design.
-    from battinfo.electrodes import electrode_polarity_for_kind
-
-    polarity = spec.get("polarity")
-    implied = electrode_polarity_for_kind(kind)
-    if isinstance(polarity, str) and polarity in ("positive", "negative") and polarity != implied:
-        _append_issue(
-            issues,
-            code="semantic.electrode_polarity_conflict",
-            severity="warning",
-            path="electrode_spec.polarity",
-            message=(
-                f"polarity '{polarity}' disagrees with kind '{kind}', which is a "
-                f"{implied} active material. Drop the polarity to let it be derived, "
-                "or correct one of the two."
-            ),
-            resource_type=resource_type,
-        )
+    # No kind-vs-polarity check: the vocabulary no longer assigns a side to an
+    # active material (system-relative — graphite is the positive electrode of
+    # a lithium-counter half cell), so an authored polarity cannot conflict
+    # with the kind.
 
 
 def _validate_size_code(

--- a/tests/test_deposit_coverage.py
+++ b/tests/test_deposit_coverage.py
@@ -243,7 +243,9 @@ def test_electrode_nodes_carry_their_full_emission() -> None:
     spec_node = by_id[_record_iri(record_sets["electrode-spec"][0])]
     types = spec_node["@type"] if isinstance(spec_node["@type"], list) else [spec_node["@type"]]
     assert "GraphiteElectrode" in types, types           # chemistry from the kind
-    assert "NegativeElectrode" in types, types           # polarity derived from the kind
+    # No polarity class: the vocabulary assigns no side to an active material
+    # (system-relative), so an unauthored polarity emits nothing.
+    assert "NegativeElectrode" not in types, types
     assert spec_node["hasProperty"]["@type"][0] == "AreicCapacity"
 
     batch_node = by_id[_record_iri(record_sets["electrode"][0])]

--- a/tests/test_electrodes_first_class.py
+++ b/tests/test_electrodes_first_class.py
@@ -23,7 +23,6 @@ import battinfo
 import battinfo.api as api
 from battinfo.electrodes import (
     electrode_kind_keys,
-    electrode_polarity_for_kind,
     is_active_kind,
     resolve_electrode_kind,
 )
@@ -115,13 +114,17 @@ def test_advertised_kinds_are_the_active_materials() -> None:
     assert all(is_active_kind(k) for k in keys)
 
 
-def test_polarity_is_derived_from_the_kind() -> None:
-    assert electrode_polarity_for_kind("lfp") == "positive"
-    assert electrode_polarity_for_kind("graphite") == "negative"
-    assert electrode_polarity_for_kind("pvdf") is None
+def test_polarity_is_authored_never_derived() -> None:
+    # The vocabulary assigns no side to an active material (system-relative:
+    # graphite is the positive electrode of a lithium-counter half cell), so a
+    # spec carries polarity only when its author states it.
+    spec = api.create_electrode_spec(name="LFP electrode", kind="lfp", validate=False)
+    assert "polarity" not in spec["electrode_spec"]
 
-    spec = api.create_electrode_spec(name="LFP cathode", kind="lfp", validate=False)
-    assert spec["electrode_spec"]["polarity"] == "positive"
+    authored = api.create_electrode_spec(
+        name="LFP positive electrode", kind="lfp", polarity="positive", validate=False
+    )
+    assert authored["electrode_spec"]["polarity"] == "positive"
 
 
 def test_unknown_kind_rejected_with_helpful_message() -> None:
@@ -151,13 +154,16 @@ def test_non_active_kind_warns_rather_than_failing() -> None:
     assert issue.severity == "warning"
 
 
-def test_polarity_conflicting_with_kind_warns() -> None:
+def test_authored_polarity_never_conflicts_with_the_kind() -> None:
+    # Retired check: with no vocabulary-assigned side there is nothing for an
+    # authored polarity to disagree with (an "LFP negative electrode" is a
+    # legitimate design in a lithium-counter half cell).
     from battinfo.validate.semantic import validate_semantic_report
 
-    spec = api.create_electrode_spec(uid="abcd23456789abcd", name="LFP anode?", kind="lfp",
-                                     polarity="negative", validate=False)
+    spec = api.create_electrode_spec(uid="abcd23456789abcd", name="LFP working electrode",
+                                     kind="lfp", polarity="negative", validate=False)
     report = validate_semantic_report(spec, policy="default")
-    assert any(i.code == "semantic.electrode_polarity_conflict" for i in report.issues)
+    assert not any(i.code == "semantic.electrode_polarity_conflict" for i in report.issues)
 
 
 def test_purchased_electrode_needs_no_material_spec() -> None:
@@ -239,14 +245,15 @@ def test_electrode_schemas_permit_attribution() -> None:
 
 # ── Emission ──────────────────────────────────────────────────────────────────
 
-def test_kind_types_the_node_with_the_chemistry_and_polarity_classes() -> None:
+def test_kind_types_the_node_and_authored_polarity_stacks() -> None:
     from battinfo.jsonld import record_to_jsonld
 
-    spec = api.create_electrode_spec(name="Si-Gr anode", kind="silicon_graphite", validate=False)
-    ld = record_to_jsonld(spec, "electrode-spec")
-    assert ld["@type"] == ["SiliconGraphiteElectrode", "NegativeElectrode"]
+    spec = api.create_electrode_spec(name="Si-Gr electrode", kind="silicon_graphite", validate=False)
+    assert record_to_jsonld(spec, "electrode-spec")["@type"] == "SiliconGraphiteElectrode"
 
-    cathode = api.create_electrode_spec(name="LFP cathode", kind="lfp", validate=False)
+    cathode = api.create_electrode_spec(
+        name="LFP positive electrode", kind="lfp", polarity="positive", validate=False
+    )
     assert record_to_jsonld(cathode, "electrode-spec")["@type"] == [
         "LithiumIronPhosphateElectrode", "PositiveElectrode",
     ]
@@ -267,9 +274,12 @@ def test_every_electrode_kind_types_the_node() -> None:
         spec = api.create_electrode_spec(name=f"{kind} electrode", kind=kind, validate=False)
         types = record_to_jsonld(spec, "electrode-spec")["@type"]
         if kind in chemistry_free:
-            assert types == "PositiveElectrode", f"{kind} typed as {types}"
+            # No chemistry electrode class (deliberate; NCA chemistry lives on
+            # the cell's battery class) and no vocabulary-assigned side: the
+            # generic Electrode class keeps the node typed.
+            assert types == "Electrode", f"{kind} typed as {types}"
             continue
-        assert isinstance(types, list) and len(types) == 2, f"{kind} typed only as {types}"
+        assert types and "Electrode" in str(types), f"{kind} untyped: {types}"
 
 
 def test_active_material_reference_emits_as_a_linked_node() -> None:

--- a/tests/test_materials_first_class.py
+++ b/tests/test_materials_first_class.py
@@ -210,7 +210,7 @@ def test_anchor_fields_stay_inside_the_declared_set() -> None:
     """A typo'd anchor key would silently emit nothing; pin the field names."""
     from battinfo.materials import EXTERNAL_ID_FIELDS, EXTERNAL_ID_IRI_TEMPLATES
 
-    known = {"label", "family", "family_note", "formula", "chemsub", "emmo",
+    known = {"label", "roles", "roles_note", "formula", "chemsub", "emmo",
              "aliases", "reference_properties", *EXTERNAL_ID_FIELDS}
     for key, entry in battinfo.material_kinds()["kinds"].items():
         unexpected = set(entry) - known

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -4038,7 +4038,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
                 "negative",
                 "unknown"
               ],
-              "description": "Electrode polarity. Derived from the kind's family when not authored (active_cathode -> positive, active_anode -> negative)."
+              "description": "Electrode polarity, authored when the design has a side to state. Never derived from the kind: which side an active material sits on is system-relative (graphite is the positive electrode of a lithium-counter half cell). Role-based cells (half / three-electrode) name electrodes by role instead."
             },
             "grade": {
               "type": "string",


### PR DESCRIPTION
## What

The material-kind vocabulary's single-valued `family` becomes multi-valued `roles` (vocabulary 0.2.0 → 0.3.0): the list of use-site slot names a substance is known to fill — coating roles (`active_material`, `binder`, `conductive_additive`, `other_additive`), electrolyte constituents (`salt`, `solvent`, `additive`), and component films/foils/coatings (`separator`, `current_collector`, `coating`). Multi-role facts are finally expressible: FEC is `[solvent, additive]`, CMC `[binder, other_additive]`. Curation fixes ride along: VC refiles from solvent to additive; NMP carries an empty list (a processing solvent fills no composition slot).

With the anode/cathode sides gone, the polarity-derivation chain retires: `create_electrode_spec` stamps `polarity` only when authored, emitted `@type` carries a polarity class only for authored polarity, `semantic.electrode_polarity_conflict` is removed, and `electrode_polarity_for_kind` (never exported from the package root) is gone.

## Why

Roles are system-relative — graphite is the positive electrode of every lithium-counter half cell, LTO flips between chemistries, carbon black was the sole member of its category — so a single forced classification was wrong twice over: it took sides, and it took exactly one. The corpus review already fought the derivation and won (ruling B3); this makes that the default. Three guardrails hold the design: the list is informative, never normative (no conflict checks — that mistake is not re-imported in list form); the role vocabulary is exactly the use-site slot names that already exist, so there is no new taxonomy to maintain; and `roles` replaces `family` outright rather than sitting beside it.

## How

Vocabulary values, enum, and description; `electrodes.py` keys on `"active_material" in roles` (`electrode_kind_keys`, `is_active_kind`); `api/_components.py` authored-polarity-only; the conflict check retired in `validate/semantic.py`; `scripts/migrate_electrode_ids.py` stops backfilling polarity. Identity seeds never contained polarity, so no IRI moves. Tests pin the new semantics (an unauthored electrode spec emits its chemistry class alone; `nca` falls back to the generic `Electrode`; an "LFP negative electrode" no longer warns). The reference-records chapter regenerated — the electrodes exemplar visibly loses its derived polarity, the drift gate doing its job.

Merge-order note: #381 (half-cells page) regenerates the same chapter — whichever lands second reruns `gen_reference_records.py` (the drift test forces it).

**After merge:** the registry re-vendors `material_kinds.json` (display data only; no registry code reads the field). **Deliberately untouched, as the separate ruled follow-up:** the record-level `material_class` enum and the material-spec `electrode_polarity` field — the same critique applies, but they are published schema (migration + re-vendor + live records).

## Testing

Full suite 2072 passed / 0 failed (one known ingest flake passed on rerun); ruff clean; reference-records drift test green against the regenerated chapter.