### PR TITLE
Polarity leaves the material record; material_class deprecates to the kind's roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`material_spec.electrode_polarity` and `material_spec.material_class`.**
+  Polarity is an electrode property, never a material's, so
+  `electrode_polarity` loses its authoring path entirely: the API kwarg is
+  removed, the embedded-to-standalone bridge and `extract_material_specs`
+  stop stamping it, and the packaged examples drop it — the schema accepts
+  the key only so existing records keep validating. `material_class` is
+  deprecated in favor of the kind's `roles` (strictly better information,
+  multi-valued, curated); it stays accepted and importers still write it,
+  slated for removal at the next record-shape version. The parameter-set
+  claim scope named `electrode_polarity` is unrelated (it describes the
+  electrode context of a measurement) and is retained.
+
 ### Changed
 
 - **Material kinds carry `roles` (a list), replacing the single-valued

--- a/assets/schemas/material-spec.schema.json
+++ b/assets/schemas/material-spec.schema.json
@@ -62,7 +62,7 @@
             "dispersant",
             "other"
           ],
-          "description": "Functional role of this material in a cell, used for querying."
+          "description": "Deprecated in favor of the kind’s roles (the curated vocabulary lists the use-site slots a kind is known to fill): a single forced role is system-relative. Accepted for back-compat and still written by importers; slated for removal at the next record-shape version."
         },
         "electrode_polarity": {
           "type": "string",
@@ -71,7 +71,7 @@
             "negative",
             "none"
           ],
-          "description": "For active materials: the electrode polarity this material is typically used at."
+          "description": "Deprecated, do not author: polarity is an electrode property, never a material’s — state it on the electrode or through the cell’s holders. Accepted only so existing records keep validating."
         },
         "formula": {
           "type": "string",

--- a/docs/howto/build-a-cell-from-components.md
+++ b/docs/howto/build-a-cell-from-components.md
@@ -23,15 +23,13 @@ def material(name, **kw):
     return save_material_spec(create_material_spec(name=name, **kw),
                               source_root=LAB, mode="upsert")["id"]
 
-NMC811_IRI   = material("NMC811", material_class="active_material",
-                        electrode_polarity="positive", formula="LiNi0.8Mn0.1Co0.1O2")
-GRAPHITE_IRI = material("Graphite", material_class="active_material",
-                        electrode_polarity="negative", formula="C")
-PVDF_IRI     = material("PVDF", material_class="binder", formula="(C2H2F2)n")
-CB_IRI       = material("Carbon black", material_class="conductive_additive", formula="C")
-LIPF6_IRI    = material("LiPF6", material_class="electrolyte_salt", formula="LiPF6")
-EC_IRI       = material("EC", material_class="electrolyte_solvent", formula="C3H4O3")
-EMC_IRI      = material("EMC", material_class="electrolyte_solvent", formula="C4H8O3")
+NMC811_IRI   = material("NMC811", kind="nmc811", formula="LiNi0.8Mn0.1Co0.1O2")
+GRAPHITE_IRI = material("Graphite", kind="graphite", formula="C")
+PVDF_IRI     = material("PVDF", kind="pvdf", formula="(C2H2F2)n")
+CB_IRI       = material("Carbon black", kind="carbon_black", formula="C")
+LIPF6_IRI    = material("LiPF6", kind="lipf6", formula="LiPF6")
+EC_IRI       = material("EC", kind="ec", formula="C3H4O3")
+EMC_IRI      = material("EMC", kind="emc", formula="C4H8O3")
 ```
 
 (electrode-recipe)=

--- a/docs/howto/register-materials.md
+++ b/docs/howto/register-materials.md
@@ -5,8 +5,8 @@ Five lines per material — create it, save it into your library, keep the IRI:
 ```python
 from battinfo.api import create_material_spec, save_material_spec
 
-nmc = create_material_spec(name="NMC811", material_class="active_material",
-                           electrode_polarity="positive", formula="LiNi0.8Mn0.1Co0.1O2")
+nmc = create_material_spec(name="NMC811", kind="nmc811",
+                           formula="LiNi0.8Mn0.1Co0.1O2")
 saved = save_material_spec(nmc, source_root="my-library", mode="upsert")
 NMC811_IRI = saved["id"]   # e.g. https://w3id.org/battinfo/spec/3ypr-gngx-x28c-rarf
 ```
@@ -18,29 +18,25 @@ duplicate.
 
 ## Variants
 
-A binder, a conductive additive, a salt, a solvent — same five lines, different
-`material_class`:
+A binder, a salt — same five lines, different `kind`. The curated kind
+carries the material's identity and its known roles; the role a material
+plays in a given cell is stated where it is used:
 
 ```python
 pvdf = save_material_spec(create_material_spec(
-    name="PVDF", material_class="binder", formula="(C2H2F2)n"),
+    name="PVDF", kind="pvdf", formula="(C2H2F2)n"),
     source_root="my-library", mode="upsert")
 
 salt = save_material_spec(create_material_spec(
-    name="LiPF6", material_class="electrolyte_salt", formula="LiPF6"),
+    name="LiPF6", kind="lipf6", formula="LiPF6"),
     source_root="my-library", mode="upsert")
 ```
-
-Valid `material_class` values: `active_material`, `binder`,
-`conductive_additive`, `current_collector`, `separator_material`,
-`electrolyte_salt`, `electrolyte_solvent`, `electrolyte_additive`,
-`metal_electrode`, `coating`, `other`.
 
 With a manufacturer and a datasheet number:
 
 ```python
 graphite = save_material_spec(create_material_spec(
-    name="Graphite", material_class="active_material", electrode_polarity="negative",
+    name="Graphite", kind="graphite",
     formula="C", manufacturer="Targray",
     property={"specific_capacity": {"value": 355, "unit": "mAh/g"}}),
     source_root="my-library", mode="upsert")

--- a/docs/records/_fragments/materials-notes.md
+++ b/docs/records/_fragments/materials-notes.md
@@ -6,6 +6,6 @@
 
 **The embedded ↔ standalone bridge.** A material described inline in a composition can be lifted to a standalone spec (`material_spec_from_component`) and a cell's inline holders decomposed and de-duplicated (`extract_material_specs`), so starting embedded never blocks graduating to first-class records.
 
-**One caveat pending review:** the record-level `electrode_polarity` field remains in the schema, but a material has no side of its own — prefer leaving it unset; the side belongs to the cell that uses the material.
+**Two deprecated record fields.** `electrode_polarity` is deprecated and has no authoring path: polarity is an electrode property, never a material's — the schema accepts the key only so existing records keep validating. `material_class` is deprecated in favor of the kind's `roles`: a single forced role is system-relative, and the kind carries strictly better information; the field stays accepted (importers still write it) until the next record-shape version.
 
 **Governance:** the vocabulary changes by PR only; tests pin that each kind's `emmo` class resolves in the bundled context and names the same substance as its `chemsub` anchor.

--- a/docs/records/materials.md
+++ b/docs/records/materials.md
@@ -27,7 +27,6 @@ record = create_material_spec(
     uid="7d9k-2m4p-8t3x-6nq5",
     name="NMC811 cathode powder",
     kind="nmc811",                     # Level-1 key from the curated vocabulary
-    material_class="active_material",
     source_type="datasheet",
 )
 ```
@@ -41,8 +40,7 @@ record = create_material_spec(
     "id": "https://w3id.org/battinfo/spec/7d9k-2m4p-8t3x-6nq5",
     "short_id": "7d9k2m",
     "name": "NMC811 cathode powder",
-    "kind": "nmc811",
-    "material_class": "active_material"
+    "kind": "nmc811"
   },
   "provenance": {
     "source_type": "datasheet",
@@ -1188,8 +1186,8 @@ Schema: [`material-spec.schema.json`](https://w3id.org/battinfo/schema/material-
 | `name` | string | yes | Human-readable material name / grade (e.g. 'LFP', 'Graphite', 'NMC811', 'PVDF'). |
 | `kind` | string |  | Required Level-1 MaterialKind key from the curated material_kinds vocabulary (e.g. 'graphite', 'lfp', 'nmc811'). The aggregation axis of the Battery Genome; resolves to the kind's chemical-substance class IRI. An unknown kind is rejected at save time. See battinfo.materials.material_kind_keys(). |
 | `grade` | string |  | Manufacturer grade / product version (e.g. 'grade X', 'v2'). Part of spec identity together with manufacturer and product. |
-| `material_class` | `active_material` \| `binder` \| `conductive_additive` \| `current_collector` … (13 values) |  | Functional role of this material in a cell, used for querying. |
-| `electrode_polarity` | `positive` \| `negative` \| `none` |  | For active materials: the electrode polarity this material is typically used at. |
+| `material_class` | `active_material` \| `binder` \| `conductive_additive` \| `current_collector` … (13 values) |  | Deprecated in favor of the kind’s roles (the curated vocabulary lists the use-site slots a kind is known to fill): a single forced role is system-relative. Accepted for back-compat and still written by importers; slated for removal at the next record-shape version. |
+| `electrode_polarity` | `positive` \| `negative` \| `none` |  | Deprecated, do not author: polarity is an electrode property, never a material’s — state it on the electrode or through the cell’s holders. Accepted only so existing records keep validating. |
 | `formula` | string |  | Chemical formula or idealized composition (e.g. 'LiFePO4', 'C', 'Zn', '(C2H2F2)n'). |
 | `chemistry_family` | string |  | Coarse chemistry family label (e.g. 'olivine', 'layered-oxide', 'spinel', 'graphitic-carbon'). |
 | `emmo_type` | string |  | Optional EMMO/domain-battery class label or IRI for this material; informs JSON-LD @type. |
@@ -1237,7 +1235,7 @@ Schema: [`material.schema.json`](https://w3id.org/battinfo/schema/material.schem
 
 **The embedded ↔ standalone bridge.** A material described inline in a composition can be lifted to a standalone spec (`material_spec_from_component`) and a cell's inline holders decomposed and de-duplicated (`extract_material_specs`), so starting embedded never blocks graduating to first-class records.
 
-**One caveat pending review:** the record-level `electrode_polarity` field remains in the schema, but a material has no side of its own — prefer leaving it unset; the side belongs to the cell that uses the material.
+**Two deprecated record fields.** `electrode_polarity` is deprecated and has no authoring path: polarity is an electrode property, never a material's — the schema accepts the key only so existing records keep validating. `material_class` is deprecated in favor of the kind's `roles`: a single forced role is system-relative, and the kind carries strictly better information; the field stays accepted (importers still write it) until the next record-shape version.
 
 **Governance:** the vocabulary changes by PR only; tests pin that each kind's `emmo` class resolves in the bundled context and names the same substance as its `chemsub` anchor.
 :::

--- a/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
+++ b/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
@@ -6,7 +6,6 @@
     "name": "LFP",
     "kind": "lfp",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiFePO4",
     "chemistry_family": "olivine",
     "manufacturer": {

--- a/examples/material-spec/83bd-jmk7-2x47-s04a.json
+++ b/examples/material-spec/83bd-jmk7-2x47-s04a.json
@@ -6,7 +6,6 @@
     "name": "LNMO",
     "kind": "lnmo",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.5Mn1.5O4",
     "chemistry_family": "spinel",
     "property": {

--- a/examples/material-spec/8y74-2v75-76kr-t9by.json
+++ b/examples/material-spec/8y74-2v75-76kr-t9by.json
@@ -6,7 +6,6 @@
     "name": "Al2O3-coated NMC811",
     "kind": "nmc811",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
+++ b/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
@@ -6,7 +6,6 @@
     "name": "MnO2",
     "kind": "mno2",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "MnO2",
     "chemistry_family": "manganese-oxide",
     "property": {

--- a/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
+++ b/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
@@ -6,7 +6,6 @@
     "name": "Graphite",
     "kind": "graphite",
     "material_class": "active_material",
-    "electrode_polarity": "negative",
     "formula": "C",
     "chemistry_family": "graphitic-carbon",
     "manufacturer": {

--- a/examples/material-spec/jnab-ggw9-cbn8-hhjr.json
+++ b/examples/material-spec/jnab-ggw9-cbn8-hhjr.json
@@ -6,7 +6,6 @@
     "name": "Silicon-graphite composite",
     "kind": "silicon_graphite",
     "material_class": "active_material",
-    "electrode_polarity": "negative",
     "formula": "Si/C",
     "property": {
       "specific_capacity": {

--- a/examples/material-spec/kg0e-vqce-3439-bnfk.json
+++ b/examples/material-spec/kg0e-vqce-3439-bnfk.json
@@ -6,7 +6,6 @@
     "name": "Zinc",
     "kind": "zinc",
     "material_class": "metal_electrode",
-    "electrode_polarity": "negative",
     "formula": "Zn",
     "chemistry_family": "metal",
     "property": {

--- a/examples/material-spec/npa4-0dnw-evyh-hhdm.json
+++ b/examples/material-spec/npa4-0dnw-evyh-hhdm.json
@@ -6,7 +6,6 @@
     "name": "NMC811",
     "kind": "nmc811",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/examples/material-spec/qwae-x6cg-c61k-njw7.json
+++ b/examples/material-spec/qwae-x6cg-c61k-njw7.json
@@ -6,7 +6,6 @@
     "name": "LMFP",
     "kind": "lmfp",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiMn0.7Fe0.3PO4",
     "chemistry_family": "olivine",
     "manufacturer": {

--- a/examples/material-spec/s2m9-ksma-nb61-8tpa.json
+++ b/examples/material-spec/s2m9-ksma-nb61-8tpa.json
@@ -6,7 +6,6 @@
     "name": "NMC622",
     "kind": "nmc622",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.6Mn0.2Co0.2O2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/examples/material-spec/shzh-t2jt-wwqv-k54m.json
+++ b/examples/material-spec/shzh-t2jt-wwqv-k54m.json
@@ -6,7 +6,6 @@
     "name": "LCO",
     "kind": "lco",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiCoO2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/scripts/gen_reference_records.py
+++ b/scripts/gen_reference_records.py
@@ -137,7 +137,6 @@ def snippet_material_spec():
         uid="7d9k-2m4p-8t3x-6nq5",
         name="NMC811 cathode powder",
         kind="nmc811",                     # Level-1 key from the curated vocabulary
-        material_class="active_material",
         source_type="datasheet",
     )
     return record

--- a/src/battinfo/api/_components.py
+++ b/src/battinfo/api/_components.py
@@ -57,7 +57,6 @@ class MaterialSpecInput(BaseModel):
     kind: str | None = None
     grade: str | None = None
     material_class: str | None = None
-    electrode_polarity: str | None = None
     formula: str | None = None
     chemistry_family: str | None = None
     emmo_type: str | None = None
@@ -287,7 +286,6 @@ def _record_from_material_spec(draft: MaterialSpecInput) -> dict[str, Any]:
         spec["grade"] = draft.grade
     for field_name in (
         "material_class",
-        "electrode_polarity",
         "formula",
         "chemistry_family",
         "emmo_type",

--- a/src/battinfo/data/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
+++ b/src/battinfo/data/examples/material-spec/5ms1-9jv8-hr54-mn4e.json
@@ -6,7 +6,6 @@
     "name": "LFP",
     "kind": "lfp",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiFePO4",
     "chemistry_family": "olivine",
     "manufacturer": {

--- a/src/battinfo/data/examples/material-spec/83bd-jmk7-2x47-s04a.json
+++ b/src/battinfo/data/examples/material-spec/83bd-jmk7-2x47-s04a.json
@@ -6,7 +6,6 @@
     "name": "LNMO",
     "kind": "lnmo",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.5Mn1.5O4",
     "chemistry_family": "spinel",
     "property": {

--- a/src/battinfo/data/examples/material-spec/8y74-2v75-76kr-t9by.json
+++ b/src/battinfo/data/examples/material-spec/8y74-2v75-76kr-t9by.json
@@ -6,7 +6,6 @@
     "name": "Al2O3-coated NMC811",
     "kind": "nmc811",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/src/battinfo/data/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
+++ b/src/battinfo/data/examples/material-spec/fwnh-2wkq-n9wm-fdab.json
@@ -6,7 +6,6 @@
     "name": "MnO2",
     "kind": "mno2",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "MnO2",
     "chemistry_family": "manganese-oxide",
     "property": {

--- a/src/battinfo/data/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
+++ b/src/battinfo/data/examples/material-spec/gwck-k5kf-ae1f-gfgc.json
@@ -6,7 +6,6 @@
     "name": "Graphite",
     "kind": "graphite",
     "material_class": "active_material",
-    "electrode_polarity": "negative",
     "formula": "C",
     "chemistry_family": "graphitic-carbon",
     "manufacturer": {

--- a/src/battinfo/data/examples/material-spec/jnab-ggw9-cbn8-hhjr.json
+++ b/src/battinfo/data/examples/material-spec/jnab-ggw9-cbn8-hhjr.json
@@ -6,7 +6,6 @@
     "name": "Silicon-graphite composite",
     "kind": "silicon_graphite",
     "material_class": "active_material",
-    "electrode_polarity": "negative",
     "formula": "Si/C",
     "property": {
       "specific_capacity": {

--- a/src/battinfo/data/examples/material-spec/kg0e-vqce-3439-bnfk.json
+++ b/src/battinfo/data/examples/material-spec/kg0e-vqce-3439-bnfk.json
@@ -6,7 +6,6 @@
     "name": "Zinc",
     "kind": "zinc",
     "material_class": "metal_electrode",
-    "electrode_polarity": "negative",
     "formula": "Zn",
     "chemistry_family": "metal",
     "property": {

--- a/src/battinfo/data/examples/material-spec/npa4-0dnw-evyh-hhdm.json
+++ b/src/battinfo/data/examples/material-spec/npa4-0dnw-evyh-hhdm.json
@@ -6,7 +6,6 @@
     "name": "NMC811",
     "kind": "nmc811",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.8Mn0.1Co0.1O2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/src/battinfo/data/examples/material-spec/qwae-x6cg-c61k-njw7.json
+++ b/src/battinfo/data/examples/material-spec/qwae-x6cg-c61k-njw7.json
@@ -6,7 +6,6 @@
     "name": "LMFP",
     "kind": "lmfp",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiMn0.7Fe0.3PO4",
     "chemistry_family": "olivine",
     "manufacturer": {

--- a/src/battinfo/data/examples/material-spec/s2m9-ksma-nb61-8tpa.json
+++ b/src/battinfo/data/examples/material-spec/s2m9-ksma-nb61-8tpa.json
@@ -6,7 +6,6 @@
     "name": "NMC622",
     "kind": "nmc622",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiNi0.6Mn0.2Co0.2O2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/src/battinfo/data/examples/material-spec/shzh-t2jt-wwqv-k54m.json
+++ b/src/battinfo/data/examples/material-spec/shzh-t2jt-wwqv-k54m.json
@@ -6,7 +6,6 @@
     "name": "LCO",
     "kind": "lco",
     "material_class": "active_material",
-    "electrode_polarity": "positive",
     "formula": "LiCoO2",
     "chemistry_family": "layered-oxide",
     "manufacturer": {

--- a/src/battinfo/data/schemas/material-spec.schema.json
+++ b/src/battinfo/data/schemas/material-spec.schema.json
@@ -62,7 +62,7 @@
             "dispersant",
             "other"
           ],
-          "description": "Functional role of this material in a cell, used for querying."
+          "description": "Deprecated in favor of the kind’s roles (the curated vocabulary lists the use-site slots a kind is known to fill): a single forced role is system-relative. Accepted for back-compat and still written by importers; slated for removal at the next record-shape version."
         },
         "electrode_polarity": {
           "type": "string",
@@ -71,7 +71,7 @@
             "negative",
             "none"
           ],
-          "description": "For active materials: the electrode polarity this material is typically used at."
+          "description": "Deprecated, do not author: polarity is an electrode property, never a material’s — state it on the electrode or through the cell’s holders. Accepted only so existing records keep validating."
         },
         "formula": {
           "type": "string",

--- a/src/battinfo/interop/battery_data_commons.py
+++ b/src/battinfo/interop/battery_data_commons.py
@@ -209,7 +209,7 @@ def import_bdc_record(record: Mapping[str, Any], *, validate: bool = True,
         if clean not in materials:
             materials[clean] = create_material_spec(
                 validate=validate, uid=_uid("bdc", "material", clean), name=clean,
-                material_class="active_material", electrode_polarity=polarity,
+                material_class="active_material",
                 emmo_type=clean if _looks_emmo(clean) else None,
                 source_type="literature", citation=citation,
             )

--- a/src/battinfo/interop/discovery.py
+++ b/src/battinfo/interop/discovery.py
@@ -227,7 +227,6 @@ class _Builder:
                 uid=_uid("discovery", "material", name),
                 name=name,
                 material_class="active_material",
-                electrode_polarity=polarity,
                 chemistry_family=family,
                 emmo_type=emmo_type,
                 source_type="literature",

--- a/src/battinfo/interop/solid_state_db.py
+++ b/src/battinfo/interop/solid_state_db.py
@@ -235,7 +235,6 @@ def from_solid_state_db_row(
             uid=_uid_from_seed(seed, "material", role, name),
             name=name,
             material_class=material_class,
-            electrode_polarity=polarity,
             chemistry_family=family,
             source_type="literature",
             citation=citation,

--- a/src/battinfo/materials.py
+++ b/src/battinfo/materials.py
@@ -175,7 +175,6 @@ def material_spec_from_component(
     component: Any,
     *,
     material_class: str | None = None,
-    electrode_polarity: str | None = None,
     uid_seed: str | None = None,
 ) -> dict[str, Any]:
     """Lift an embedded material holder to a standalone material-spec record.
@@ -203,8 +202,6 @@ def material_spec_from_component(
             fields[key] = holder[key]
     if material_class:
         fields["material_class"] = material_class
-    if electrode_polarity:
-        fields["electrode_polarity"] = electrode_polarity
     return create_material_spec(validate=False, **fields)
 
 
@@ -216,7 +213,11 @@ def link_component_to_spec(component: Any, material_spec_id: str) -> dict[str, A
 
 
 def _iter_embedded_materials(cell_spec_record: Mapping[str, Any]):
-    """Yield (holder_dict, material_class, electrode_polarity) for every embedded material."""
+    """Yield (holder_dict, material_class) for every embedded material.
+
+    No polarity is derived or stamped: polarity is an electrode property, never
+    a material's. The holder position says which electrode used the material;
+    the material record does not repeat it."""
     data = cell_spec_record
     # Electrode coatings: active_material / binder / additive
     group_class = {
@@ -224,14 +225,11 @@ def _iter_embedded_materials(cell_spec_record: Mapping[str, Any]):
         "binder": "binder",
         "additive": "conductive_additive",
     }
-    # Role holders carry no polarity: a half cell or a three-electrode cell has
-    # none to assign, so their active materials are extracted with "none" rather
-    # than a guessed side.
-    for electrode_key, polarity in (
-        ("positive_electrode", "positive"),
-        ("negative_electrode", "negative"),
-        ("working_electrode", "none"),
-        ("counter_electrode", "none"),
+    for electrode_key in (
+        "positive_electrode",
+        "negative_electrode",
+        "working_electrode",
+        "counter_electrode",
     ):
         electrode = data.get(electrode_key)
         if not isinstance(electrode, Mapping):
@@ -242,29 +240,28 @@ def _iter_embedded_materials(cell_spec_record: Mapping[str, Any]):
             for group, mclass in group_class.items():
                 for item in _as_material_list(component.get(group)):
                     if isinstance(item, Mapping) and item.get("name"):
-                        pol = polarity if group == "active_material" else "none"
-                        yield item, mclass, pol
+                        yield item, mclass
         collector = electrode.get("current_collector")
         if isinstance(collector, Mapping) and collector.get("name"):
-            yield collector, "current_collector", "none"
+            yield collector, "current_collector"
 
     electrolyte = data.get("electrolyte")
     if isinstance(electrolyte, Mapping):
         salt = electrolyte.get("salt")
         if isinstance(salt, Mapping) and salt.get("name"):
-            yield salt, "electrolyte_salt", "none"
+            yield salt, "electrolyte_salt"
         solvent_mixture = electrolyte.get("solvent_mixture")
         if isinstance(solvent_mixture, Mapping):
             for item in _as_material_list(solvent_mixture.get("component")):
                 if isinstance(item, Mapping) and item.get("name"):
-                    yield item, "electrolyte_solvent", "none"
+                    yield item, "electrolyte_solvent"
         for item in _as_material_list(electrolyte.get("additive")):
             if isinstance(item, Mapping) and item.get("name"):
-                yield item, "electrolyte_additive", "none"
+                yield item, "electrolyte_additive"
 
     separator = data.get("separator")
     if isinstance(separator, Mapping) and isinstance(separator.get("material"), str):
-        yield {"name": separator["material"]}, "separator_material", "none"
+        yield {"name": separator["material"]}, "separator_material"
 
 
 def extract_material_specs(cell_spec_record: Mapping[str, Any]) -> list[dict[str, Any]]:
@@ -276,7 +273,7 @@ def extract_material_specs(cell_spec_record: Mapping[str, Any]) -> list[dict[str
     """
     seen: dict[str, dict[str, Any]] = {}
     seen_identity: dict[str, tuple[Any, dict[str, Any]]] = {}
-    for holder, mclass, polarity in _iter_embedded_materials(cell_spec_record):
+    for holder, mclass in _iter_embedded_materials(cell_spec_record):
         key = str(holder["name"]).strip().lower()
         identity = (holder.get("molecular_formula"), _intrinsic_property(holder.get("property")))
         if key in seen:
@@ -292,8 +289,6 @@ def extract_material_specs(cell_spec_record: Mapping[str, Any]) -> list[dict[str
                     stacklevel=2,
                 )
             continue
-        seen[key] = material_spec_from_component(
-            holder, material_class=mclass, electrode_polarity=polarity
-        )
+        seen[key] = material_spec_from_component(holder, material_class=mclass)
         seen_identity[key] = identity
     return list(seen.values())

--- a/tests/test_electrode_roles.py
+++ b/tests/test_electrode_roles.py
@@ -322,4 +322,5 @@ def test_role_holder_materials_are_extracted_without_a_polarity() -> None:
     names = {s["material_spec"]["name"] for s in specs}
     assert {"Graphite", "Lithium"} <= names
     for spec in specs:
-        assert spec["material_spec"].get("electrode_polarity") in (None, "none")
+        # Polarity is an electrode property; extraction never stamps one.
+        assert "electrode_polarity" not in spec["material_spec"]

--- a/tests/test_material_contract.py
+++ b/tests/test_material_contract.py
@@ -81,7 +81,6 @@ def test_material_spec_and_instance_roundtrip(tmp_path: Path) -> None:
         uid="abcd23456789abcd",
         name="LFP",
         material_class="active_material",
-        electrode_polarity="positive",
         formula="LiFePO4",
         property={"specific_capacity": {"value": 160, "unit": "mAh/g"}},
     )

--- a/tests/test_materials_bridge.py
+++ b/tests/test_materials_bridge.py
@@ -12,7 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_material_spec_from_component_lifts_holder() -> None:
     holder = {"name": "LFP", "molecular_formula": "LiFePO4",
               "property": {"mass_fraction": {"value": 0.94, "unit": "1"}, "particle_d50": {"value": 1.8, "unit": "um"}}}
-    spec = bi.material_spec_from_component(holder, material_class="active_material", electrode_polarity="positive")
+    spec = bi.material_spec_from_component(holder, material_class="active_material")
     body = spec["material_spec"]
     assert body["name"] == "LFP"
     assert body["formula"] == "LiFePO4"

--- a/tests/test_schema_model_parity.py
+++ b/tests/test_schema_model_parity.py
@@ -118,6 +118,7 @@ KNOWN_GAPS: dict[tuple[str, str], str] = {
 
     # schema.org descriptive fields the schema permits on a product record.
     ("cell-spec", "brand"): "schema:brand object; datasheets use manufacturer + model instead",
+    ("material-spec", "electrode_polarity"): "deprecated: polarity is an electrode property; schema accepts it for back-compat only, no authoring path",
     ("cell-spec", "category"): "schema:category; the emitter derives a category from battery_category/chemistry",
     ("cell-spec", "url"): "schema:url for the product page; datasheet_url/provenance.source_url carry this today",
     ("cell-spec", "additional_type"): "schema:additionalType; the emitter derives the EMMO type from format + chemistry",

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -6411,7 +6411,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
                 "dispersant",
                 "other"
               ],
-              "description": "Functional role of this material in a cell, used for querying."
+              "description": "Deprecated in favor of the kind’s roles (the curated vocabulary lists the use-site slots a kind is known to fill): a single forced role is system-relative. Accepted for back-compat and still written by importers; slated for removal at the next record-shape version."
             },
             "electrode_polarity": {
               "type": "string",
@@ -6420,7 +6420,7 @@ export const schemaFiles: { path: string; schema: Record<string, unknown> }[] = 
                 "negative",
                 "none"
               ],
-              "description": "For active materials: the electrode polarity this material is typically used at."
+              "description": "Deprecated, do not author: polarity is an electrode property, never a material’s — state it on the electrode or through the cell’s holders. Accepted only so existing records keep validating."
             },
             "formula": {
               "type": "string",


### PR DESCRIPTION
## What

The point-4 rulings, implemented. `material_spec.electrode_polarity` loses its authoring path everywhere - the API kwarg, the embedded-to-standalone bridge (`material_spec_from_component`), the extraction walk that stamped a side from holder position, the three importers that wrote it (BDC, Discovery, solid-state DB), the eleven packaged examples, and the two executed how-to recipes (which now lead with the curated `kind` instead of advertising the deprecated classifications). The schema keeps accepting the key, marked deprecated, so existing records validate; the parity test carries the waiver. `material_class` deprecates in favor of the kind's `roles`: it stays accepted (importers still write it) and is slated for removal at the next record-shape version.

Deliberately retained: the parameter-set claim scope named `electrode_polarity` (it describes the electrode context of a measurement, consistent with the ruling) and the BPX importer that feeds it.

## Why

Polarity is an electrode property, never a material's - graphite is the positive electrode of every lithium-counter half cell. And a single forced `material_class` is the same system-relative classification the kind's multi-valued `roles` now does strictly better. Both deprecations follow the announced-deprecation contract: keys stay accepted, authoring stops, removal rides the next record-shape version.

## How

Description-only schema edits (assets + packaged + web vendored copy in sync); `materials.py` extraction yields `(holder, material_class)` pairs with no polarity derivation; interop callers updated; examples re-synced into the wheel; how-to recipes teach `kind=`; CHANGELOG carries a Deprecated section; the materials page's design notes state both rulings. Rebased onto main after #386 merged - the diff is now just this change.

## Testing

Full suite 2073 passed / 0 failed; the doc-snippet gate that caught the how-to recipes now passes with zero failures; drift tests green; `sphinx-build -W` clean; ruff clean.